### PR TITLE
fix: update README with correct repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ chmod +x co-circom
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/TaceoLabs/co-circom.git
+git clone https://github.com/TaceoLabs/co-snarks
 ```
 
 2. Build the project:


### PR DESCRIPTION
This branch should:

- [x] change the old repo url that return "not found" with the new one.