### PR TITLE
chore: added wait statements to example shell scripts

### DIFF
--- a/co-circom/co-circom/examples/groth16/run_full_kyc.sh
+++ b/co-circom/co-circom/examples/groth16/run_full_kyc.sh
@@ -4,9 +4,11 @@ cargo run --release --bin co-circom -- split-input --circuit test_vectors/kyc/ci
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.0.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/kyc/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.1.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/kyc/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.2.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/kyc/witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/kyc/witness.wtns.0.shared --zkey test_vectors/kyc/bn254/kyc.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/kyc/witness.wtns.1.shared --zkey test_vectors/kyc/bn254/kyc.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/kyc/witness.wtns.2.shared --zkey test_vectors/kyc/bn254/kyc.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify groth16 --proof proof.0.json --vk test_vectors/kyc/bn254/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/groth16/run_full_kyc_shamir_bls.sh
+++ b/co-circom/co-circom/examples/groth16/run_full_kyc_shamir_bls.sh
@@ -4,13 +4,16 @@ cargo run --release --bin co-circom -- split-input --circuit test_vectors/kyc/ci
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.0.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BLS12-381 --config ../configs/party1.toml --out test_vectors/kyc/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.1.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BLS12-381 --config ../configs/party2.toml --out test_vectors/kyc/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.2.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BLS12-381 --config ../configs/party3.toml --out test_vectors/kyc/witness.wtns.2.shared
+wait $(jobs -p)
 # run translation from REP3 to Shamir
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/kyc/witness.wtns.0.shared --src-protocol REP3 --target-protocol SHAMIR --curve BLS12-381 --config ../configs/party1.toml --out test_vectors/kyc/shamir_witness.wtns.0.shared &
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/kyc/witness.wtns.1.shared --src-protocol REP3 --target-protocol SHAMIR --curve BLS12-381 --config ../configs/party2.toml --out test_vectors/kyc/shamir_witness.wtns.1.shared &
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/kyc/witness.wtns.2.shared --src-protocol REP3 --target-protocol SHAMIR --curve BLS12-381 --config ../configs/party3.toml --out test_vectors/kyc/shamir_witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/kyc/shamir_witness.wtns.0.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol SHAMIR --curve BLS12-381 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/kyc/shamir_witness.wtns.1.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol SHAMIR --curve BLS12-381 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/kyc/shamir_witness.wtns.2.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol SHAMIR --curve BLS12-381 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify groth16 --proof proof.0.json --vk test_vectors/kyc/bls12/verification_key.json --public-input public_input.json --curve BLS12-381

--- a/co-circom/co-circom/examples/groth16/run_full_multiplier2.sh
+++ b/co-circom/co-circom/examples/groth16/run_full_multiplier2.sh
@@ -4,9 +4,11 @@ cargo run --release --bin co-circom -- split-input --circuit test_vectors/multip
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/multiplier2/input.json.0.shared --circuit test_vectors/multiplier2/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/multiplier2/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/multiplier2/input.json.1.shared --circuit test_vectors/multiplier2/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/multiplier2/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/multiplier2/input.json.2.shared --circuit test_vectors/multiplier2/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/multiplier2/witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/multiplier2/witness.wtns.0.shared --zkey test_vectors/multiplier2/multiplier2.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/multiplier2/witness.wtns.1.shared --zkey test_vectors/multiplier2/multiplier2.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/multiplier2/witness.wtns.2.shared --zkey test_vectors/multiplier2/multiplier2.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify groth16 --proof proof.0.json --vk test_vectors/multiplier2/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/groth16/run_full_poseidon.sh
+++ b/co-circom/co-circom/examples/groth16/run_full_poseidon.sh
@@ -4,9 +4,11 @@ cargo run --release --bin co-circom -- split-input --circuit test_vectors/poseid
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.0.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/poseidon/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.1.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/poseidon/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.2.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/poseidon/witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/witness.wtns.0.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/witness.wtns.1.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/witness.wtns.2.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify groth16 --proof proof.0.json --vk test_vectors/poseidon/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/groth16/run_full_poseidon_shamir.sh
+++ b/co-circom/co-circom/examples/groth16/run_full_poseidon_shamir.sh
@@ -4,13 +4,16 @@ cargo run --release --bin co-circom -- split-input --circuit test_vectors/poseid
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.0.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/poseidon/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.1.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/poseidon/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.2.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/poseidon/witness.wtns.2.shared
+wait $(jobs -p)
 # run translation from REP3 to Shamir
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/poseidon/witness.wtns.0.shared --src-protocol REP3 --target-protocol SHAMIR --curve BN254 --config ../configs/party1.toml --out test_vectors/poseidon/shamir_witness.wtns.0.shared &
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/poseidon/witness.wtns.1.shared --src-protocol REP3 --target-protocol SHAMIR --curve BN254 --config ../configs/party2.toml --out test_vectors/poseidon/shamir_witness.wtns.1.shared &
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/poseidon/witness.wtns.2.shared --src-protocol REP3 --target-protocol SHAMIR --curve BN254 --config ../configs/party3.toml --out test_vectors/poseidon/shamir_witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/shamir_witness.wtns.0.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/shamir_witness.wtns.1.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/shamir_witness.wtns.2.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify groth16 --proof proof.0.json --vk test_vectors/poseidon/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/groth16/run_full_sum_arrays.sh
+++ b/co-circom/co-circom/examples/groth16/run_full_sum_arrays.sh
@@ -4,9 +4,11 @@ cargo run --release --bin co-circom -- split-input  --circuit test_vectors/sum_a
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/sum_arrays/input.json.0.shared --circuit test_vectors/sum_arrays/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/sum_arrays/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/sum_arrays/input.json.1.shared --circuit test_vectors/sum_arrays/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/sum_arrays/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/sum_arrays/input.json.2.shared --circuit test_vectors/sum_arrays/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/sum_arrays/witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/sum_arrays/witness.wtns.0.shared --zkey test_vectors/sum_arrays/sum_arrays.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/sum_arrays/witness.wtns.1.shared --zkey test_vectors/sum_arrays/sum_arrays.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/sum_arrays/witness.wtns.2.shared --zkey test_vectors/sum_arrays/sum_arrays.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify groth16 --proof proof.0.json --vk test_vectors/sum_arrays/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/groth16/run_full_with_merge.sh
+++ b/co-circom/co-circom/examples/groth16/run_full_with_merge.sh
@@ -11,9 +11,11 @@ cargo run --release --bin co-circom -- merge-input-shares --inputs test_vectors/
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/$EXAMPLE_NAME/input.json.0.shared --circuit test_vectors/$EXAMPLE_NAME/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/$EXAMPLE_NAME/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/$EXAMPLE_NAME/input.json.1.shared --circuit test_vectors/$EXAMPLE_NAME/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/$EXAMPLE_NAME/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/$EXAMPLE_NAME/input.json.2.shared --circuit test_vectors/$EXAMPLE_NAME/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/$EXAMPLE_NAME/witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/$EXAMPLE_NAME/witness.wtns.0.shared --zkey test_vectors/$EXAMPLE_NAME/$EXAMPLE_NAME.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/$EXAMPLE_NAME/witness.wtns.1.shared --zkey test_vectors/$EXAMPLE_NAME/$EXAMPLE_NAME.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/$EXAMPLE_NAME/witness.wtns.2.shared --zkey test_vectors/$EXAMPLE_NAME/$EXAMPLE_NAME.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify groth16 --proof proof.0.json --vk test_vectors/$EXAMPLE_NAME/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/groth16/run_proof_only_kyc_bls.sh
+++ b/co-circom/co-circom/examples/groth16/run_proof_only_kyc_bls.sh
@@ -4,5 +4,6 @@ cargo run --release --bin co-circom -- split-witness --witness test_vectors/kyc/
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/kyc/witness.wtns.0.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol REP3 --curve BLS12-381 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/kyc/witness.wtns.1.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol REP3 --curve BLS12-381 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/kyc/witness.wtns.2.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol REP3 --curve BLS12-381 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify groth16 --proof proof.0.json --vk test_vectors/kyc/bls12/verification_key.json --public-input public_input.json --curve BLS12-381

--- a/co-circom/co-circom/examples/groth16/run_proof_only_poseidon.sh
+++ b/co-circom/co-circom/examples/groth16/run_proof_only_poseidon.sh
@@ -4,5 +4,6 @@ cargo run --release --bin co-circom -- split-witness --witness test_vectors/pose
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/witness.wtns.0.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/witness.wtns.1.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/witness.wtns.2.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify groth16 --proof proof.0.json --vk test_vectors/poseidon/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/groth16/run_proof_only_poseidon_shamir.sh
+++ b/co-circom/co-circom/examples/groth16/run_proof_only_poseidon_shamir.sh
@@ -4,5 +4,6 @@ cargo run --release --bin co-circom -- split-witness --witness test_vectors/pose
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/witness.wtns.0.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/witness.wtns.1.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof groth16 --witness test_vectors/poseidon/witness.wtns.2.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify groth16 --proof proof.0.json --vk test_vectors/poseidon/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/plonk/run_full_kyc.sh
+++ b/co-circom/co-circom/examples/plonk/run_full_kyc.sh
@@ -4,9 +4,11 @@ cargo run --release --bin co-circom -- split-input --circuit test_vectors/kyc/ci
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.0.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/kyc/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.1.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/kyc/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.2.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/kyc/witness.wtns.2.shared 
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/kyc/witness.wtns.0.shared --zkey test_vectors/kyc/bn254/kyc.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/kyc/witness.wtns.1.shared --zkey test_vectors/kyc/bn254/kyc.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/kyc/witness.wtns.2.shared --zkey test_vectors/kyc/bn254/kyc.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify plonk --proof proof.0.json --vk test_vectors/kyc/bn254/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/plonk/run_full_kyc_shamir_bls.sh
+++ b/co-circom/co-circom/examples/plonk/run_full_kyc_shamir_bls.sh
@@ -4,13 +4,16 @@ cargo run --release --bin co-circom -- split-input --circuit test_vectors/kyc/ci
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.0.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BLS12-381 --config ../configs/party1.toml --out test_vectors/kyc/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.1.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BLS12-381 --config ../configs/party2.toml --out test_vectors/kyc/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/kyc/input.json.2.shared --circuit test_vectors/kyc/circuit.circom --protocol REP3 --curve BLS12-381 --config ../configs/party3.toml --out test_vectors/kyc/witness.wtns.2.shared
+wait $(jobs -p)
 # run translation from REP3 to Shamir
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/kyc/witness.wtns.0.shared --src-protocol REP3 --target-protocol SHAMIR --curve BLS12-381 --config ../configs/party1.toml --out test_vectors/kyc/shamir_witness.wtns.0.shared &
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/kyc/witness.wtns.1.shared --src-protocol REP3 --target-protocol SHAMIR --curve BLS12-381 --config ../configs/party2.toml --out test_vectors/kyc/shamir_witness.wtns.1.shared &
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/kyc/witness.wtns.2.shared --src-protocol REP3 --target-protocol SHAMIR --curve BLS12-381 --config ../configs/party3.toml --out test_vectors/kyc/shamir_witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/kyc/shamir_witness.wtns.0.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol SHAMIR --curve BLS12-381 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/kyc/shamir_witness.wtns.1.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol SHAMIR --curve BLS12-381 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/kyc/shamir_witness.wtns.2.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol SHAMIR --curve BLS12-381 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify plonk --proof proof.0.json --vk test_vectors/kyc/bls12/verification_key.json --public-input public_input.json --curve BLS12-381

--- a/co-circom/co-circom/examples/plonk/run_full_multiplier2.sh
+++ b/co-circom/co-circom/examples/plonk/run_full_multiplier2.sh
@@ -4,9 +4,11 @@ cargo run --release --bin co-circom -- split-input --circuit test_vectors/multip
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/multiplier2/input.json.0.shared --circuit test_vectors/multiplier2/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/multiplier2/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/multiplier2/input.json.1.shared --circuit test_vectors/multiplier2/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/multiplier2/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/multiplier2/input.json.2.shared --circuit test_vectors/multiplier2/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/multiplier2/witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/multiplier2/witness.wtns.0.shared --zkey test_vectors/multiplier2/multiplier2.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/multiplier2/witness.wtns.1.shared --zkey test_vectors/multiplier2/multiplier2.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/multiplier2/witness.wtns.2.shared --zkey test_vectors/multiplier2/multiplier2.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify plonk --proof proof.0.json --vk test_vectors/multiplier2/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/plonk/run_full_multiplier2_shamir.sh
+++ b/co-circom/co-circom/examples/plonk/run_full_multiplier2_shamir.sh
@@ -4,13 +4,16 @@ cargo run --release --bin co-circom -- split-input --circuit test_vectors/multip
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/multiplier2/input.json.0.shared --circuit test_vectors/multiplier2/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/multiplier2/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/multiplier2/input.json.1.shared --circuit test_vectors/multiplier2/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/multiplier2/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/multiplier2/input.json.2.shared --circuit test_vectors/multiplier2/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/multiplier2/witness.wtns.2.shared
+wait $(jobs -p)
 # run translation from REP3 to Shamir
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/multiplier2/witness.wtns.0.shared --src-protocol REP3 --target-protocol SHAMIR --curve BN254 --config ../configs/party1.toml --out test_vectors/multiplier2/shamir_witness.wtns.0.shared &
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/multiplier2/witness.wtns.1.shared --src-protocol REP3 --target-protocol SHAMIR --curve BN254 --config ../configs/party2.toml --out test_vectors/multiplier2/shamir_witness.wtns.1.shared &
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/multiplier2/witness.wtns.2.shared --src-protocol REP3 --target-protocol SHAMIR --curve BN254 --config ../configs/party3.toml --out test_vectors/multiplier2/shamir_witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/multiplier2/shamir_witness.wtns.0.shared --zkey test_vectors/multiplier2/multiplier2.zkey --protocol SHAMIR --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/multiplier2/shamir_witness.wtns.1.shared --zkey test_vectors/multiplier2/multiplier2.zkey --protocol SHAMIR --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/multiplier2/shamir_witness.wtns.2.shared --zkey test_vectors/multiplier2/multiplier2.zkey --protocol SHAMIR --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify plonk --proof proof.0.json --vk test_vectors/multiplier2/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/plonk/run_full_poseidon.sh
+++ b/co-circom/co-circom/examples/plonk/run_full_poseidon.sh
@@ -4,9 +4,11 @@ cargo run --release --bin co-circom -- split-input --circuit test_vectors/poseid
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.0.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/poseidon/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.1.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/poseidon/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.2.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/poseidon/witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/witness.wtns.0.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/witness.wtns.1.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/witness.wtns.2.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify plonk --proof proof.0.json --vk test_vectors/poseidon/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/plonk/run_full_poseidon_shamir.sh
+++ b/co-circom/co-circom/examples/plonk/run_full_poseidon_shamir.sh
@@ -4,13 +4,16 @@ cargo run --release --bin co-circom -- split-input --circuit test_vectors/poseid
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.0.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/poseidon/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.1.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/poseidon/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/poseidon/input.json.2.shared --circuit test_vectors/poseidon/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/poseidon/witness.wtns.2.shared
+wait $(jobs -p)
 # run translation from REP3 to Shamir
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/poseidon/witness.wtns.0.shared --src-protocol REP3 --target-protocol SHAMIR --curve BN254 --config ../configs/party1.toml --out test_vectors/poseidon/shamir_witness.wtns.0.shared &
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/poseidon/witness.wtns.1.shared --src-protocol REP3 --target-protocol SHAMIR --curve BN254 --config ../configs/party2.toml --out test_vectors/poseidon/shamir_witness.wtns.1.shared &
 cargo run --release --bin co-circom -- translate-witness --witness test_vectors/poseidon/witness.wtns.2.shared --src-protocol REP3 --target-protocol SHAMIR --curve BN254 --config ../configs/party3.toml --out test_vectors/poseidon/shamir_witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/shamir_witness.wtns.0.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/shamir_witness.wtns.1.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/shamir_witness.wtns.2.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify plonk --proof proof.0.json --vk test_vectors/poseidon/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/plonk/run_full_sum_arrays.sh
+++ b/co-circom/co-circom/examples/plonk/run_full_sum_arrays.sh
@@ -4,9 +4,11 @@ cargo run --release --bin co-circom -- split-input  --circuit test_vectors/sum_a
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/sum_arrays/input.json.0.shared --circuit test_vectors/sum_arrays/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/sum_arrays/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/sum_arrays/input.json.1.shared --circuit test_vectors/sum_arrays/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/sum_arrays/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/sum_arrays/input.json.2.shared --circuit test_vectors/sum_arrays/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/sum_arrays/witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/sum_arrays/witness.wtns.0.shared --zkey test_vectors/sum_arrays/sum_arrays.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/sum_arrays/witness.wtns.1.shared --zkey test_vectors/sum_arrays/sum_arrays.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/sum_arrays/witness.wtns.2.shared --zkey test_vectors/sum_arrays/sum_arrays.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify plonk --proof proof.0.json --vk test_vectors/sum_arrays/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/plonk/run_full_with_merge.sh
+++ b/co-circom/co-circom/examples/plonk/run_full_with_merge.sh
@@ -11,9 +11,11 @@ cargo run --release --bin co-circom -- merge-input-shares --inputs test_vectors/
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/$EXAMPLE_NAME/input.json.0.shared --circuit test_vectors/$EXAMPLE_NAME/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party1.toml --out test_vectors/$EXAMPLE_NAME/witness.wtns.0.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/$EXAMPLE_NAME/input.json.1.shared --circuit test_vectors/$EXAMPLE_NAME/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party2.toml --out test_vectors/$EXAMPLE_NAME/witness.wtns.1.shared &
 cargo run --release --bin co-circom -- generate-witness --input test_vectors/$EXAMPLE_NAME/input.json.2.shared --circuit test_vectors/$EXAMPLE_NAME/circuit.circom --protocol REP3 --curve BN254 --config ../configs/party3.toml --out test_vectors/$EXAMPLE_NAME/witness.wtns.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/$EXAMPLE_NAME/witness.wtns.0.shared --zkey test_vectors/$EXAMPLE_NAME/$EXAMPLE_NAME.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/$EXAMPLE_NAME/witness.wtns.1.shared --zkey test_vectors/$EXAMPLE_NAME/$EXAMPLE_NAME.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/$EXAMPLE_NAME/witness.wtns.2.shared --zkey test_vectors/$EXAMPLE_NAME/$EXAMPLE_NAME.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify plonk --proof proof.0.json --vk test_vectors/$EXAMPLE_NAME/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/plonk/run_proof_only_kyc_bls.sh
+++ b/co-circom/co-circom/examples/plonk/run_proof_only_kyc_bls.sh
@@ -4,5 +4,6 @@ cargo run --release --bin co-circom -- split-witness --witness test_vectors/kyc/
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/kyc/witness.wtns.0.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol REP3 --curve BLS12-381 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/kyc/witness.wtns.1.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol REP3 --curve BLS12-381 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/kyc/witness.wtns.2.shared --zkey test_vectors/kyc/bls12/kyc.zkey --protocol REP3 --curve BLS12-381 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify plonk --proof proof.0.json --vk test_vectors/kyc/bls12/verification_key.json --public-input public_input.json --curve BLS12-381

--- a/co-circom/co-circom/examples/plonk/run_proof_only_poseidon.sh
+++ b/co-circom/co-circom/examples/plonk/run_proof_only_poseidon.sh
@@ -4,5 +4,6 @@ cargo run --release --bin co-circom -- split-witness --witness test_vectors/pose
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/witness.wtns.0.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/witness.wtns.1.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/witness.wtns.2.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol REP3 --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify plonk --proof proof.0.json --vk test_vectors/poseidon/verification_key.json --public-input public_input.json --curve BN254

--- a/co-circom/co-circom/examples/plonk/run_proof_only_poseidon_shamir.sh
+++ b/co-circom/co-circom/examples/plonk/run_proof_only_poseidon_shamir.sh
@@ -4,5 +4,6 @@ cargo run --release --bin co-circom -- split-witness --witness test_vectors/pose
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/witness.wtns.0.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party1.toml --out proof.0.json --public-input public_input.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/witness.wtns.1.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party2.toml --out proof.1.json &
 cargo run --release --bin co-circom -- generate-proof plonk --witness test_vectors/poseidon/witness.wtns.2.shared --zkey test_vectors/poseidon/poseidon.zkey --protocol SHAMIR --curve BN254 --config ../configs/party3.toml --out proof.2.json
+wait $(jobs -p)
 # verify proof
 cargo run --release --bin co-circom -- verify plonk --proof proof.0.json --vk test_vectors/poseidon/verification_key.json --public-input public_input.json --curve BN254

--- a/co-noir/co-noir/examples/run_full_add3.sh
+++ b/co-noir/co-noir/examples/run_full_add3.sh
@@ -10,10 +10,12 @@ cargo run --release --bin co-noir -- merge-input-shares --inputs test_vectors/ad
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/add3/Prover.toml.0.shared --circuit test_vectors/add3/add3.json --protocol REP3 --config configs/party1.toml --out test_vectors/add3/add3.gz.0.shared &
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/add3/Prover.toml.1.shared --circuit test_vectors/add3/add3.json --protocol REP3 --config configs/party2.toml --out test_vectors/add3/add3.gz.1.shared &
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/add3/Prover.toml.2.shared --circuit test_vectors/add3/add3.json --protocol REP3 --config configs/party3.toml --out test_vectors/add3/add3.gz.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/add3/add3.gz.0.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party1.toml --out proof.0.proof --public-input public_input.json &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/add3/add3.gz.1.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party2.toml --out proof.1.proof &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/add3/add3.gz.2.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party3.toml --out proof.2.proof
+wait $(jobs -p)
 # Create verification key
 cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --vk test_vectors/add3/verification_key
 # verify proof

--- a/co-noir/co-noir/examples/run_full_poseidon.sh
+++ b/co-noir/co-noir/examples/run_full_poseidon.sh
@@ -4,10 +4,12 @@ cargo run --release --bin co-noir -- split-input --circuit test_vectors/poseidon
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon/Prover.toml.0.shared --circuit test_vectors/poseidon/poseidon.json --protocol REP3 --config configs/party1.toml --out test_vectors/poseidon/poseidon.gz.0.shared &
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon/Prover.toml.1.shared --circuit test_vectors/poseidon/poseidon.json --protocol REP3 --config configs/party2.toml --out test_vectors/poseidon/poseidon.gz.1.shared &
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon/Prover.toml.2.shared --circuit test_vectors/poseidon/poseidon.json --protocol REP3 --config configs/party3.toml --out test_vectors/poseidon/poseidon.gz.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party1.toml --out proof.0.proof --public-input public_input.json &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party2.toml --out proof.1.proof &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party3.toml --out proof.2.proof
+wait $(jobs -p)
 # Create verification key
 cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --vk test_vectors/poseidon/verification_key
 # verify proof

--- a/co-noir/co-noir/examples/run_full_poseidon_shamir.sh
+++ b/co-noir/co-noir/examples/run_full_poseidon_shamir.sh
@@ -4,14 +4,17 @@ cargo run --release --bin co-noir -- split-input --circuit test_vectors/poseidon
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon/Prover.toml.0.shared --circuit test_vectors/poseidon/poseidon.json --protocol REP3 --config configs/party1.toml --out test_vectors/poseidon/poseidon.gz.0.shared &
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon/Prover.toml.1.shared --circuit test_vectors/poseidon/poseidon.json --protocol REP3 --config configs/party2.toml --out test_vectors/poseidon/poseidon.gz.1.shared &
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon/Prover.toml.2.shared --circuit test_vectors/poseidon/poseidon.json --protocol REP3 --config configs/party3.toml --out test_vectors/poseidon/poseidon.gz.2.shared
+wait $(jobs -p)
 # run translation from REP3 to Shamir
 cargo run --release --bin co-noir -- translate-witness --witness test_vectors/poseidon/poseidon.gz.0.shared --src-protocol REP3 --target-protocol SHAMIR --config configs/party1.toml --out test_vectors/poseidon/shamir_poseidon.gz.0.shared &
 cargo run --release --bin co-noir -- translate-witness --witness test_vectors/poseidon/poseidon.gz.1.shared --src-protocol REP3 --target-protocol SHAMIR --config configs/party2.toml --out test_vectors/poseidon/shamir_poseidon.gz.1.shared &
 cargo run --release --bin co-noir -- translate-witness --witness test_vectors/poseidon/poseidon.gz.2.shared --src-protocol REP3 --target-protocol SHAMIR --config configs/party3.toml --out test_vectors/poseidon/shamir_poseidon.gz.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/shamir_poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --config configs/party1.toml --out proof.0.proof --public-input public_input.json &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/shamir_poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --config configs/party2.toml --out proof.1.proof &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/shamir_poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --config configs/party3.toml --out proof.2.proof
+wait $(jobs -p)
 # Create verification key
 cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --vk test_vectors/poseidon/verification_key
 # verify proof

--- a/co-noir/co-noir/examples/run_full_poseidon_with_merge.sh
+++ b/co-noir/co-noir/examples/run_full_poseidon_with_merge.sh
@@ -9,10 +9,12 @@ cargo run --release --bin co-noir -- merge-input-shares --inputs test_vectors/po
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon_input2/Prover.toml.0.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --protocol REP3 --config configs/party1.toml --out test_vectors/poseidon_input2/poseidon_input2.gz.0.shared &
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon_input2/Prover.toml.1.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --protocol REP3 --config configs/party2.toml --out test_vectors/poseidon_input2/poseidon_input2.gz.1.shared &
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon_input2/Prover.toml.2.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --protocol REP3 --config configs/party3.toml --out test_vectors/poseidon_input2/poseidon_input2.gz.2.shared
+wait $(jobs -p)
 # run proving in MPC
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon_input2/poseidon_input2.gz.0.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party1.toml --out proof.0.proof --public-input public_input.json &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon_input2/poseidon_input2.gz.1.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party2.toml --out proof.1.proof &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon_input2/poseidon_input2.gz.2.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party3.toml --out proof.2.proof
+wait $(jobs -p)
 # Create verification key
 cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --vk test_vectors/poseidon_input2/verification_key
 # verify proof

--- a/co-noir/co-noir/examples/run_proof_only_add3.sh
+++ b/co-noir/co-noir/examples/run_proof_only_add3.sh
@@ -4,6 +4,7 @@ cargo run --release --bin co-noir -- split-witness --witness test_vectors/add3/a
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/add3/add3.gz.0.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party1.toml --out proof.0.proof --public-input public_input.json &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/add3/add3.gz.1.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party2.toml --out proof.1.proof &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/add3/add3.gz.2.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party3.toml --out proof.2.proof
+wait $(jobs -p)
 # Create verification key
 cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --vk test_vectors/add3/verification_key
 # verify proof

--- a/co-noir/co-noir/examples/run_proof_only_add3_shamir.sh
+++ b/co-noir/co-noir/examples/run_proof_only_add3_shamir.sh
@@ -4,6 +4,7 @@ cargo run --release --bin co-noir -- split-witness --witness test_vectors/add3/a
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/add3/add3.gz.0.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --config configs/party1.toml --out proof.0.proof --public-input public_input.json &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/add3/add3.gz.1.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --config configs/party2.toml --out proof.1.proof &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/add3/add3.gz.2.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --config configs/party3.toml --out proof.2.proof
+wait $(jobs -p)
 # Create verification key
 cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --vk test_vectors/add3/verification_key
 # verify proof

--- a/co-noir/co-noir/examples/run_proof_only_poseidon.sh
+++ b/co-noir/co-noir/examples/run_proof_only_poseidon.sh
@@ -4,6 +4,7 @@ cargo run --release --bin co-noir -- split-witness --witness test_vectors/poseid
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party1.toml --out proof.0.proof --public-input public_input.json &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party2.toml --out proof.1.proof &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --config configs/party3.toml --out proof.2.proof
+wait $(jobs -p)
 # Create verification key
 cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --vk test_vectors/poseidon/verification_key
 # verify proof

--- a/co-noir/co-noir/examples/run_proof_only_poseidon_shamir.sh
+++ b/co-noir/co-noir/examples/run_proof_only_poseidon_shamir.sh
@@ -4,6 +4,7 @@ cargo run --release --bin co-noir -- split-witness --witness test_vectors/poseid
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --config configs/party1.toml --out proof.0.proof --public-input public_input.json &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --config configs/party2.toml --out proof.1.proof &
 cargo run --release --bin co-noir -- generate-proof --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --config configs/party3.toml --out proof.2.proof
+wait $(jobs -p)
 # Create verification key
 cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --vk test_vectors/poseidon/verification_key
 # verify proof


### PR DESCRIPTION
sometimes example scripts fail because one party finishes faster than the others and the next commands are executed, leading to address already used errors.

by adding wait statements we make sure that all parties are done before we advance.