### PR TITLE
feat!: added run_and_get_network to CircomRep3VmWitnessExtension, changed run and run_with_flat back to consume self

### DIFF
--- a/co-circom/circom-mpc-compiler/src/lib.rs
+++ b/co-circom/circom-mpc-compiler/src/lib.rs
@@ -719,7 +719,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut plain_vm = parsed.to_plain_vm(VMConfig::default());
+        let plain_vm = parsed.to_plain_vm(VMConfig::default());
         let finalized_witness = plain_vm
             .run_with_flat(
                 to_field_vec!(vec![

--- a/co-circom/circom-mpc-vm/src/mpc/rep3.rs
+++ b/co-circom/circom-mpc-vm/src/mpc/rep3.rs
@@ -80,6 +80,10 @@ impl<F: PrimeField, N: Rep3Network> CircomRep3VmWitnessExtension<F, N> {
         })
     }
 
+    pub fn get_network(self) -> N {
+        self.io_context0.network
+    }
+
     /// Normally F is split into positive and negative numbers in the range [0, p/2] and [p/2 + 1, p)
     /// However, for comparisons, we want the negative numbers to be "lower" than the positive ones.
     /// Therefore we shift the input by p/2 + 1 to the left, which results in a mapping of [negative, 0, positive] into F.

--- a/co-circom/co-circom/src/lib.rs
+++ b/co-circom/co-circom/src/lib.rs
@@ -667,7 +667,7 @@ where
     let id = usize::from(net.get_id());
 
     // init MPC protocol
-    let mut rep3_vm = parsed_circom_circuit
+    let rep3_vm = parsed_circom_circuit
         .to_rep3_vm_with_network(net, config.vm)
         .context("while constructing MPC VM")?;
 

--- a/tests/tests/circom/witness_extension_tests/rep3.rs
+++ b/tests/tests/circom/witness_extension_tests/rep3.rs
@@ -113,7 +113,7 @@ macro_rules! run_test {
                 compiler_config
                     .link_library
                     .push("../test_vectors/WitnessExtension/tests/libs/".into());
-                let mut witness_extension =
+                let witness_extension =
                     CoCircomCompiler::<Bn254>::parse($file.to_owned(), compiler_config)
                         .unwrap()
                         .to_rep3_vm_with_network(net, VMConfig::default())


### PR DESCRIPTION
BREAKING CHANGE: run and run_with_flat methods on WitnessExtension now consume self again