### PR TITLE
refactor!: remove slice and slicemut types from traits

### DIFF
--- a/mpc-core/src/protocols/aby3/fieldshare.rs
+++ b/mpc-core/src/protocols/aby3/fieldshare.rs
@@ -187,20 +187,6 @@ impl<F: PrimeField> Aby3PrimeFieldShareVec<F> {
         (self.a, self.b)
     }
 
-    pub fn to_ref(&self) -> Aby3PrimeFieldShareSlice<F> {
-        Aby3PrimeFieldShareSlice {
-            a: &self.a,
-            b: &self.b,
-        }
-    }
-
-    pub fn to_mut(&mut self) -> Aby3PrimeFieldShareSliceMut<F> {
-        Aby3PrimeFieldShareSliceMut {
-            a: &mut self.a,
-            b: &mut self.b,
-        }
-    }
-
     pub fn is_empty(&self) -> bool {
         debug_assert_eq!(self.a.is_empty(), self.b.is_empty());
         self.a.is_empty()
@@ -227,83 +213,5 @@ impl<F: PrimeField> std::ops::Add for Aby3PrimeFieldShareVec<F> {
             a: self.a.iter().zip(rhs.a).map(|(a, b)| *a + b).collect(),
             b: self.b.iter().zip(rhs.b).map(|(a, b)| *a + b).collect(),
         }
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct Aby3PrimeFieldShareSlice<'a, F: PrimeField> {
-    // Deliberately a &Vec<F> instead of a &[F] since fft_in_place requires it
-    pub(crate) a: &'a Vec<F>,
-    pub(crate) b: &'a Vec<F>,
-}
-
-impl<'a, F: PrimeField> Aby3PrimeFieldShareSlice<'a, F> {
-    fn clone_to_vec(&self) -> Aby3PrimeFieldShareVec<F> {
-        Aby3PrimeFieldShareVec {
-            a: self.a.to_vec(),
-            b: self.b.to_vec(),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        debug_assert_eq!(self.a.is_empty(), self.b.is_empty());
-        self.a.is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        debug_assert_eq!(self.a.len(), self.b.len());
-        self.a.len()
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct Aby3PrimeFieldShareSliceMut<'a, F: PrimeField> {
-    // Deliberately a &Vec<F> instead of a &[F] since fft_in_place requires it
-    pub(crate) a: &'a mut Vec<F>,
-    pub(crate) b: &'a mut Vec<F>,
-}
-
-impl<'a, F: PrimeField> Aby3PrimeFieldShareSliceMut<'a, F> {
-    fn clone_to_vec(&self) -> Aby3PrimeFieldShareVec<F> {
-        Aby3PrimeFieldShareVec {
-            a: self.a.to_vec(),
-            b: self.b.to_vec(),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        debug_assert_eq!(self.a.is_empty(), self.b.is_empty());
-        self.a.is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        debug_assert_eq!(self.a.len(), self.b.len());
-        self.a.len()
-    }
-}
-
-impl<'a, F: PrimeField> From<&'a Aby3PrimeFieldShareVec<F>> for Aby3PrimeFieldShareSlice<'a, F> {
-    fn from(value: &'a Aby3PrimeFieldShareVec<F>) -> Self {
-        value.to_ref()
-    }
-}
-
-impl<'a, F: PrimeField> From<&'a mut Aby3PrimeFieldShareVec<F>>
-    for Aby3PrimeFieldShareSliceMut<'a, F>
-{
-    fn from(value: &'a mut Aby3PrimeFieldShareVec<F>) -> Self {
-        value.to_mut()
-    }
-}
-
-impl<F: PrimeField> From<Aby3PrimeFieldShareSlice<'_, F>> for Aby3PrimeFieldShareVec<F> {
-    fn from(value: Aby3PrimeFieldShareSlice<F>) -> Self {
-        value.clone_to_vec()
-    }
-}
-
-impl<F: PrimeField> From<Aby3PrimeFieldShareSliceMut<'_, F>> for Aby3PrimeFieldShareVec<F> {
-    fn from(value: Aby3PrimeFieldShareSliceMut<F>) -> Self {
-        value.clone_to_vec()
     }
 }

--- a/mpc-core/src/protocols/gsz/fieldshare.rs
+++ b/mpc-core/src/protocols/gsz/fieldshare.rs
@@ -173,14 +173,6 @@ impl<F: PrimeField> GSZPrimeFieldShareVec<F> {
         self.a
     }
 
-    pub fn to_ref(&self) -> GSZPrimeFieldShareSlice<F> {
-        GSZPrimeFieldShareSlice { a: &self.a }
-    }
-
-    pub fn to_mut(&mut self) -> GSZPrimeFieldShareSliceMut<F> {
-        GSZPrimeFieldShareSliceMut { a: &mut self.a }
-    }
-
     pub fn is_empty(&self) -> bool {
         self.a.is_empty()
     }
@@ -205,72 +197,6 @@ impl<F: PrimeField> std::ops::Add for GSZPrimeFieldShareVec<F> {
         Self {
             a: self.a.iter().zip(rhs.a).map(|(a, b)| *a + b).collect(),
         }
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct GSZPrimeFieldShareSlice<'a, F: PrimeField> {
-    // Deliberately a &Vec<F> instead of a &[F] since fft_in_place requires it
-    pub(crate) a: &'a Vec<F>,
-}
-
-impl<'a, F: PrimeField> GSZPrimeFieldShareSlice<'a, F> {
-    fn clone_to_vec(&self) -> GSZPrimeFieldShareVec<F> {
-        GSZPrimeFieldShareVec { a: self.a.to_vec() }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.a.is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        self.a.len()
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct GSZPrimeFieldShareSliceMut<'a, F: PrimeField> {
-    // Deliberately a &Vec<F> instead of a &[F] since fft_in_place requires it
-    pub(crate) a: &'a mut Vec<F>,
-}
-
-impl<'a, F: PrimeField> GSZPrimeFieldShareSliceMut<'a, F> {
-    fn clone_to_vec(&self) -> GSZPrimeFieldShareVec<F> {
-        GSZPrimeFieldShareVec { a: self.a.to_vec() }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.a.is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        self.a.len()
-    }
-}
-
-impl<'a, F: PrimeField> From<&'a GSZPrimeFieldShareVec<F>> for GSZPrimeFieldShareSlice<'a, F> {
-    fn from(value: &'a GSZPrimeFieldShareVec<F>) -> Self {
-        value.to_ref()
-    }
-}
-
-impl<'a, F: PrimeField> From<&'a mut GSZPrimeFieldShareVec<F>>
-    for GSZPrimeFieldShareSliceMut<'a, F>
-{
-    fn from(value: &'a mut GSZPrimeFieldShareVec<F>) -> Self {
-        value.to_mut()
-    }
-}
-
-impl<F: PrimeField> From<GSZPrimeFieldShareSlice<'_, F>> for GSZPrimeFieldShareVec<F> {
-    fn from(value: GSZPrimeFieldShareSlice<F>) -> Self {
-        value.clone_to_vec()
-    }
-}
-
-impl<F: PrimeField> From<GSZPrimeFieldShareSliceMut<'_, F>> for GSZPrimeFieldShareVec<F> {
-    fn from(value: GSZPrimeFieldShareSliceMut<F>) -> Self {
-        value.clone_to_vec()
     }
 }
 

--- a/mpc-core/tests/protocols/aby3.rs
+++ b/mpc-core/tests/protocols/aby3.rs
@@ -142,11 +142,7 @@ mod field_share {
     use crate::protocols::aby3::Aby3TestNetwork;
     use ark_ff::Field;
     use ark_std::{UniformRand, Zero};
-    use mpc_core::protocols::aby3::{
-        self,
-        fieldshare::{Aby3PrimeFieldShareSlice, Aby3PrimeFieldShareVec},
-        Aby3Protocol,
-    };
+    use mpc_core::protocols::aby3::{self, fieldshare::Aby3PrimeFieldShareVec, Aby3Protocol};
     use mpc_core::traits::PrimeFieldMpcProtocol;
     use rand::thread_rng;
     use std::{collections::HashSet, thread};
@@ -343,9 +339,7 @@ mod field_share {
             thread::spawn(move || {
                 let mut aby3 = Aby3Protocol::new(net).unwrap();
 
-                let x_slice = Aby3PrimeFieldShareSlice::from(&x);
-                let y_slice = Aby3PrimeFieldShareSlice::from(&y);
-                let mul = aby3.mul_vec(&x_slice, &y_slice).unwrap();
+                let mul = aby3.mul_vec(&x, &y).unwrap();
                 tx.send(mul)
             });
         }
@@ -409,11 +403,8 @@ mod field_share {
             thread::spawn(move || {
                 let mut aby3 = Aby3Protocol::new(net).unwrap();
 
-                let x_slice = Aby3PrimeFieldShareSlice::from(&x);
-                let y_slice = Aby3PrimeFieldShareSlice::from(&y);
-                let mul = aby3.mul_vec(&x_slice, &y_slice).unwrap();
-                let mul_slice = Aby3PrimeFieldShareSlice::from(&mul);
-                let mul = aby3.mul_vec(&mul_slice, &y_slice).unwrap();
+                let mul = aby3.mul_vec(&x, &y).unwrap();
+                let mul = aby3.mul_vec(&mul, &y).unwrap();
                 tx.send(mul)
             });
         }

--- a/mpc-core/tests/protocols/gsz.rs
+++ b/mpc-core/tests/protocols/gsz.rs
@@ -432,7 +432,7 @@ mod field_share {
         for (net, tx, x, y) in izip!(test_network.get_party_networks(), tx, x_shares, y_shares) {
             thread::spawn(move || {
                 let mut gsz = GSZProtocol::new(threshold, net).unwrap();
-                let mul = gsz.mul_vec(&x.to_ref(), &y.to_ref()).unwrap();
+                let mul = gsz.mul_vec(&x, &y).unwrap();
                 tx.send(mul)
             });
         }
@@ -489,8 +489,8 @@ mod field_share {
         for (net, tx, x, y) in izip!(test_network.get_party_networks(), tx, x_shares, y_shares) {
             thread::spawn(move || {
                 let mut gsz = GSZProtocol::new(threshold, net).unwrap();
-                let mul = gsz.mul_vec(&x.to_ref(), &y.to_ref()).unwrap();
-                let mul = gsz.mul_vec(&mul.to_ref(), &y.to_ref()).unwrap();
+                let mul = gsz.mul_vec(&x, &y).unwrap();
+                let mul = gsz.mul_vec(&mul, &y).unwrap();
                 tx.send(mul)
             });
         }


### PR DESCRIPTION
Removed `SliceShare` and `SliceShareMut` from MPC traits as we do not really use them as slices anyway due to the constraits of the ark-fft implementation.

Closes #24.
