### PR TITLE
feat!: Replace a panic from the ultracircuitbuilder with an Error

### DIFF
--- a/co-noir/co-noir/src/bin/co-noir.rs
+++ b/co-noir/co-noir/src/bin/co-noir.rs
@@ -495,7 +495,7 @@ fn run_generate_proof(config: GenerateProofConfig) -> color_eyre::Result<ExitCod
             .expect("failed to get prover crs");
 
             // Get the proving key and prover
-            let proving_key = ProvingKey::create(id, builder, prover_crs);
+            let proving_key = ProvingKey::create(id, builder, prover_crs)?;
             let public_input = proving_key.get_public_inputs();
             let prover = CoUltraHonk::<_, _, Poseidon2Sponge>::new(driver);
             let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
@@ -540,7 +540,7 @@ fn run_generate_proof(config: GenerateProofConfig) -> color_eyre::Result<ExitCod
             .expect("failed to get prover crs");
 
             // Get the proving key and prover
-            let proving_key = ProvingKey::create(id, builder, prover_crs);
+            let proving_key = ProvingKey::create(id, builder, prover_crs)?;
             let public_input = proving_key.get_public_inputs();
             let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
             tracing::info!(

--- a/co-noir/co-ultrahonk/src/parse/builder_variable.rs
+++ b/co-noir/co-ultrahonk/src/parse/builder_variable.rs
@@ -1,7 +1,7 @@
 use ark_ec::pairing::Pairing;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-use ultrahonk::prelude::UltraCircuitVariable;
+use ultrahonk::prelude::{HonkProofError, HonkProofResult, UltraCircuitVariable};
 
 use crate::mpc::NoirUltraHonkProver;
 
@@ -80,10 +80,10 @@ impl<T: NoirUltraHonkProver<P>, P: Pairing> UltraCircuitVariable<P::ScalarField>
         }
     }
 
-    fn public_into_field(self) -> P::ScalarField {
+    fn public_into_field(self) -> HonkProofResult<P::ScalarField> {
         match self {
-            SharedBuilderVariable::Public(val) => val,
-            SharedBuilderVariable::Shared(_) => panic!("Expected public value"),
+            SharedBuilderVariable::Public(val) => Ok(val),
+            SharedBuilderVariable::Shared(_) => Err(HonkProofError::ExpectedPublicWitness),
         }
     }
 }

--- a/co-noir/co-ultrahonk/src/parse/proving_key.rs
+++ b/co-noir/co-ultrahonk/src/parse/proving_key.rs
@@ -26,7 +26,7 @@ impl<T: NoirUltraHonkProver<P>, P: Pairing> ProvingKey<T, P> {
         id: T::PartyID,
         mut circuit: CoUltraCircuitBuilder<T, P>,
         crs: ProverCrs<P>,
-    ) -> Self {
+    ) -> HonkProofResult<Self> {
         tracing::info!("ProvingKey create");
         circuit.finalize_circuit(true);
 
@@ -69,10 +69,10 @@ impl<T: NoirUltraHonkProver<P>, P: Pairing> ProvingKey<T, P> {
             .cloned()
         {
             let var = circuit.get_variable(var_idx as usize);
-            proving_key.public_inputs.push(var.public_into_field());
+            proving_key.public_inputs.push(var.public_into_field()?);
         }
 
-        proving_key
+        Ok(proving_key)
     }
 
     pub fn create_keys(
@@ -85,7 +85,7 @@ impl<T: NoirUltraHonkProver<P>, P: Pairing> ProvingKey<T, P> {
         };
         let verifier_crs = crs.g2_x;
 
-        let pk = ProvingKey::create(id, circuit, prover_crs);
+        let pk = ProvingKey::create(id, circuit, prover_crs)?;
         let circuit_size = pk.circuit_size;
 
         let mut commitments = PrecomputedEntities::default();

--- a/co-noir/ultrahonk/src/parse/types.rs
+++ b/co-noir/ultrahonk/src/parse/types.rs
@@ -1,6 +1,7 @@
 use super::builder::{GenericUltraCircuitBuilder, UltraCircuitBuilder, UltraCircuitVariable};
 use super::plookup::{BasicTableId, MultiTableId};
 use crate::decider::polynomial::Polynomial;
+use crate::prover::HonkProofResult;
 use crate::types::ProvingKey;
 use crate::Utils;
 use ark_ec::pairing::Pairing;
@@ -428,7 +429,9 @@ impl<F: PrimeField> RomTable<F> {
         assert!(val < BigUint::from(self.length));
 
         let witness_index = index.normalize(builder).get_witness_index();
-        let output_idx = builder.read_rom_array(self.rom_id, witness_index);
+        let output_idx = builder
+            .read_rom_array(self.rom_id, witness_index)
+            .expect("Not implemented for other cases");
         FieldCT::from_witness_index(output_idx)
     }
 
@@ -558,7 +561,8 @@ impl<F: PrimeField> FieldCT<F> {
         if self.witness_index != Self::IS_CONSTANT {
             let variable = builder
                 .get_variable(self.witness_index as usize)
-                .public_into_field(); // TACEO TODO this is just implemented for the Plain backend
+                .public_into_field()
+                .expect("Not implemented for other cases"); // TACEO TODO this is just implemented for the Plain backend
             self.multiplicative_constant * F::from(variable) + self.additive_constant
         } else {
             self.additive_constant.to_owned()
@@ -627,8 +631,9 @@ impl<F: PrimeField> FieldCT<F> {
         let value = F::from(
             builder
                 .get_variable(self.witness_index as usize)
-                .public_into_field(),
-        ); // TACEO TODO this is just implemented for the Plain backend
+                .public_into_field()
+                .expect("Not implemented for other cases"), // TACEO TODO this is just implemented for the Plain backend
+        );
         let out = self.multiplicative_constant * value + self.additive_constant;
 
         result.witness_index = builder.add_variable(S::from_public(P::ScalarField::from(out)));

--- a/co-noir/ultrahonk/src/prover.rs
+++ b/co-noir/ultrahonk/src/prover.rs
@@ -32,6 +32,9 @@ pub enum HonkProofError {
     /// Corrupted Key
     #[error("Corrupted Key")]
     CorruptedKey,
+    /// Expected Public Witness, Shared received
+    #[error("Expected Public Witness, Shared received")]
+    ExpectedPublicWitness,
     #[error(transparent)]
     IOError(#[from] io::Error),
 }

--- a/tests/tests/noir/proof_tests/rep3.rs
+++ b/tests/tests/noir/proof_tests/rep3.rs
@@ -88,7 +88,7 @@ fn proof_test<H: TranscriptHasher<TranscriptFieldType>>(name: &str) {
             let mut io_context0 = IoContext::init(net).unwrap();
             let io_context1 = io_context0.fork().unwrap();
             let driver = Rep3UltraHonkDriver::new(io_context0, io_context1);
-            let proving_key = ProvingKey::create(id, builder, crs);
+            let proving_key = ProvingKey::create(id, builder, crs).unwrap();
 
             let prover = CoUltraHonk::<_, _, H>::new(driver);
             prover.prove(proving_key).unwrap()
@@ -154,7 +154,7 @@ fn witness_and_proof_test<H: TranscriptHasher<TranscriptFieldType>>(name: &str) 
             let mut io_context0 = IoContext::init(net2).unwrap();
             let io_context1 = io_context0.fork().unwrap();
             let driver = Rep3UltraHonkDriver::new(io_context0, io_context1);
-            let proving_key = ProvingKey::create(id, builder, prover_crs);
+            let proving_key = ProvingKey::create(id, builder, prover_crs).unwrap();
 
             let prover = CoUltraHonk::<_, _, H>::new(driver);
             prover.prove(proving_key).unwrap()

--- a/tests/tests/noir/proof_tests/shamir.rs
+++ b/tests/tests/noir/proof_tests/shamir.rs
@@ -53,7 +53,7 @@ fn proof_test<H: TranscriptHasher<TranscriptFieldType>>(
 
             let id = net.id;
 
-            let proving_key = ProvingKey::create(id, builder, prover_crs);
+            let proving_key = ProvingKey::create(id, builder, prover_crs).unwrap();
 
             let n = proving_key.circuit_size as usize;
             let num_pairs_oink_prove = OINK_CRAND_PAIRS_FACTOR_N * n


### PR DESCRIPTION
BREAKING CHANGE: The interface of the UltraCircuitVariable trait has change. Thus, also ProvingKey::create() throws an error now.