### PR TITLE
refactor!: split network config into two types

### DIFF
--- a/co-circom/co-circom/src/lib.rs
+++ b/co-circom/co-circom/src/lib.rs
@@ -28,7 +28,7 @@ use mpc_core::protocols::{
     },
     shamir::ShamirPrimeFieldShare,
 };
-use mpc_net::config::NetworkConfig;
+use mpc_net::config::{NetworkConfig, NetworkConfigFile};
 use rand::{CryptoRng, Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 
@@ -316,7 +316,7 @@ pub struct GenerateWitnessConfig {
     #[serde(default)]
     pub vm: VMConfig,
     /// Network config
-    pub network: NetworkConfig,
+    pub network: NetworkConfigFile,
 }
 
 /// Cli arguments for `transalte_witness`
@@ -362,7 +362,7 @@ pub struct TranslateWitnessConfig {
     /// The output file where the final witness share is written to
     pub out: PathBuf,
     /// Network config
-    pub network: NetworkConfig,
+    pub network: NetworkConfigFile,
 }
 
 /// Cli arguments for `generate_proof`
@@ -424,7 +424,7 @@ pub struct GenerateProofConfig {
     /// The threshold of tolerated colluding parties
     pub threshold: usize,
     /// Network config
-    pub network: NetworkConfig,
+    pub network: NetworkConfigFile,
 }
 
 /// Cli arguments for `verify`

--- a/co-noir/co-noir/src/bin/co-noir.rs
+++ b/co-noir/co-noir/src/bin/co-noir.rs
@@ -354,7 +354,12 @@ fn run_generate_witness(config: GenerateWitnessConfig) -> color_eyre::Result<Exi
     let input_share = translate_witness_share_rep3(input_share, &compiled_program.abi)?;
 
     // connect to network
-    let net = Rep3MpcNet::new(config.network).context("while connecting to network")?;
+    let network_config = config
+        .network
+        .to_owned()
+        .try_into()
+        .context("while converting network config")?;
+    let net = Rep3MpcNet::new(network_config).context("while connecting to network")?;
     let id = usize::from(net.get_id());
 
     // init MPC protocol
@@ -407,7 +412,12 @@ fn run_translate_witness(config: TranslateWitnessConfig) -> color_eyre::Result<E
     }
 
     // connect to network
-    let net = Rep3MpcNet::new(config.network)?;
+    let network_config = config
+        .network
+        .to_owned()
+        .try_into()
+        .context("while converting network config")?;
+    let net = Rep3MpcNet::new(network_config)?;
     let id = usize::from(net.get_id());
 
     // init MPC protocol
@@ -468,6 +478,12 @@ fn run_generate_proof(config: GenerateProofConfig) -> color_eyre::Result<ExitCod
     let constraint_system = Utils::get_constraint_system_from_file(&circuit_path, true)
         .context("while parsing program artifact")?;
 
+    let network_config = config
+        .network
+        .to_owned()
+        .try_into()
+        .context("while converting network config")?;
+
     let (proof, public_input) = match protocol {
         MPCProtocol::REP3 => {
             if t != 1 {
@@ -476,7 +492,7 @@ fn run_generate_proof(config: GenerateProofConfig) -> color_eyre::Result<ExitCod
             let witness_share = bincode::deserialize_from(witness_file)
                 .context("while deserializing witness share")?;
             // connect to network
-            let net = Rep3MpcNet::new(config.network)?;
+            let net = Rep3MpcNet::new(network_config)?;
             let id = net.get_id();
 
             let mut io_context0 = IoContext::init(net)?;
@@ -526,7 +542,7 @@ fn run_generate_proof(config: GenerateProofConfig) -> color_eyre::Result<ExitCod
             let witness_share = bincode::deserialize_from(witness_file)
                 .context("while deserializing witness share")?;
             // connect to network
-            let net = ShamirMpcNet::new(config.network)?;
+            let net = ShamirMpcNet::new(network_config)?;
             let id = net.get_id();
 
             // Create the circuit

--- a/co-noir/co-noir/src/lib.rs
+++ b/co-noir/co-noir/src/lib.rs
@@ -24,7 +24,7 @@ use mpc_core::protocols::{
     },
     shamir::{self, network::ShamirNetwork},
 };
-use mpc_net::config::NetworkConfig;
+use mpc_net::config::NetworkConfigFile;
 use noirc_abi::Abi;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
@@ -223,7 +223,7 @@ pub struct GenerateWitnessConfig {
     /// The output file where the final witness share is written to
     pub out: PathBuf,
     /// Network config
-    pub network: NetworkConfig,
+    pub network: NetworkConfigFile,
 }
 
 /// Cli arguments for `translate_witness`
@@ -263,7 +263,7 @@ pub struct TranslateWitnessConfig {
     /// The output file where the final witness share is written to
     pub out: PathBuf,
     /// Network config
-    pub network: NetworkConfig,
+    pub network: NetworkConfigFile,
 }
 
 /// Cli arguments for `generate_proof`
@@ -320,7 +320,7 @@ pub struct GenerateProofConfig {
     /// The threshold of tolerated colluding parties
     pub threshold: usize,
     /// Network config
-    pub network: NetworkConfig,
+    pub network: NetworkConfigFile,
 }
 
 /// Cli arguments for `creating_vk`

--- a/mpc-net/examples/three_party_bincode_channels.rs
+++ b/mpc-net/examples/three_party_bincode_channels.rs
@@ -6,7 +6,10 @@ use color_eyre::{
     Result,
 };
 use futures::{SinkExt, StreamExt};
-use mpc_net::{config::NetworkConfig, MpcNetworkHandler};
+use mpc_net::{
+    config::{NetworkConfig, NetworkConfigFile},
+    MpcNetworkHandler,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Parser)]
@@ -23,11 +26,13 @@ async fn main() -> Result<()> {
         .install_default()
         .map_err(|_| eyre!("Could not install default rustls crypto provider"))?;
 
-    let config: NetworkConfig =
+    let config: NetworkConfigFile =
         toml::from_str(&std::fs::read_to_string(args.config_file).context("opening config file")?)
             .context("parsing config file")?;
+    let config = NetworkConfig::try_from(config).context("converting network config")?;
+    let my_id = config.my_id;
 
-    let network = MpcNetworkHandler::establish(config.clone()).await?;
+    let network = MpcNetworkHandler::establish(config).await?;
 
     let mut channels = network.get_serde_bincode_channels().await?;
 
@@ -40,7 +45,7 @@ async fn main() -> Result<()> {
     for (&_, channel) in channels.iter_mut() {
         let buf = channel.next().await;
         if let Some(Ok(Message::Ping(b))) = buf {
-            assert!(b.iter().all(|&x| x == config.my_id as u8))
+            assert!(b.iter().all(|&x| x == my_id as u8))
         } else {
             panic!("could not receive message");
         }
@@ -54,7 +59,7 @@ async fn main() -> Result<()> {
     for (&_, channel) in channels.iter_mut() {
         let buf = channel.next().await;
         if let Some(Ok(Message::Pong(b))) = buf {
-            assert!(b.iter().all(|&x| x == config.my_id as u8))
+            assert!(b.iter().all(|&x| x == my_id as u8))
         } else {
             panic!("could not receive message");
         }

--- a/mpc-net/examples/three_party_managed.rs
+++ b/mpc-net/examples/three_party_managed.rs
@@ -5,7 +5,11 @@ use color_eyre::{
     eyre::{eyre, Context},
     Result,
 };
-use mpc_net::{channel::ChannelHandle, config::NetworkConfig, MpcNetworkHandler};
+use mpc_net::{
+    channel::ChannelHandle,
+    config::{NetworkConfig, NetworkConfigFile},
+    MpcNetworkHandler,
+};
 
 #[derive(Parser)]
 struct Args {
@@ -21,11 +25,13 @@ async fn main() -> Result<()> {
         .install_default()
         .map_err(|_| eyre!("Could not install default rustls crypto provider"))?;
 
-    let config: NetworkConfig =
+    let config: NetworkConfigFile =
         toml::from_str(&std::fs::read_to_string(args.config_file).context("opening config file")?)
             .context("parsing config file")?;
+    let config = NetworkConfig::try_from(config).context("converting network config")?;
+    let my_id = config.my_id;
 
-    let network = MpcNetworkHandler::establish(config.clone()).await?;
+    let network = MpcNetworkHandler::establish(config).await?;
 
     let channels = network.get_byte_channels().await?;
     let mut managed_channels = channels
@@ -42,8 +48,8 @@ async fn main() -> Result<()> {
     for (&_, channel) in managed_channels.iter_mut() {
         let buf = channel.recv().await.await;
         if let Ok(Ok(b)) = buf {
-            println!("received {}, should be {}", b[0], config.my_id as u8);
-            assert!(b.iter().all(|&x| x == config.my_id as u8))
+            println!("received {}, should be {}", b[0], my_id as u8);
+            assert!(b.iter().all(|&x| x == my_id as u8))
         }
     }
     network.print_connection_stats(&mut std::io::stdout())?;


### PR DESCRIPTION
One type is used to represent the config file, it can be converted into the other which holds certs and key instead of their paths.

BREAKING CHANGE: MpcNetworkHandler::establish now takes the config with already read certs and key.

fixes (#228)