### PR TITLE
feat: Adapt co-Noir to allow shared LUTs for Blackbox_and and blackbox_xor

### DIFF
--- a/co-noir/co-acvm/src/mpc.rs
+++ b/co-noir/co-acvm/src/mpc.rs
@@ -120,6 +120,21 @@ pub trait NoirWitnessExtensionProtocol<F: PrimeField> {
         lut: &mut <Self::Lookup as LookupTableProvider<F>>::LutType,
     ) -> io::Result<()>;
 
+    /// Creates a shared one-hot-encoded vector from a given shared index
+    fn one_hot_vector_from_shared_index(
+        &mut self,
+        index: Self::ArithmeticShare,
+        len: usize,
+    ) -> io::Result<Vec<Self::ArithmeticShare>>;
+
+    /// Writes to a shared LUT from a given shared one-hot-encoded vector.
+    fn write_to_shared_lut_from_ohv(
+        &mut self,
+        ohv: &[Self::ArithmeticShare],
+        value: Self::ArithmeticShare,
+        lut: &mut [Self::ArithmeticShare],
+    ) -> io::Result<()>;
+
     /// Returns true if the value is shared
     fn is_shared(a: &Self::AcvmType) -> bool;
 

--- a/co-noir/co-acvm/src/mpc.rs
+++ b/co-noir/co-acvm/src/mpc.rs
@@ -203,30 +203,32 @@ pub trait NoirWitnessExtensionProtocol<F: PrimeField> {
         num_bits: u32,
     ) -> std::io::Result<Self::AcvmType>;
 
-    /// slices according to bases, does and on them and then rotates them
+    /// Slices input1 and input2 into a vector of basis_bits bits each, ANDs all values and rotates the results by rotation. Thereby, in total only total_bitsize bits per input are considered.
     #[expect(clippy::type_complexity)]
-    fn slice_and_get_and_rotate_values<const BITS_PER_SLICE: u64>(
+    fn slice_and_get_and_rotate_values(
         &mut self,
         input1: Self::ArithmeticShare,
         input2: Self::ArithmeticShare,
-        bases: &[u64],
+        basis_bits: usize,
+        total_bitsize: usize,
         rotation: usize,
     ) -> std::io::Result<(
-        Vec<(Self::AcvmType, Self::AcvmType)>,
+        Vec<Self::AcvmType>,
         Vec<Self::AcvmType>,
         Vec<Self::AcvmType>,
     )>;
 
-    /// slices according to bases, does xor on them and then rotates them
+    /// Slices input1 and input2 into a vector of basis_bits bits each, XORs all values and rotates the results by rotation. Thereby, in total only total_bitsize bits per input are considered.
     #[expect(clippy::type_complexity)]
-    fn slice_and_get_xor_rotate_values<const BITS_PER_SLICE: u64>(
+    fn slice_and_get_xor_rotate_values(
         &mut self,
         input1: Self::ArithmeticShare,
         input2: Self::ArithmeticShare,
-        bases: &[u64],
+        basis_bits: usize,
+        total_bitsize: usize,
         rotation: usize,
     ) -> std::io::Result<(
-        Vec<(Self::AcvmType, Self::AcvmType)>,
+        Vec<Self::AcvmType>,
         Vec<Self::AcvmType>,
         Vec<Self::AcvmType>,
     )>;

--- a/co-noir/co-acvm/src/mpc.rs
+++ b/co-noir/co-acvm/src/mpc.rs
@@ -202,4 +202,32 @@ pub trait NoirWitnessExtensionProtocol<F: PrimeField> {
         rhs: Self::AcvmType,
         num_bits: u32,
     ) -> std::io::Result<Self::AcvmType>;
+
+    /// slices according to bases, does and on them and then rotates them
+    #[expect(clippy::type_complexity)]
+    fn slice_and_get_and_rotate_values<const BITS_PER_SLICE: u64>(
+        &mut self,
+        input1: Self::ArithmeticShare,
+        input2: Self::ArithmeticShare,
+        bases: &[u64],
+        rotation: usize,
+    ) -> std::io::Result<(
+        Vec<(Self::AcvmType, Self::AcvmType)>,
+        Vec<Self::AcvmType>,
+        Vec<Self::AcvmType>,
+    )>;
+
+    /// slices according to bases, does xor on them and then rotates them
+    #[expect(clippy::type_complexity)]
+    fn slice_and_get_xor_rotate_values<const BITS_PER_SLICE: u64>(
+        &mut self,
+        input1: Self::ArithmeticShare,
+        input2: Self::ArithmeticShare,
+        bases: &[u64],
+        rotation: usize,
+    ) -> std::io::Result<(
+        Vec<(Self::AcvmType, Self::AcvmType)>,
+        Vec<Self::AcvmType>,
+        Vec<Self::AcvmType>,
+    )>;
 }

--- a/co-noir/co-acvm/src/mpc/plain.rs
+++ b/co-noir/co-acvm/src/mpc/plain.rs
@@ -147,6 +147,39 @@ impl<F: PrimeField> NoirWitnessExtensionProtocol<F> for PlainAcvmSolver<F> {
             .write_to_lut(index, value, lut, &mut a, &mut b)
     }
 
+    fn one_hot_vector_from_shared_index(
+        &mut self,
+        index: Self::ArithmeticShare,
+        len: usize,
+    ) -> std::io::Result<Vec<Self::ArithmeticShare>> {
+        let len_ = if len.is_power_of_two() {
+            len
+        } else {
+            len.next_power_of_two()
+        };
+        let mut result = vec![F::zero(); len_];
+        let index: BigUint = index.into();
+        let index = usize::try_from(index).expect("Index to large for usize");
+        result[index] = F::one();
+        Ok(result)
+    }
+
+    fn write_to_shared_lut_from_ohv(
+        &mut self,
+        ohv: &[Self::ArithmeticShare],
+        value: Self::ArithmeticShare,
+        lut: &mut [Self::ArithmeticShare],
+    ) -> std::io::Result<()> {
+        let index = ohv
+            .iter()
+            .enumerate()
+            .find(|x| x.1.is_one())
+            .expect("Is an one_hot_encoded vector")
+            .0;
+        lut[index] = value;
+        Ok(())
+    }
+
     fn is_shared(_: &Self::AcvmType) -> bool {
         false
     }

--- a/co-noir/co-acvm/src/mpc/plain.rs
+++ b/co-noir/co-acvm/src/mpc/plain.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::io;
 use std::marker::PhantomData;
 
@@ -8,7 +7,6 @@ use co_brillig::mpc::{PlainBrilligDriver, PlainBrilligType};
 use mpc_core::lut::{LookupTableProvider, PlainLookupTableProvider};
 use num_bigint::BigUint;
 
-#[derive(Default)]
 pub struct PlainAcvmSolver<F: PrimeField> {
     plain_lut: PlainLookupTableProvider<F>,
     phantom_data: PhantomData<F>,
@@ -19,6 +17,12 @@ impl<F: PrimeField> PlainAcvmSolver<F> {
             plain_lut: Default::default(),
             phantom_data: Default::default(),
         }
+    }
+}
+
+impl<F: PrimeField> Default for PlainAcvmSolver<F> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/co-noir/co-acvm/src/mpc/rep3.rs
+++ b/co-noir/co-acvm/src/mpc/rep3.rs
@@ -730,4 +730,90 @@ impl<F: PrimeField, N: Rep3Network> NoirWitnessExtensionProtocol<F> for Rep3Acvm
             }
         }
     }
+
+    fn slice_and_get_and_rotate_values<const BITS_PER_SLICE: u64>(
+        &mut self,
+        input1: Self::ArithmeticShare,
+        input2: Self::ArithmeticShare,
+        bases: &[u64],
+        rotation: usize,
+    ) -> std::io::Result<(
+        Vec<(Self::AcvmType, Self::AcvmType)>,
+        Vec<Self::AcvmType>,
+        Vec<Self::AcvmType>,
+    )> {
+        let result = yao::slice_and(
+            input1,
+            input2,
+            &mut self.io_context0,
+            bases[0] as usize,
+            rotation,
+            BITS_PER_SLICE.try_into().unwrap(),
+        )?;
+        let num_outputs = result.len();
+        let mut chunks = result.chunks(num_outputs / 3);
+        let rotation_values = chunks
+            .next()
+            .unwrap()
+            .iter()
+            .map(|a| (Rep3AcvmType::Shared(*a), Rep3AcvmType::Public(F::zero())))
+            .collect();
+        let key_a_slices = chunks
+            .next()
+            .unwrap()
+            .iter()
+            .map(|a| Rep3AcvmType::Shared(*a))
+            .collect();
+        let key_b_slices = chunks
+            .next()
+            .unwrap()
+            .iter()
+            .map(|a| Rep3AcvmType::Shared(*a))
+            .collect();
+
+        Ok((rotation_values, key_a_slices, key_b_slices))
+    }
+
+    fn slice_and_get_xor_rotate_values<const BITS_PER_SLICE: u64>(
+        &mut self,
+        input1: Self::ArithmeticShare,
+        input2: Self::ArithmeticShare,
+        bases: &[u64],
+        rotation: usize,
+    ) -> std::io::Result<(
+        Vec<(Self::AcvmType, Self::AcvmType)>,
+        Vec<Self::AcvmType>,
+        Vec<Self::AcvmType>,
+    )> {
+        let result = yao::slice_xor(
+            input1,
+            input2,
+            &mut self.io_context0,
+            bases[0] as usize,
+            rotation,
+            BITS_PER_SLICE.try_into().unwrap(),
+        )?;
+        let num_outputs = result.len();
+        let mut chunks = result.chunks(num_outputs / 3);
+        let rotation_values = chunks
+            .next()
+            .unwrap()
+            .iter()
+            .map(|a| (Rep3AcvmType::Shared(*a), Rep3AcvmType::Public(F::zero())))
+            .collect();
+        let key_a_slices = chunks
+            .next()
+            .unwrap()
+            .iter()
+            .map(|a| Rep3AcvmType::Shared(*a))
+            .collect();
+        let key_b_slices = chunks
+            .next()
+            .unwrap()
+            .iter()
+            .map(|a| Rep3AcvmType::Shared(*a))
+            .collect();
+
+        Ok((rotation_values, key_a_slices, key_b_slices))
+    }
 }

--- a/co-noir/co-acvm/src/mpc/rep3.rs
+++ b/co-noir/co-acvm/src/mpc/rep3.rs
@@ -522,6 +522,30 @@ impl<F: PrimeField, N: Rep3Network> NoirWitnessExtensionProtocol<F> for Rep3Acvm
         Ok(())
     }
 
+    fn one_hot_vector_from_shared_index(
+        &mut self,
+        index: Self::ArithmeticShare,
+        len: usize,
+    ) -> std::io::Result<Vec<Self::ArithmeticShare>> {
+        self.lut_provider
+            .ohv_from_index(index, len, &mut self.io_context0, &mut self.io_context1)
+    }
+
+    fn write_to_shared_lut_from_ohv(
+        &mut self,
+        ohv: &[Self::ArithmeticShare],
+        value: Self::ArithmeticShare,
+        lut: &mut [Self::ArithmeticShare],
+    ) -> std::io::Result<()> {
+        self.lut_provider.write_to_shared_lut_from_ohv(
+            ohv,
+            value,
+            lut,
+            &mut self.io_context0,
+            &mut self.io_context1,
+        )
+    }
+
     fn is_shared(a: &Self::AcvmType) -> bool {
         matches!(a, Rep3AcvmType::Shared(_))
     }

--- a/co-noir/co-acvm/src/mpc/rep3.rs
+++ b/co-noir/co-acvm/src/mpc/rep3.rs
@@ -752,12 +752,6 @@ impl<F: PrimeField, N: Rep3Network> NoirWitnessExtensionProtocol<F> for Rep3Acvm
         )?;
         let num_outputs = result.len();
         let mut chunks = result.chunks(num_outputs / 3);
-        let rotation_values = chunks
-            .next()
-            .unwrap()
-            .iter()
-            .map(|a| (Rep3AcvmType::Shared(*a), Rep3AcvmType::Public(F::zero())))
-            .collect();
         let key_a_slices = chunks
             .next()
             .unwrap()
@@ -769,6 +763,12 @@ impl<F: PrimeField, N: Rep3Network> NoirWitnessExtensionProtocol<F> for Rep3Acvm
             .unwrap()
             .iter()
             .map(|a| Rep3AcvmType::Shared(*a))
+            .collect();
+        let rotation_values = chunks
+            .next()
+            .unwrap()
+            .iter()
+            .map(|a| (Rep3AcvmType::Shared(*a), Rep3AcvmType::Public(F::zero())))
             .collect();
 
         Ok((rotation_values, key_a_slices, key_b_slices))
@@ -795,12 +795,6 @@ impl<F: PrimeField, N: Rep3Network> NoirWitnessExtensionProtocol<F> for Rep3Acvm
         )?;
         let num_outputs = result.len();
         let mut chunks = result.chunks(num_outputs / 3);
-        let rotation_values = chunks
-            .next()
-            .unwrap()
-            .iter()
-            .map(|a| (Rep3AcvmType::Shared(*a), Rep3AcvmType::Public(F::zero())))
-            .collect();
         let key_a_slices = chunks
             .next()
             .unwrap()
@@ -812,6 +806,12 @@ impl<F: PrimeField, N: Rep3Network> NoirWitnessExtensionProtocol<F> for Rep3Acvm
             .unwrap()
             .iter()
             .map(|a| Rep3AcvmType::Shared(*a))
+            .collect();
+        let rotation_values = chunks
+            .next()
+            .unwrap()
+            .iter()
+            .map(|a| (Rep3AcvmType::Shared(*a), Rep3AcvmType::Public(F::zero())))
             .collect();
 
         Ok((rotation_values, key_a_slices, key_b_slices))

--- a/co-noir/co-acvm/src/mpc/rep3.rs
+++ b/co-noir/co-acvm/src/mpc/rep3.rs
@@ -746,7 +746,7 @@ impl<F: PrimeField, N: Rep3Network> NoirWitnessExtensionProtocol<F> for Rep3Acvm
             input1,
             input2,
             &mut self.io_context0,
-            bases[0] as usize,
+            bases[0].ilog2() as usize,
             rotation,
             BITS_PER_SLICE.try_into().unwrap(),
         )?;
@@ -789,7 +789,7 @@ impl<F: PrimeField, N: Rep3Network> NoirWitnessExtensionProtocol<F> for Rep3Acvm
             input1,
             input2,
             &mut self.io_context0,
-            bases[0] as usize,
+            bases[0].ilog2() as usize,
             rotation,
             BITS_PER_SLICE.try_into().unwrap(),
         )?;

--- a/co-noir/co-acvm/src/mpc/shamir.rs
+++ b/co-noir/co-acvm/src/mpc/shamir.rs
@@ -492,4 +492,32 @@ impl<F: PrimeField, N: ShamirNetwork> NoirWitnessExtensionProtocol<F> for Shamir
             _ => panic!("functionality bitwise_xor not feasible for Shamir"),
         }
     }
+
+    fn slice_and_get_and_rotate_values<const BITS_PER_SLICE: u64>(
+        &mut self,
+        _input1: Self::ArithmeticShare,
+        _input2: Self::ArithmeticShare,
+        _bases: &[u64],
+        _rotation: usize,
+    ) -> std::io::Result<(
+        Vec<(Self::AcvmType, Self::AcvmType)>,
+        Vec<Self::AcvmType>,
+        Vec<Self::AcvmType>,
+    )> {
+        panic!("functionality slice_and_get_and_rotate_values not feasible for Shamir")
+    }
+
+    fn slice_and_get_xor_rotate_values<const BITS_PER_SLICE: u64>(
+        &mut self,
+        _input1: Self::ArithmeticShare,
+        _input2: Self::ArithmeticShare,
+        _bases: &[u64],
+        _rotation: usize,
+    ) -> std::io::Result<(
+        Vec<(Self::AcvmType, Self::AcvmType)>,
+        Vec<Self::AcvmType>,
+        Vec<Self::AcvmType>,
+    )> {
+        panic!("functionality slice_and_get_xor_rotate_values not feasible for Shamir")
+    }
 }

--- a/co-noir/co-acvm/src/mpc/shamir.rs
+++ b/co-noir/co-acvm/src/mpc/shamir.rs
@@ -493,28 +493,30 @@ impl<F: PrimeField, N: ShamirNetwork> NoirWitnessExtensionProtocol<F> for Shamir
         }
     }
 
-    fn slice_and_get_and_rotate_values<const BITS_PER_SLICE: u64>(
+    fn slice_and_get_and_rotate_values(
         &mut self,
         _input1: Self::ArithmeticShare,
         _input2: Self::ArithmeticShare,
-        _bases: &[u64],
+        _basis_bits: usize,
+        _total_bitsize: usize,
         _rotation: usize,
     ) -> std::io::Result<(
-        Vec<(Self::AcvmType, Self::AcvmType)>,
+        Vec<Self::AcvmType>,
         Vec<Self::AcvmType>,
         Vec<Self::AcvmType>,
     )> {
         panic!("functionality slice_and_get_and_rotate_values not feasible for Shamir")
     }
 
-    fn slice_and_get_xor_rotate_values<const BITS_PER_SLICE: u64>(
+    fn slice_and_get_xor_rotate_values(
         &mut self,
         _input1: Self::ArithmeticShare,
         _input2: Self::ArithmeticShare,
-        _bases: &[u64],
+        _basis_bits: usize,
+        _total_bitsize: usize,
         _rotation: usize,
     ) -> std::io::Result<(
-        Vec<(Self::AcvmType, Self::AcvmType)>,
+        Vec<Self::AcvmType>,
         Vec<Self::AcvmType>,
         Vec<Self::AcvmType>,
     )> {

--- a/co-noir/co-acvm/src/mpc/shamir.rs
+++ b/co-noir/co-acvm/src/mpc/shamir.rs
@@ -371,6 +371,23 @@ impl<F: PrimeField, N: ShamirNetwork> NoirWitnessExtensionProtocol<F> for Shamir
         panic!("write_lut_by_acvm_type: Operation atm not supported")
     }
 
+    fn one_hot_vector_from_shared_index(
+        &mut self,
+        _index: Self::ArithmeticShare,
+        _len: usize,
+    ) -> std::io::Result<Vec<Self::ArithmeticShare>> {
+        panic!("one_hot_vector_from_shared_index: Operation atm not supported")
+    }
+
+    fn write_to_shared_lut_from_ohv(
+        &mut self,
+        _ohv: &[Self::ArithmeticShare],
+        _value: Self::ArithmeticShare,
+        _lut: &mut [Self::ArithmeticShare],
+    ) -> std::io::Result<()> {
+        panic!("write_to_shared_lut_from_ohv: Operation atm not supported")
+    }
+
     fn is_shared(a: &Self::AcvmType) -> bool {
         matches!(a, ShamirAcvmType::Shared(_))
     }

--- a/co-noir/co-builder/src/builder.rs
+++ b/co-noir/co-builder/src/builder.rs
@@ -684,7 +684,7 @@ impl<P: Pairing, T: NoirWitnessExtensionProtocol<P::ScalarField>> GenericUltraCi
             let b_chunk = FieldCT::from_witness(right_chunk, self);
 
             let result_chunk = if is_xor_gate {
-                Plookup::<P::ScalarField>::read_from_2_to_1_table(
+                Plookup::read_from_2_to_1_table(
                     self,
                     driver,
                     MultiTableId::Uint32Xor,
@@ -692,7 +692,7 @@ impl<P: Pairing, T: NoirWitnessExtensionProtocol<P::ScalarField>> GenericUltraCi
                     b_chunk.to_owned(),
                 )?
             } else {
-                Plookup::<P::ScalarField>::read_from_2_to_1_table(
+                Plookup::read_from_2_to_1_table(
                     self,
                     driver,
                     MultiTableId::Uint32And,

--- a/co-noir/co-builder/src/keys/proving_key.rs
+++ b/co-noir/co-builder/src/keys/proving_key.rs
@@ -420,9 +420,11 @@ impl<P: Pairing> ProvingKey<P> {
 
                 // find the index of the entry in the table
                 // let index_in_table = table.index_map[table_entry]; // We calculate indices from keys
-                let index_in_table =
-                    gate_data.calculate_table_index(table.use_twin_keys, table.column_2_step_size);
-                let index_in_table = T::AcvmType::from(index_in_table); // TODO this just simulates that we potentially have shared LUTs, adapt later when we implement it
+                let index_in_table = gate_data.calculate_table_index(
+                    driver,
+                    table.use_twin_keys,
+                    table.column_2_step_size,
+                );
 
                 if T::is_shared(&index_in_table) {
                     let index_in_table =

--- a/co-noir/co-builder/src/keys/proving_key.rs
+++ b/co-noir/co-builder/src/keys/proving_key.rs
@@ -399,7 +399,6 @@ impl<P: Pairing> ProvingKey<P> {
         }
     }
 
-    // TACEO TODO adapt this function once the calculate_table_index returns an ACVM type
     pub fn construct_lookup_read_counts<T: NoirWitnessExtensionProtocol<P::ScalarField>>(
         driver: &mut T,
         witness: &mut [Polynomial<T::ArithmeticShare>; 2],

--- a/co-noir/co-builder/src/keys/proving_key.rs
+++ b/co-noir/co-builder/src/keys/proving_key.rs
@@ -411,7 +411,7 @@ impl<P: Pairing> ProvingKey<P> {
         let mut table_offset = offset; // offset of the present table in the table polynomials
                                        // loop over all tables used in the circuit; each table contains data about the lookups made on it
         for table in circuit.lookup_tables.iter_mut() {
-            table.initialize_index_map();
+            // table.initialize_index_map(); // We calculate indices from keys
 
             // TACEO TODO for shared lookup tables:
             // - get index_in_table with LUT
@@ -422,10 +422,12 @@ impl<P: Pairing> ProvingKey<P> {
             // - Skip the or if len is just one
             for gate_data in table.lookup_gates.iter() {
                 // convert lookup gate data to an array of three field elements, one for each of the 3 columns
-                let table_entry = gate_data.to_table_components(table.use_twin_keys);
+                // let table_entry = gate_data.to_table_components(table.use_twin_keys); // We calculate indices from keys
 
                 // find the index of the entry in the table
-                let index_in_table = table.index_map[table_entry];
+                // let index_in_table = table.index_map[table_entry]; // We calculate indices from keys
+                let index_in_table =
+                    gate_data.calculate_table_index(table.use_twin_keys, table.column_2_step_size);
 
                 // increment the read count at the corresponding index in the full polynomial
                 let index_in_poly = table_offset + index_in_table;

--- a/co-noir/co-builder/src/polynomials/polynomial_types.rs
+++ b/co-noir/co-builder/src/polynomials/polynomial_types.rs
@@ -72,6 +72,10 @@ impl<T: Default> ProverWitnessEntities<T> {
     // const Z_PERM: usize = 4; // column 4 (computed by prover)
     // const LOOKUP_INVERSES: usize = 5; // column 5 (computed by prover);
 
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.elements.iter()
+    }
+
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
         self.elements.iter_mut()
     }

--- a/co-noir/co-builder/src/polynomials/polynomial_types.rs
+++ b/co-noir/co-builder/src/polynomials/polynomial_types.rs
@@ -59,7 +59,7 @@ impl<T: Default> ProverWitnessEntities<T> {
     /// column 0
     const W_L: usize = 0;
     /// column 1
-    const W_R: usize = 1;
+    pub const W_R: usize = 1;
     /// column 2
     const W_O: usize = 2;
     /// column 3 (modified by prover)

--- a/co-noir/co-builder/src/prelude.rs
+++ b/co-noir/co-builder/src/prelude.rs
@@ -9,7 +9,9 @@ pub use crate::keys::verification_key::VerifyingKey;
 pub use crate::keys::verification_key::VerifyingKeyBarretenberg;
 pub use crate::polynomials::polynomial::Polynomial;
 pub use crate::polynomials::polynomial_types::Polynomials;
-pub use crate::polynomials::polynomial_types::{PrecomputedEntities, PRECOMPUTED_ENTITIES_SIZE};
+pub use crate::polynomials::polynomial_types::{
+    PrecomputedEntities, ProverWitnessEntities, PRECOMPUTED_ENTITIES_SIZE,
+};
 pub use crate::serialize::{Serialize, SerializeP};
 pub use crate::types::types::{
     AggregationObjectPubInputIndices, CycleNode, CyclicPermutation, AGGREGATION_OBJECT_SIZE,

--- a/co-noir/co-builder/src/types/types.rs
+++ b/co-noir/co-builder/src/types/types.rs
@@ -1247,7 +1247,6 @@ impl<F: PrimeField> LookupEntry<F> {
             index_b += F::from(self.key[1].to_owned());
         }
         index_b
-        // usize::try_from(index_b).expect("index is too large for usize?")
     }
 }
 

--- a/co-noir/co-builder/src/types/types.rs
+++ b/co-noir/co-builder/src/types/types.rs
@@ -1238,6 +1238,16 @@ impl<F: PrimeField> LookupEntry<F> {
             },
         ]
     }
+
+    pub(crate) fn calculate_table_index(&self, use_two_key: bool, base: F) -> usize {
+        let mut index_b = self.key[0].to_owned();
+        if use_two_key {
+            let b: BigUint = base.into();
+            index_b *= b;
+            index_b += &self.key[1];
+        }
+        usize::try_from(index_b).expect("index is too large for usize?")
+    }
 }
 
 pub(crate) struct PlookupBasicTable<F: PrimeField> {

--- a/co-noir/co-builder/src/types/types.rs
+++ b/co-noir/co-builder/src/types/types.rs
@@ -1239,14 +1239,15 @@ impl<F: PrimeField> LookupEntry<F> {
         ]
     }
 
-    pub(crate) fn calculate_table_index(&self, use_two_key: bool, base: F) -> usize {
-        let mut index_b = self.key[0].to_owned();
+    // TACEO TODO this one will get adapted to return an ACVMType later
+    pub(crate) fn calculate_table_index(&self, use_two_key: bool, base: F) -> F {
+        let mut index_b = F::from(self.key[0].to_owned());
         if use_two_key {
-            let b: BigUint = base.into();
-            index_b *= b;
-            index_b += &self.key[1];
+            index_b *= base;
+            index_b += F::from(self.key[1].to_owned());
         }
-        usize::try_from(index_b).expect("index is too large for usize?")
+        index_b
+        // usize::try_from(index_b).expect("index is too large for usize?")
     }
 }
 

--- a/co-noir/co-noir/examples/compare_mpc.sh
+++ b/co-noir/co-noir/examples/compare_mpc.sh
@@ -36,7 +36,7 @@ echo "Using nargo version $NARGO_VERSION"
 echo "Using bb version $BARRETENBERG_VERSION"
 echo ""
 
-test_cases=("add3u64" "mul3u64" "assert" "get_bytes" "if_then" "negative" "add3" "add3_assert" "poseidon" "poseidon_input2" "approx_sigmoid" "addition_multiplication" "unconstrained_fn_field" "poseidon_assert" "quantized" "unconstrained_fn" "blackbox_not")
+test_cases=("add3u64" "mul3u64" "assert" "get_bytes" "if_then" "negative" "add3" "add3_assert" "poseidon" "poseidon_input2" "approx_sigmoid" "addition_multiplication" "unconstrained_fn_field" "poseidon_assert" "quantized" "unconstrained_fn" "blackbox_not" "blackbox_and" "blackbox_xor")
 
 run_proof_verification() {
   local name=$1

--- a/co-noir/co-noir/src/bin/co-noir.rs
+++ b/co-noir/co-noir/src/bin/co-noir.rs
@@ -630,7 +630,6 @@ fn run_translate_proving_key(config: TranslateProvingKeyConfig) -> color_eyre::R
     let shares = proving_key
         .polynomials
         .witness
-        .private_elements
         .into_iter()
         .flat_map(|el| el.into_vec().into_iter())
         .collect::<Vec<_>>();
@@ -668,8 +667,7 @@ fn run_translate_proving_key(config: TranslateProvingKeyConfig) -> color_eyre::R
 
     let polynomials = Polynomials {
         witness: ProverWitnessEntities {
-            private_elements: translated_shares,
-            public_elements: proving_key.polynomials.witness.public_elements,
+            elements: translated_shares,
         },
         precomputed: proving_key.polynomials.precomputed,
     };

--- a/co-noir/co-noir/src/bin/co-noir.rs
+++ b/co-noir/co-noir/src/bin/co-noir.rs
@@ -309,7 +309,6 @@ fn run_split_proving_key(config: SplitProvingKeyConfig) -> color_eyre::Result<Ex
     let witness_entities = proving_key
         .polynomials
         .witness
-        .get_wires()
         .iter()
         .flat_map(|el| el.iter().cloned())
         .collect::<Vec<_>>();
@@ -656,7 +655,7 @@ fn run_translate_proving_key(config: TranslateProvingKeyConfig) -> color_eyre::R
     let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
     tracing::info!("Party {}: Translating shares took {} ms", id, duration_ms);
 
-    if translated_shares.len() != 4 * proving_key.circuit_size as usize {
+    if translated_shares.len() != 6 * proving_key.circuit_size as usize {
         return Err(eyre!("Invalid number of shares translated"));
     };
 

--- a/co-noir/co-ultrahonk/src/co_decider/co_shplemini/prover.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/co_shplemini/prover.rs
@@ -100,15 +100,8 @@ impl<
 
         // Shared part of f_batched
         let mut f_batched = SharedPolynomial::<T, P>::promote_poly(&self.driver, f_batched);
-        for f_poly in f_polynomials.witness.shared_iter() {
+        for f_poly in f_polynomials.witness.iter() {
             f_batched.add_scaled_slice(&mut self.driver, f_poly, &batching_scalar);
-
-            batching_scalar *= rho;
-        }
-
-        // Final public part of f_batched
-        for f_poly in f_polynomials.witness.public_iter() {
-            f_batched.add_scaled_slice_public(&mut self.driver, f_poly, &batching_scalar);
 
             batching_scalar *= rho;
         }
@@ -474,7 +467,7 @@ impl<
         // Find n, the maximum size of all polynomials fⱼ(X)
         let mut max_poly_size: usize = 0;
         for claim in opening_claims {
-            max_poly_size = max_poly_size.max(claim.polynomial.len());
+            max_poly_size = std::cmp::max(max_poly_size, claim.polynomial.len());
         }
 
         // Q(X) = ∑ⱼ νʲ ⋅ ( fⱼ(X) − vⱼ) / ( X − xⱼ )

--- a/co-noir/co-ultrahonk/src/co_decider/co_shplemini/types.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/co_shplemini/types.rs
@@ -1,11 +1,10 @@
-use crate::types::WitnessEntities;
 use co_builder::prelude::PrecomputedEntities;
 use std::iter;
-use ultrahonk::prelude::{ShiftedTableEntities, ShiftedWitnessEntities};
+use ultrahonk::prelude::{ShiftedTableEntities, ShiftedWitnessEntities, WitnessEntities};
 
 pub(crate) struct PolyF<'a, Shared: Default, Public: Default> {
     pub(crate) precomputed: &'a PrecomputedEntities<Public>,
-    pub(crate) witness: &'a WitnessEntities<Shared, Public>,
+    pub(crate) witness: &'a WitnessEntities<Shared>,
 }
 
 pub(crate) struct PolyG<'a, Shared: Default, Public: Default> {

--- a/co-noir/co-ultrahonk/src/co_decider/co_zeromorph/prover.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/co_zeromorph/prover.rs
@@ -379,21 +379,10 @@ impl<
         let mut f_batched = SharedPolynomial::<T, P>::promote_poly(&self.driver, f_batched);
         for (f_poly, f_eval) in f_polynomials
             .witness
-            .shared_iter()
-            .zip(f_evaluations.witness.shared_iter())
+            .iter()
+            .zip(f_evaluations.witness.iter())
         {
             f_batched.add_scaled_slice(&mut self.driver, f_poly, &batching_scalar);
-            batched_evaluation += batching_scalar * f_eval;
-            batching_scalar *= rho;
-        }
-
-        // Final public part of f_batched
-        for (f_poly, f_eval) in f_polynomials
-            .witness
-            .public_iter()
-            .zip(f_evaluations.witness.public_iter())
-        {
-            f_batched.add_scaled_slice_public(&mut self.driver, f_poly, &batching_scalar);
             batched_evaluation += batching_scalar * f_eval;
             batching_scalar *= rho;
         }

--- a/co-noir/co-ultrahonk/src/co_decider/co_zeromorph/types.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/co_zeromorph/types.rs
@@ -1,11 +1,10 @@
-use crate::types::WitnessEntities;
 use co_builder::prelude::PrecomputedEntities;
 use std::iter;
-use ultrahonk::prelude::{ShiftedTableEntities, ShiftedWitnessEntities};
+use ultrahonk::prelude::{ShiftedTableEntities, ShiftedWitnessEntities, WitnessEntities};
 
 pub(crate) struct PolyF<'a, Shared: Default, Public: Default> {
     pub(crate) precomputed: &'a PrecomputedEntities<Public>,
-    pub(crate) witness: &'a WitnessEntities<Shared, Public>,
+    pub(crate) witness: &'a WitnessEntities<Shared>,
 }
 
 pub(crate) struct PolyG<'a, Shared: Default, Public: Default> {

--- a/co-noir/co-ultrahonk/src/co_decider/polynomial.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/polynomial.rs
@@ -60,6 +60,7 @@ impl<T: NoirUltraHonkProver<P>, P: Pairing> SharedPolynomial<T, P> {
         self.add_scaled_slice(driver, &src.coefficients, scalar);
     }
 
+    #[expect(unused)]
     pub(crate) fn add_scaled_slice_public(
         &mut self,
         driver: &mut T,

--- a/co-noir/co-ultrahonk/src/co_decider/univariates.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/univariates.rs
@@ -84,6 +84,7 @@ impl<T: NoirUltraHonkProver<P>, P: Pairing, const SIZE: usize> SharedUnivariate<
         result
     }
 
+    #[expect(unused)]
     pub(crate) fn sub_public(
         &self,
         driver: &mut T,

--- a/co-noir/co-ultrahonk/src/co_oink/mod.rs
+++ b/co-noir/co-ultrahonk/src/co_oink/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) mod prover;
 pub(crate) mod types;
 
-// execute_log_derivative_inverse_round: n
-pub const CRAND_PAIRS_FACTOR_N: usize = 1;
+// execute_log_derivative_inverse_round: n for inv and n for mult
+pub const CRAND_PAIRS_FACTOR_N: usize = 2;
 // execute_grand_product_computation_round:
 //      compute_grand_product:
 //      4 * batched_grand_product_num_denom: (domain_size - 1)

--- a/co-noir/co-ultrahonk/src/key/proving_key.rs
+++ b/co-noir/co-ultrahonk/src/key/proving_key.rs
@@ -304,8 +304,8 @@ impl<T: NoirUltraHonkProver<P>, P: Pairing> ProvingKey<T, P> {
         let memory_write_records = plain_key.memory_write_records.to_owned();
         let final_active_wire_idx = plain_key.final_active_wire_idx;
 
-        if shares.len() != circuit_size as usize * 4 {
-            return Err(eyre::eyre!("Share length is not 4 times circuit size"));
+        if shares.len() != circuit_size as usize * 6 {
+            return Err(eyre::eyre!("Share length is not 6 times circuit size"));
         }
 
         let mut polynomials = Polynomials::default();

--- a/co-noir/co-ultrahonk/src/key/proving_key.rs
+++ b/co-noir/co-ultrahonk/src/key/proving_key.rs
@@ -112,7 +112,7 @@ impl<T: NoirUltraHonkProver<P>, P: Pairing> ProvingKey<T, P> {
                 .unwrap(),
             &mut circuit,
             dyadic_circuit_size,
-        );
+        )?;
 
         // Construct the public inputs array
         let block = circuit.blocks.get_pub_inputs();

--- a/co-noir/co-ultrahonk/src/prelude.rs
+++ b/co-noir/co-ultrahonk/src/prelude.rs
@@ -4,10 +4,10 @@ pub use crate::mpc::rep3::Rep3UltraHonkDriver;
 pub use crate::mpc::shamir::ShamirUltraHonkDriver;
 pub use crate::mpc::NoirUltraHonkProver;
 pub use crate::prover::CoUltraHonk;
-pub use crate::types::{Polynomials, ProverWitnessEntities};
+pub use crate::types::Polynomials;
 pub use crate::{PlainCoBuilder, Rep3CoBuilder, ShamirCoBuilder};
 // Re-exporting the following types from `ultrahonk` and `co_builder` crates:
-pub use co_builder::prelude::{Crs, Polynomial, ProverCrs};
+pub use co_builder::prelude::{Crs, Polynomial, ProverCrs, ProverWitnessEntities};
 pub use co_builder::prelude::{ProvingKey as PlainProvingKey, VerifyingKey};
 pub use ultrahonk::prelude::HonkProof;
 pub use ultrahonk::prelude::Poseidon2Sponge;

--- a/co-noir/co-ultrahonk/src/types.rs
+++ b/co-noir/co-ultrahonk/src/types.rs
@@ -1,6 +1,6 @@
-use co_builder::prelude::{Polynomial, PrecomputedEntities};
+use co_builder::prelude::{Polynomial, PrecomputedEntities, ProverWitnessEntities};
 use serde::{Deserialize, Serialize};
-use ultrahonk::prelude::{ShiftedTableEntities, ShiftedWitnessEntities};
+use ultrahonk::prelude::{ShiftedTableEntities, ShiftedWitnessEntities, WitnessEntities};
 
 // This is what we get from the proving key, we shift at a later point
 #[derive(Default, Serialize, Deserialize)]
@@ -10,7 +10,7 @@ where
     Polynomial<Shared>: Serialize + for<'a> Deserialize<'a>,
     Polynomial<Public>: Serialize + for<'a> Deserialize<'a>,
 {
-    pub witness: ProverWitnessEntities<Polynomial<Shared>, Polynomial<Public>>,
+    pub witness: ProverWitnessEntities<Polynomial<Shared>>,
     pub precomputed: PrecomputedEntities<Polynomial<Public>>,
 }
 
@@ -24,12 +24,6 @@ where
         // Shifting is done at a later point
         polynomials
             .witness
-            .get_wires_mut()
-            .iter_mut()
-            .for_each(|el| el.resize(circuit_size, Default::default()));
-        polynomials
-            .witness
-            .lookup_read_counts_and_tags_mut()
             .iter_mut()
             .for_each(|el| el.resize(circuit_size, Default::default()));
         polynomials.precomputed.iter_mut().for_each(|el| {
@@ -42,7 +36,7 @@ where
 
 #[derive(Default)]
 pub(crate) struct AllEntities<Shared: Default, Public: Default> {
-    pub(crate) witness: WitnessEntities<Shared, Public>,
+    pub(crate) witness: WitnessEntities<Shared>,
     pub(crate) precomputed: PrecomputedEntities<Public>,
     pub(crate) shifted_witness: ShiftedWitnessEntities<Shared>,
     pub(crate) shifted_tables: ShiftedTableEntities<Public>,
@@ -50,32 +44,26 @@ pub(crate) struct AllEntities<Shared: Default, Public: Default> {
 
 impl<Shared: Default, Public: Default> AllEntities<Shared, Public> {
     pub(crate) fn public_iter(&self) -> impl Iterator<Item = &Public> {
-        self.precomputed
-            .iter()
-            .chain(self.witness.public_iter())
-            .chain(self.shifted_tables.iter())
+        self.precomputed.iter().chain(self.shifted_tables.iter())
     }
 
     pub(crate) fn shared_iter(&self) -> impl Iterator<Item = &Shared> {
-        self.witness
-            .shared_iter()
-            .chain(self.shifted_witness.iter())
+        self.witness.iter().chain(self.shifted_witness.iter())
     }
 
     pub(crate) fn into_shared_iter(self) -> impl Iterator<Item = Shared> {
-        self.witness.into_shared_iter().chain(self.shifted_witness)
+        self.witness.into_iter().chain(self.shifted_witness)
     }
 
     pub(crate) fn public_iter_mut(&mut self) -> impl Iterator<Item = &mut Public> {
         self.precomputed
             .iter_mut()
-            .chain(self.witness.public_iter_mut())
             .chain(self.shifted_tables.iter_mut())
     }
 
     pub(crate) fn shared_iter_mut(&mut self) -> impl Iterator<Item = &mut Shared> {
         self.witness
-            .shared_iter_mut()
+            .iter_mut()
             .chain(self.shifted_witness.iter_mut())
     }
 }
@@ -99,157 +87,8 @@ impl<T: Default> AllEntities<T, T> {
     pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {
         self.precomputed
             .iter()
-            .chain(self.witness.shared_iter())
-            .chain(self.witness.public_iter())
+            .chain(self.witness.iter())
             .chain(self.shifted_tables.iter())
             .chain(self.shifted_witness.iter())
-    }
-}
-
-const PROVER_PRIVATE_WITNESS_ENTITIES_SIZE: usize = 4;
-const PROVER_PUBLIC_WITNESS_ENTITIES_SIZE: usize = 2;
-#[derive(Default, Serialize, Deserialize)]
-pub struct ProverWitnessEntities<Shared, Public> {
-    pub private_elements: [Shared; PROVER_PRIVATE_WITNESS_ENTITIES_SIZE],
-    pub public_elements: [Public; PROVER_PUBLIC_WITNESS_ENTITIES_SIZE],
-}
-
-impl<Shared, Public> ProverWitnessEntities<Shared, Public> {
-    const W_L: usize = 0; // column 0
-    pub(crate) const W_R: usize = 1; // column 1
-    const W_O: usize = 2; // column 2
-    const W_4: usize = 3; // column 3 (modified by prover)
-
-    const LOOKUP_READ_COUNTS: usize = 0; // column 6
-    const LOOKUP_READ_TAGS: usize = 1; // column 7
-
-    // const Z_PERM: usize = 4; // column 4 (computed by prover)
-    // const LOOKUP_INVERSES: usize = 5; // column 5 (computed by prover);
-
-    pub(crate) fn into_wires(self) -> impl Iterator<Item = Shared> {
-        self.private_elements
-            .into_iter()
-            // .skip(Self::W_L)
-            .take(Self::W_4 + 1 - Self::W_L)
-    }
-
-    pub(crate) fn get_wires_mut(&mut self) -> &mut [Shared] {
-        &mut self.private_elements[Self::W_L..=Self::W_4]
-    }
-
-    pub(crate) fn w_l(&self) -> &Shared {
-        &self.private_elements[Self::W_L]
-    }
-
-    pub(crate) fn w_r(&self) -> &Shared {
-        &self.private_elements[Self::W_R]
-    }
-
-    pub(crate) fn w_o(&self) -> &Shared {
-        &self.private_elements[Self::W_O]
-    }
-
-    pub(crate) fn w_4(&self) -> &Shared {
-        &self.private_elements[Self::W_4]
-    }
-
-    pub(crate) fn lookup_read_counts(&self) -> &Public {
-        &self.public_elements[Self::LOOKUP_READ_COUNTS]
-    }
-
-    pub(crate) fn lookup_read_tags(&self) -> &Public {
-        &self.public_elements[Self::LOOKUP_READ_TAGS]
-    }
-
-    pub(crate) fn lookup_read_counts_and_tags_mut(&mut self) -> &mut [Public] {
-        &mut self.public_elements[Self::LOOKUP_READ_COUNTS..Self::LOOKUP_READ_TAGS + 1]
-    }
-}
-
-const PRIVATE_WITNESS_ENTITIES_SIZE: usize = 6;
-const PUBLIC_WITNESS_ENTITIES_SIZE: usize = 2;
-#[derive(Default)]
-pub(crate) struct WitnessEntities<Shared, Public> {
-    pub(crate) private_elements: [Shared; PRIVATE_WITNESS_ENTITIES_SIZE],
-    pub(crate) public_elements: [Public; PUBLIC_WITNESS_ENTITIES_SIZE],
-}
-
-impl<Shared, Public> WitnessEntities<Shared, Public> {
-    const W_L: usize = 0; // column 0
-    const W_R: usize = 1; // column 1
-    const W_O: usize = 2; // column 2
-    const W_4: usize = 3; // column 3 (computed by prover)
-    const Z_PERM: usize = 4; // column 4 (computed by prover)
-    pub(crate) const LOOKUP_INVERSES: usize = 5; // column 5 (computed by prover);
-
-    pub(crate) const LOOKUP_READ_COUNTS: usize = 0; // column 6
-    pub(crate) const LOOKUP_READ_TAGS: usize = 1; // column 7
-
-    pub(crate) fn shared_iter(&self) -> impl Iterator<Item = &Shared> {
-        self.private_elements.iter()
-    }
-
-    pub(crate) fn public_iter(&self) -> impl Iterator<Item = &Public> {
-        self.public_elements.iter()
-    }
-
-    pub(crate) fn into_shared_iter(self) -> impl Iterator<Item = Shared> {
-        self.private_elements.into_iter()
-    }
-
-    pub(crate) fn shared_iter_mut(&mut self) -> impl Iterator<Item = &mut Shared> {
-        self.private_elements.iter_mut()
-    }
-
-    pub(crate) fn public_iter_mut(&mut self) -> impl Iterator<Item = &mut Public> {
-        self.public_elements.iter_mut()
-    }
-
-    pub(crate) fn to_be_shifted_mut(&mut self) -> &mut [Shared] {
-        &mut self.private_elements[Self::W_L..=Self::Z_PERM]
-    }
-
-    pub(crate) fn w_l(&self) -> &Shared {
-        &self.private_elements[Self::W_L]
-    }
-
-    pub(crate) fn w_r(&self) -> &Shared {
-        &self.private_elements[Self::W_R]
-    }
-
-    pub(crate) fn w_o(&self) -> &Shared {
-        &self.private_elements[Self::W_O]
-    }
-
-    pub(crate) fn w_4(&self) -> &Shared {
-        &self.private_elements[Self::W_4]
-    }
-
-    pub(crate) fn z_perm(&self) -> &Shared {
-        &self.private_elements[Self::Z_PERM]
-    }
-
-    pub(crate) fn lookup_inverses(&self) -> &Shared {
-        &self.private_elements[Self::LOOKUP_INVERSES]
-    }
-
-    pub(crate) fn lookup_read_counts(&self) -> &Public {
-        &self.public_elements[Self::LOOKUP_READ_COUNTS]
-    }
-
-    pub(crate) fn lookup_read_tags(&self) -> &Public {
-        &self.public_elements[Self::LOOKUP_READ_TAGS]
-    }
-
-    pub(crate) fn lookup_inverses_mut(&mut self) -> &mut Shared {
-        &mut self.private_elements[Self::LOOKUP_INVERSES]
-    }
-
-    pub(crate) fn lookup_read_counts_mut(&mut self) -> &mut Public {
-        &mut self.public_elements[Self::LOOKUP_READ_COUNTS]
-    }
-
-    pub(crate) fn lookup_read_tags_mut(&mut self) -> &mut Public {
-        &mut self.public_elements[Self::LOOKUP_READ_TAGS]
     }
 }

--- a/co-noir/ultrahonk/src/prelude.rs
+++ b/co-noir/ultrahonk/src/prelude.rs
@@ -6,7 +6,7 @@ pub use crate::prover::UltraHonk;
 pub use crate::transcript::Poseidon2Sponge;
 pub use crate::transcript::{Transcript, TranscriptHasher};
 pub use crate::types::HonkProof;
-pub use crate::types::{ShiftedTableEntities, ShiftedWitnessEntities};
+pub use crate::types::{ShiftedTableEntities, ShiftedWitnessEntities, WitnessEntities};
 pub use co_builder::prelude::PlainAcvmSolver;
 pub use co_builder::prelude::VerifyingKeyBarretenberg;
 pub use co_builder::prelude::{ProvingKey, UltraCircuitBuilder};

--- a/co-noir/ultrahonk/src/types.rs
+++ b/co-noir/ultrahonk/src/types.rs
@@ -72,7 +72,7 @@ impl<T: Default + Clone> AllEntities<Vec<T>> {
 
 const WITNESS_ENTITIES_SIZE: usize = 8;
 #[derive(Default)]
-pub(crate) struct WitnessEntities<T: Default> {
+pub struct WitnessEntities<T: Default> {
     pub(crate) elements: [T; WITNESS_ENTITIES_SIZE],
 }
 
@@ -155,11 +155,11 @@ impl<T: Default> WitnessEntities<T> {
     /// column 7
     pub(crate) const LOOKUP_READ_TAGS: usize = 7;
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.elements.iter()
     }
 
-    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
         self.elements.iter_mut()
     }
 
@@ -167,39 +167,39 @@ impl<T: Default> WitnessEntities<T> {
         &self.elements[Self::W_L..=Self::Z_PERM]
     }
 
-    pub(crate) fn to_be_shifted_mut(&mut self) -> &mut [T] {
+    pub fn to_be_shifted_mut(&mut self) -> &mut [T] {
         &mut self.elements[Self::W_L..=Self::Z_PERM]
     }
 
-    pub(crate) fn w_l(&self) -> &T {
+    pub fn w_l(&self) -> &T {
         &self.elements[Self::W_L]
     }
 
-    pub(crate) fn w_r(&self) -> &T {
+    pub fn w_r(&self) -> &T {
         &self.elements[Self::W_R]
     }
 
-    pub(crate) fn w_o(&self) -> &T {
+    pub fn w_o(&self) -> &T {
         &self.elements[Self::W_O]
     }
 
-    pub(crate) fn w_4(&self) -> &T {
+    pub fn w_4(&self) -> &T {
         &self.elements[Self::W_4]
     }
 
-    pub(crate) fn z_perm(&self) -> &T {
+    pub fn z_perm(&self) -> &T {
         &self.elements[Self::Z_PERM]
     }
 
-    pub(crate) fn lookup_inverses(&self) -> &T {
+    pub fn lookup_inverses(&self) -> &T {
         &self.elements[Self::LOOKUP_INVERSES]
     }
 
-    pub(crate) fn lookup_read_counts(&self) -> &T {
+    pub fn lookup_read_counts(&self) -> &T {
         &self.elements[Self::LOOKUP_READ_COUNTS]
     }
 
-    pub(crate) fn lookup_read_tags(&self) -> &T {
+    pub fn lookup_read_tags(&self) -> &T {
         &self.elements[Self::LOOKUP_READ_TAGS]
     }
 
@@ -223,15 +223,15 @@ impl<T: Default> WitnessEntities<T> {
         &mut self.elements[Self::Z_PERM]
     }
 
-    pub(crate) fn lookup_inverses_mut(&mut self) -> &mut T {
+    pub fn lookup_inverses_mut(&mut self) -> &mut T {
         &mut self.elements[Self::LOOKUP_INVERSES]
     }
 
-    pub(crate) fn lookup_read_counts_mut(&mut self) -> &mut T {
+    pub fn lookup_read_counts_mut(&mut self) -> &mut T {
         &mut self.elements[Self::LOOKUP_READ_COUNTS]
     }
 
-    pub(crate) fn lookup_read_tags_mut(&mut self) -> &mut T {
+    pub fn lookup_read_tags_mut(&mut self) -> &mut T {
         &mut self.elements[Self::LOOKUP_READ_TAGS]
     }
 }

--- a/mpc-core/src/lut.rs
+++ b/mpc-core/src/lut.rs
@@ -18,7 +18,7 @@ pub trait LookupTableProvider<F: PrimeField> {
     /// Initializes a LUT from the provided secret values.
     fn init_private(&self, values: Vec<Self::SecretShare>) -> Self::LutType;
 
-    /// Initializes a LUT from the provided secret values.
+    /// Initializes a LUT from the provided public values.
     fn init_public(&self, values: Vec<F>) -> Self::LutType;
 
     /// Reads a value from the LUT associated with the provided index. As we work over secret-shared

--- a/mpc-core/src/protocols/rep3/yao.rs
+++ b/mpc-core/src/protocols/rep3/yao.rs
@@ -969,21 +969,21 @@ pub fn slice_arithmetic_many<F: PrimeField, N: Rep3Network>(
     )
 }
 
-/// Slices two vectors of field elements, does XOR on the slices and then rotates them. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+/// Slices two vectors of field elements, does XOR on the slices and then rotates them. The rotation is done on 64-bit values. Base_bit is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits per input.
 pub fn slice_xor_many<F: PrimeField, N: Rep3Network>(
     input1: &[Rep3PrimeFieldShare<F>],
     input2: &[Rep3PrimeFieldShare<F>],
     io_context: &mut IoContext<N>,
-    base: usize,
+    base_bit: usize,
     rotation: usize,
     total_output_bitlen_per_field: usize,
 ) -> IoResult<Vec<Rep3PrimeFieldShare<F>>> {
     let num_inputs = input1.len();
-    debug_assert_eq!(input1.len(), input2.len());
-    let num_decomps_per_field = total_output_bitlen_per_field.div_ceil(base);
+    debug_assert_eq!(num_inputs, input2.len());
+    let num_decomps_per_field = total_output_bitlen_per_field.div_ceil(base_bit);
     let total_output_elements = 3 * num_decomps_per_field * num_inputs;
 
-    let mut combined_inputs = Vec::with_capacity(input1.len() + input2.len());
+    let mut combined_inputs = Vec::with_capacity(num_inputs + input2.len());
     combined_inputs.extend_from_slice(input1);
     combined_inputs.extend_from_slice(input2);
 
@@ -992,24 +992,24 @@ pub fn slice_xor_many<F: PrimeField, N: Rep3Network>(
         io_context,
         total_output_elements,
         GarbledCircuits::slice_and_get_xor_rotate_values_from_key_many::<_, F>,
-        (base, rotation, total_output_bitlen_per_field)
+        (base_bit, rotation, total_output_bitlen_per_field)
     )
 }
 
-/// Slices two vectors of field elements, does AND on the slices and then rotates them. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+/// Slices two vectors of field elements, does AND on the slices and then rotates them. The rotation is done on 64-bit values. Base_bit is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits per input.
 pub fn slice_and_many<F: PrimeField, N: Rep3Network>(
     input1: &[Rep3PrimeFieldShare<F>],
     input2: &[Rep3PrimeFieldShare<F>],
     io_context: &mut IoContext<N>,
-    base: usize,
+    base_bit: usize,
     rotation: usize,
     total_output_bitlen_per_field: usize,
 ) -> IoResult<Vec<Rep3PrimeFieldShare<F>>> {
     let num_inputs = input1.len();
-    debug_assert_eq!(input1.len(), input2.len());
-    let num_decomps_per_field = total_output_bitlen_per_field.div_ceil(base);
+    debug_assert_eq!(num_inputs, input2.len());
+    let num_decomps_per_field = total_output_bitlen_per_field.div_ceil(base_bit);
     let total_output_elements = 3 * num_decomps_per_field * num_inputs;
-    let mut combined_inputs = Vec::with_capacity(input1.len() + input2.len());
+    let mut combined_inputs = Vec::with_capacity(num_inputs + input2.len());
     combined_inputs.extend_from_slice(input1);
     combined_inputs.extend_from_slice(input2);
 
@@ -1018,16 +1018,16 @@ pub fn slice_and_many<F: PrimeField, N: Rep3Network>(
         io_context,
         total_output_elements,
         GarbledCircuits::slice_and_get_and_rotate_values_from_key_many::<_, F>,
-        (base, rotation, total_output_bitlen_per_field)
+        (base_bit, rotation, total_output_bitlen_per_field)
     )
 }
 
-/// Slices two field elements, does AND on the slices and then rotates them. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+/// Slices two field elements, does AND on the slices and then rotates them. The rotation is done on 64-bit values. Base_bit is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits per input.
 pub fn slice_and<F: PrimeField, N: Rep3Network>(
     input1: Rep3PrimeFieldShare<F>,
     input2: Rep3PrimeFieldShare<F>,
     io_context: &mut IoContext<N>,
-    base: usize,
+    base_bit: usize,
     rotation: usize,
     total_output_bitlen_per_field: usize,
 ) -> IoResult<Vec<Rep3PrimeFieldShare<F>>> {
@@ -1035,18 +1035,18 @@ pub fn slice_and<F: PrimeField, N: Rep3Network>(
         &[input1],
         &[input2],
         io_context,
-        base,
+        base_bit,
         rotation,
         total_output_bitlen_per_field,
     )
 }
 
-/// Slices two field elements, does XOR on the slices and then rotates them. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+/// Slices two field elements, does XOR on the slices and then rotates them. The rotation is done on 64-bit values. Base_bit is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits per input.
 pub fn slice_xor<F: PrimeField, N: Rep3Network>(
     input1: Rep3PrimeFieldShare<F>,
     input2: Rep3PrimeFieldShare<F>,
     io_context: &mut IoContext<N>,
-    base: usize,
+    base_bit: usize,
     rotation: usize,
     total_output_bitlen_per_field: usize,
 ) -> IoResult<Vec<Rep3PrimeFieldShare<F>>> {
@@ -1054,7 +1054,7 @@ pub fn slice_xor<F: PrimeField, N: Rep3Network>(
         &[input1],
         &[input2],
         io_context,
-        base,
+        base_bit,
         rotation,
         total_output_bitlen_per_field,
     )

--- a/mpc-core/src/protocols/rep3/yao.rs
+++ b/mpc-core/src/protocols/rep3/yao.rs
@@ -968,3 +968,94 @@ pub fn slice_arithmetic_many<F: PrimeField, N: Rep3Network>(
         (msb, lsb, bitsize)
     )
 }
+
+/// Slices two vectors of field elements, does XOR on the slices and then rotates them. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+pub fn slice_xor_many<F: PrimeField, N: Rep3Network>(
+    input1: &[Rep3PrimeFieldShare<F>],
+    input2: &[Rep3PrimeFieldShare<F>],
+    io_context: &mut IoContext<N>,
+    base: usize,
+    rotation: usize,
+    total_output_bitlen_per_field: usize,
+) -> IoResult<Vec<Rep3PrimeFieldShare<F>>> {
+    let num_inputs = input1.len();
+    debug_assert_eq!(input1.len(), input2.len());
+    let num_decomps_per_field = total_output_bitlen_per_field.div_ceil(base);
+    let total_output_elements = 3 * num_decomps_per_field * num_inputs;
+
+    let mut combined_inputs = Vec::with_capacity(input1.len() + input2.len());
+    combined_inputs.extend_from_slice(input1);
+    combined_inputs.extend_from_slice(input2);
+
+    decompose_circuit_compose_blueprint!(
+        &combined_inputs,
+        io_context,
+        total_output_elements,
+        GarbledCircuits::slice_and_get_xor_rotate_values_from_key_many::<_, F>,
+        (base, rotation, total_output_bitlen_per_field)
+    )
+}
+
+/// Slices two vectors of field elements, does AND on the slices and then rotates them. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+pub fn slice_and_many<F: PrimeField, N: Rep3Network>(
+    input1: &[Rep3PrimeFieldShare<F>],
+    input2: &[Rep3PrimeFieldShare<F>],
+    io_context: &mut IoContext<N>,
+    base: usize,
+    rotation: usize,
+    total_output_bitlen_per_field: usize,
+) -> IoResult<Vec<Rep3PrimeFieldShare<F>>> {
+    let num_inputs = input1.len();
+    debug_assert_eq!(input1.len(), input2.len());
+    let num_decomps_per_field = total_output_bitlen_per_field.div_ceil(base);
+    let total_output_elements = 3 * num_decomps_per_field * num_inputs;
+    let mut combined_inputs = Vec::with_capacity(input1.len() + input2.len());
+    combined_inputs.extend_from_slice(input1);
+    combined_inputs.extend_from_slice(input2);
+
+    decompose_circuit_compose_blueprint!(
+        &combined_inputs,
+        io_context,
+        total_output_elements,
+        GarbledCircuits::slice_and_get_and_rotate_values_from_key_many::<_, F>,
+        (base, rotation, total_output_bitlen_per_field)
+    )
+}
+
+/// Slices two field elements, does AND on the slices and then rotates them. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+pub fn slice_and<F: PrimeField, N: Rep3Network>(
+    input1: Rep3PrimeFieldShare<F>,
+    input2: Rep3PrimeFieldShare<F>,
+    io_context: &mut IoContext<N>,
+    base: usize,
+    rotation: usize,
+    total_output_bitlen_per_field: usize,
+) -> IoResult<Vec<Rep3PrimeFieldShare<F>>> {
+    slice_and_many(
+        &[input1],
+        &[input2],
+        io_context,
+        base,
+        rotation,
+        total_output_bitlen_per_field,
+    )
+}
+
+/// Slices two field elements, does XOR on the slices and then rotates them. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+pub fn slice_xor<F: PrimeField, N: Rep3Network>(
+    input1: Rep3PrimeFieldShare<F>,
+    input2: Rep3PrimeFieldShare<F>,
+    io_context: &mut IoContext<N>,
+    base: usize,
+    rotation: usize,
+    total_output_bitlen_per_field: usize,
+) -> IoResult<Vec<Rep3PrimeFieldShare<F>>> {
+    slice_xor_many(
+        &[input1],
+        &[input2],
+        io_context,
+        base,
+        rotation,
+        total_output_bitlen_per_field,
+    )
+}

--- a/mpc-core/src/protocols/rep3/yao/circuits.rs
+++ b/mpc-core/src/protocols/rep3/yao/circuits.rs
@@ -125,6 +125,16 @@ impl GarbledCircuits {
         Ok(c)
     }
 
+    /// Returns a constant bundle of 0s and 1s
+    fn bin_constant_bundle<G: FancyBinary + FancyBinaryConstant>(
+        g: &mut G,
+        xs: &[bool],
+    ) -> Result<Vec<G::Item>, G::Error> {
+        xs.iter()
+            .map(|&x| if x { g.const_one() } else { g.const_zero() })
+            .collect::<Result<Vec<G::Item>, G::Error>>()
+    }
+
     /// Binary addition. Returns the result and the carry.
     #[expect(clippy::type_complexity)]
     fn bin_addition<G: FancyBinary>(
@@ -448,7 +458,7 @@ impl GarbledCircuits {
             .collect::<Result<Vec<G::Item>, G::Error>>()
     }
 
-    /// subtracts p from wires (with carry) and returns the result and the overflow bit
+    /// Subtracts p from wires (with carry) and returns the result and the overflow bit.
     #[expect(clippy::type_complexity)]
     fn sub_p<G: FancyBinary, F: PrimeField>(
         g: &mut G,
@@ -524,7 +534,7 @@ impl GarbledCircuits {
         Ok(result)
     }
 
-    /// Adds two shared field elements mod p. The field elements are encoded as Yao shared wires
+    /// Adds two shared field elements mod p. The field elements are encoded as Yao shared wires.
     pub fn adder_mod_p<G: FancyBinary, F: PrimeField>(
         g: &mut G,
         wires_a: &BinaryBundle<G::Item>,
@@ -541,7 +551,7 @@ impl GarbledCircuits {
         Ok(BinaryBundle::new(res))
     }
 
-    /// Adds two shared ring elements mod 2^k. The ring elements are encoded as Yao shared wires
+    /// Adds two shared ring elements mod 2^k. The ring elements are encoded as Yao shared wires.
     pub fn adder_mod_2k<G: FancyBinary>(
         g: &mut G,
         wires_a: &BinaryBundle<G::Item>,
@@ -1189,7 +1199,7 @@ impl GarbledCircuits {
         Ok(BinaryBundle::new(results))
     }
 
-    /// Divides a ring element by a power of 2. The ring element is represented as two bitdecompositions wires_a, wires_b which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as wires_a and wires_b
+    /// Divides a ring element by a power of 2. The ring element is represented as two bitdecompositions wires_a, wires_b which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as wires_a and wires_b.
     fn ring_div_power_2<G: FancyBinary>(
         g: &mut G,
         wires_a: &[G::Item],
@@ -1236,7 +1246,7 @@ impl GarbledCircuits {
         Ok(added)
     }
 
-    /// Divides a field element by a power of 2. The field element is represented as two bitdecompositions wires_a, wires_b which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as wires_a and wires_b
+    /// Divides a field element by a power of 2. The field element is represented as two bitdecompositions wires_a, wires_b which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as wires_a and wires_b.
     fn field_int_div_power_2<G: FancyBinary, F: PrimeField>(
         g: &mut G,
         wires_a: &[G::Item],
@@ -1270,7 +1280,7 @@ impl GarbledCircuits {
         Ok(result)
     }
 
-    /// Divides a ring element by another. The ring elements are represented as bitdecompositions x1s, x2s, y1s and y2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires
+    /// Divides a ring element by another. The ring elements are represented as bitdecompositions x1s, x2s, y1s and y2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires.
     fn ring_div<G: FancyBinary + FancyBinaryConstant>(
         g: &mut G,
         x1s: &[G::Item],
@@ -1307,7 +1317,7 @@ impl GarbledCircuits {
         Ok(added)
     }
 
-    /// Divides a ring element by another public ring element. The ring element is represented as bitdecompositions x1s and x2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires
+    /// Divides a ring element by another public ring element. The ring element is represented as bitdecompositions x1s and x2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires.
     fn ring_div_by_public<G: FancyBinary + FancyBinaryConstant>(
         g: &mut G,
         x1s: &[G::Item],
@@ -1342,7 +1352,7 @@ impl GarbledCircuits {
         Ok(added)
     }
 
-    /// Divides a public ring element by another shared ring element. The ring element is represented as bitdecompositions x1s and x2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires
+    /// Divides a public ring element by another shared ring element. The ring element is represented as bitdecompositions x1s and x2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires.
     fn ring_div_by_shared<G: FancyBinary + FancyBinaryConstant>(
         g: &mut G,
         x1s: &[G::Item],
@@ -1377,7 +1387,7 @@ impl GarbledCircuits {
         Ok(added)
     }
 
-    /// Divides a field element by another. The field elements are represented as bitdecompositions x1s, x2s, y1s and y2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires
+    /// Divides a field element by another. The field elements are represented as bitdecompositions x1s, x2s, y1s and y2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires.
     fn field_int_div<G: FancyBinary + FancyBinaryConstant, F: PrimeField>(
         g: &mut G,
         x1s: &[G::Item],
@@ -1407,7 +1417,7 @@ impl GarbledCircuits {
         Ok(result)
     }
 
-    /// Divides a field element by another public field element. The field elements is represented as bitdecompositions x1s and x2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires
+    /// Divides a field element by another public field element. The field elements is represented as bitdecompositions x1s and x2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires.
     fn field_int_div_by_public<G: FancyBinary + FancyBinaryConstant, F: PrimeField>(
         g: &mut G,
         x1s: &[G::Item],
@@ -1433,7 +1443,7 @@ impl GarbledCircuits {
         Ok(result)
     }
 
-    /// Divides a public field element by another shared field element. The field elements is represented as bitdecompositions x1s and x2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires
+    /// Divides a public field element by another shared field element. The field elements is represented as bitdecompositions x1s and x2s which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as the input wires.
     fn field_int_div_by_shared<G: FancyBinary + FancyBinaryConstant, F: PrimeField>(
         g: &mut G,
         x1s: &[G::Item],
@@ -1459,7 +1469,7 @@ impl GarbledCircuits {
         Ok(result)
     }
 
-    /// Divides a ring element by a power of 2. The ring element is represented as two bitdecompositions wires_a, wires_b which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as wires_a and wires_b
+    /// Divides a ring element by a power of 2. The ring element is represented as two bitdecompositions wires_a, wires_b which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as wires_a and wires_b.
     pub(crate) fn ring_div_power_2_many<G: FancyBinary>(
         g: &mut G,
         wires_a: &BinaryBundle<G::Item>,
@@ -1497,7 +1507,7 @@ impl GarbledCircuits {
         Ok(BinaryBundle::new(results))
     }
 
-    /// Divides a field element by a power of 2. The field element is represented as two bitdecompositions wires_a, wires_b which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as wires_a and wires_b
+    /// Divides a field element by a power of 2. The field element is represented as two bitdecompositions wires_a, wires_b which need to be added first. The output is composed using wires_c, whereas wires_c are the same size as wires_a and wires_b.
     pub(crate) fn field_int_div_power_2_many<G: FancyBinary, F: PrimeField>(
         g: &mut G,
         wires_a: &BinaryBundle<G::Item>,
@@ -1572,7 +1582,7 @@ impl GarbledCircuits {
         Ok(BinaryBundle::new(results))
     }
 
-    /// Binary division for two vecs of inputs. The ring elements are represented as two bitdecompositions wires_a, wires_b which need to be split first to get the two inputs. The output is composed using wires_c, whereas wires_c is half the size as wires_a and wires_b
+    /// Binary division for two vecs of inputs. The ring elements are represented as two bitdecompositions wires_a, wires_b which need to be split first to get the two inputs. The output is composed using wires_c, whereas wires_c is half the size as wires_a and wires_b.
     pub fn ring_div_by_public_many<G: FancyBinary + FancyBinaryConstant>(
         g: &mut G,
         wires_x1: &BinaryBundle<G::Item>,
@@ -1608,7 +1618,7 @@ impl GarbledCircuits {
         Ok(BinaryBundle::new(results))
     }
 
-    /// Binary division for two vecs of inputs. The ring elements are represented as two bitdecompositions wires_a, wires_b which need to be split first to get the two inputs. The output is composed using wires_c, whereas wires_c is half the size as wires_a and wires_b
+    /// Binary division for two vecs of inputs. The ring elements are represented as two bitdecompositions wires_a, wires_b which need to be split first to get the two inputs. The output is composed using wires_c, whereas wires_c is half the size as wires_a and wires_b.
     pub fn ring_div_by_shared_many<G: FancyBinary + FancyBinaryConstant>(
         g: &mut G,
         wires_x1: &BinaryBundle<G::Item>,
@@ -1644,7 +1654,7 @@ impl GarbledCircuits {
         Ok(BinaryBundle::new(results))
     }
 
-    /// Divides a field element by another. The field elements are represented as two bitdecompositions wires_a, wires_b which need to be split first to get the two inputs. The output is composed using wires_c, whereas wires_c is half the size as wires_a and wires_b
+    /// Divides a field element by another. The field elements are represented as two bitdecompositions wires_a, wires_b which need to be split first to get the two inputs. The output is composed using wires_c, whereas wires_c is half the size as wires_a and wires_b.
     pub(crate) fn field_int_div_many<G: FancyBinary + FancyBinaryConstant, F: PrimeField>(
         g: &mut G,
         wires_x1: &BinaryBundle<G::Item>,
@@ -1683,7 +1693,7 @@ impl GarbledCircuits {
         Ok(BinaryBundle::new(results))
     }
 
-    /// Divides a field element by another public. The field elements are represented as two bitdecompositions wires_a, wires_b which need to be split first to get the two inputs. The output is composed using wires_c, whereas wires_c is half the size as wires_a and wires_b
+    /// Divides a field element by another public. The field elements are represented as two bitdecompositions wires_a, wires_b which need to be split first to get the two inputs. The output is composed using wires_c, whereas wires_c is half the size as wires_a and wires_b.
     pub(crate) fn field_int_div_by_public_many<
         G: FancyBinary + FancyBinaryConstant,
         F: PrimeField,
@@ -1725,7 +1735,7 @@ impl GarbledCircuits {
         Ok(BinaryBundle::new(results))
     }
 
-    /// Divides a public field element by another shared. The field elements are represented as two bitdecompositions wires_a, wires_b which need to be split first to get the two inputs. The output is composed using wires_c, whereas wires_c is half the size as wires_a and wires_b
+    /// Divides public field elements by another shared. The field elements are represented as two bitdecompositions wires_a, wires_b which need to be split first to get the two inputs. The output is composed using wires_c, whereas wires_c is half the size as wires_a and wires_b.
     pub(crate) fn field_int_div_by_shared_many<
         G: FancyBinary + FancyBinaryConstant,
         F: PrimeField,
@@ -1734,7 +1744,7 @@ impl GarbledCircuits {
         wires_x1: &BinaryBundle<G::Item>,
         wires_x2: &BinaryBundle<G::Item>,
         wires_c: &BinaryBundle<G::Item>,
-        divisor: Vec<bool>,
+        dividend: Vec<bool>,
     ) -> Result<BinaryBundle<G::Item>, G::Error>
     where
         G::Item: Default,
@@ -1746,13 +1756,13 @@ impl GarbledCircuits {
 
         debug_assert_eq!(length % input_bitlen, 0);
         debug_assert_eq!(wires_c.size(), length);
-        debug_assert_eq!(divisor.len(), length);
+        debug_assert_eq!(dividend.len(), length);
         let mut results = Vec::with_capacity(wires_c.size());
 
         for (chunk_x1, chunk_x2, div, chunk_c) in izip!(
             wires_x1.wires().chunks(input_bitlen),
             wires_x2.wires().chunks(input_bitlen),
-            divisor.chunks(input_bitlen),
+            dividend.chunks(input_bitlen),
             wires_c.wires().chunks(input_bitlen),
         ) {
             results.extend(Self::field_int_div_by_shared::<G, F>(
@@ -1765,6 +1775,256 @@ impl GarbledCircuits {
             )?);
         }
         Ok(BinaryBundle::new(results))
+    }
+
+    /// Slices field elements in chunks, then XORs the slices and rotates them, a specific circuit for the plookup accumulator in the builder. The field elements are represented as two bitdecompositions wires_x1, wires_x2 which need to be split first to get the two inputs. The output is composed using wires_c. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+    pub(crate) fn slice_and_get_xor_rotate_values_from_key_many<
+        G: FancyBinary + FancyBinaryConstant,
+        F: PrimeField,
+    >(
+        g: &mut G,
+        wires_x1: &BinaryBundle<G::Item>,
+        wires_x2: &BinaryBundle<G::Item>,
+        wires_c: &BinaryBundle<G::Item>,
+        base: usize,
+        rotation: usize,
+        total_output_bitlen_per_field: usize,
+    ) -> Result<BinaryBundle<G::Item>, G::Error> {
+        let input_bitlen = F::MODULUS_BIT_SIZE as usize;
+        debug_assert_eq!(wires_x1.size(), wires_x2.size());
+        let length = wires_x1.size();
+        debug_assert_eq!(length % 2, 0);
+        let num_decomps_per_field = total_output_bitlen_per_field.div_ceil(base);
+        let num_inputs = (length / 2) / input_bitlen;
+
+        let total_output_elements = 3 * num_decomps_per_field * num_inputs;
+        debug_assert_eq!(wires_c.size(), total_output_elements * input_bitlen);
+        debug_assert_eq!((length / 2) % input_bitlen, 0);
+
+        let mut results = Vec::with_capacity(wires_c.size() / 3);
+
+        for (chunk_x1, chunk_x2, chunk_y1, chunk_y2, chunk_c) in izip!(
+            wires_x1.wires()[0..length / 2].chunks(input_bitlen),
+            wires_x2.wires()[0..length / 2].chunks(input_bitlen),
+            wires_x1.wires()[length / 2..].chunks(input_bitlen),
+            wires_x2.wires()[length / 2..].chunks(input_bitlen),
+            wires_c
+                .wires()
+                .chunks(3 * input_bitlen * num_decomps_per_field),
+        ) {
+            let value = Self::slice_and_get_xor_rotate_values_from_key::<G, F>(
+                g,
+                chunk_x1,
+                chunk_x2,
+                chunk_y1,
+                chunk_y2,
+                chunk_c,
+                base,
+                rotation,
+                total_output_bitlen_per_field,
+            )?;
+
+            results.extend(value);
+        }
+        Ok(BinaryBundle::new(results))
+    }
+
+    /// Slices field elements in chunks, then ANDs the slices and rotates them, a specific circuit for the plookup accumulator in the builder. The field elements are represented as two bitdecompositions wires_x1, wires_x2 which need to be split first to get the two sets of inputs. The output is composed using wires_c. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+    pub(crate) fn slice_and_get_and_rotate_values_from_key_many<
+        G: FancyBinary + FancyBinaryConstant,
+        F: PrimeField,
+    >(
+        g: &mut G,
+        wires_x1: &BinaryBundle<G::Item>,
+        wires_x2: &BinaryBundle<G::Item>,
+        wires_c: &BinaryBundle<G::Item>,
+        base: usize,
+        rotation: usize,
+        total_output_bitlen_per_field: usize,
+    ) -> Result<BinaryBundle<G::Item>, G::Error> {
+        let input_bitlen = F::MODULUS_BIT_SIZE as usize;
+        debug_assert_eq!(wires_x1.size(), wires_x2.size());
+        let length = wires_x1.size();
+        debug_assert_eq!(length % 2, 0);
+        let num_decomps_per_field = total_output_bitlen_per_field.div_ceil(base);
+        let num_inputs = (length / 2) / input_bitlen;
+
+        let total_output_elements = 3 * num_decomps_per_field * num_inputs;
+        debug_assert_eq!(wires_c.size(), total_output_elements * input_bitlen);
+        debug_assert_eq!((length / 2) % input_bitlen, 0);
+
+        let mut results = Vec::with_capacity(wires_c.size() / 3);
+
+        for (chunk_x1, chunk_x2, chunk_y1, chunk_y2, chunk_c) in izip!(
+            wires_x1.wires()[0..length / 2].chunks(input_bitlen),
+            wires_x2.wires()[0..length / 2].chunks(input_bitlen),
+            wires_x1.wires()[length / 2..].chunks(input_bitlen),
+            wires_x2.wires()[length / 2..].chunks(input_bitlen),
+            wires_c
+                .wires()
+                .chunks(3 * input_bitlen * num_decomps_per_field),
+        ) {
+            let value = Self::slice_and_get_and_rotate_values_from_key::<G, F>(
+                g,
+                chunk_x1,
+                chunk_x2,
+                chunk_y1,
+                chunk_y2,
+                chunk_c,
+                base,
+                rotation,
+                total_output_bitlen_per_field,
+            )?;
+            results.extend(value);
+        }
+
+        Ok(BinaryBundle::new(results))
+    }
+
+    /// Slice two field elements in chunks, then XORs the slices and rotates them, a specific circuit for the plookup accumulator in the builder. The field elements are represented as bitdecompositions x1s, x2s, y1s and y2s which need to be added first get the two sets of inputs. The output is composed using wires_c. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+    #[expect(clippy::too_many_arguments)]
+    pub(crate) fn slice_and_get_xor_rotate_values_from_key<
+        G: FancyBinary + FancyBinaryConstant,
+        F: PrimeField,
+    >(
+        g: &mut G,
+        x1s: &[G::Item],
+        x2s: &[G::Item],
+        y1s: &[G::Item],
+        y2s: &[G::Item],
+        wires_c: &[G::Item],
+        base: usize,
+        rotation: usize,
+        total_output_bitlen_per_field: usize,
+    ) -> Result<Vec<G::Item>, G::Error> {
+        let input_bitlen = x1s.len();
+        let length_c = wires_c.len();
+        let input_bits_1 =
+            Self::adder_mod_p_with_output_size::<_, F>(g, x1s, x2s, total_output_bitlen_per_field)?;
+
+        let input_bits_2 =
+            Self::adder_mod_p_with_output_size::<_, F>(g, y1s, y2s, total_output_bitlen_per_field)?;
+        let mut results = Vec::with_capacity(length_c / 3);
+        let mut rands = wires_c.chunks(input_bitlen);
+
+        let res: Vec<G::Item> = input_bits_1
+            .iter()
+            .zip(input_bits_2.iter())
+            .map(|(x, y)| g.xor(x, y))
+            .collect::<Result<Vec<_>, _>>()?;
+        let const_zeros =
+            Self::bin_constant_bundle(g, &vec![false; total_output_bitlen_per_field - base])?;
+        let mut padded_res_chunks = Vec::new();
+
+        for inp in res.chunks(base) {
+            padded_res_chunks.extend_from_slice(inp);
+            padded_res_chunks.extend_from_slice(&const_zeros);
+            if inp.len() != base {
+                let additional_padding =
+                    Self::bin_constant_bundle(g, &vec![false; base - inp.len()])?;
+                padded_res_chunks.extend_from_slice(&additional_padding);
+            }
+        }
+
+        for inp_1 in input_bits_1.chunks(base) {
+            results.extend(Self::compose_field_element::<_, F>(
+                g,
+                inp_1,
+                rands.next().unwrap(),
+            )?);
+        }
+        for inp_2 in input_bits_2.chunks(base) {
+            results.extend(Self::compose_field_element::<_, F>(
+                g,
+                inp_2,
+                rands.next().unwrap(),
+            )?);
+        }
+        for xs in padded_res_chunks.chunks_mut(total_output_bitlen_per_field) {
+            xs.reverse();
+
+            xs.rotate_right(rotation);
+            xs.reverse();
+            results.extend(Self::compose_field_element::<_, F>(
+                g,
+                xs,
+                rands.next().unwrap(),
+            )?);
+        }
+        Ok(results)
+    }
+
+    /// Slice two field elements in chunks, then ANDs the slices and rotates them, a specific circuit for the plookup accumulator in the builder. The field elements are represented as bitdecompositions x1s, x2s, y1s and y2s which need to be added first get the two inputs. The output is composed using wires_c. Base is the size of the slice, rotation the the length of the rotation and total_output_bitlen_per_field is the amount of bits the output field elements have.
+    #[expect(clippy::too_many_arguments)]
+    pub(crate) fn slice_and_get_and_rotate_values_from_key<
+        G: FancyBinary + FancyBinaryConstant,
+        F: PrimeField,
+    >(
+        g: &mut G,
+        x1s: &[G::Item],
+        x2s: &[G::Item],
+        y1s: &[G::Item],
+        y2s: &[G::Item],
+        wires_c: &[G::Item],
+        base: usize,
+        rotation: usize,
+        total_output_bitlen_per_field: usize,
+    ) -> Result<Vec<G::Item>, G::Error> {
+        let input_bitlen = x1s.len();
+        let length_c = wires_c.len();
+        let input_bits_1 =
+            Self::adder_mod_p_with_output_size::<_, F>(g, x1s, x2s, total_output_bitlen_per_field)?;
+
+        let input_bits_2 =
+            Self::adder_mod_p_with_output_size::<_, F>(g, y1s, y2s, total_output_bitlen_per_field)?;
+        let mut results = Vec::with_capacity(length_c / 3);
+        let mut rands = wires_c.chunks(input_bitlen);
+
+        let res = input_bits_1
+            .iter()
+            .zip(input_bits_2.iter())
+            .map(|(x, y)| g.and(x, y))
+            .collect::<Result<Vec<_>, _>>()?;
+        let const_zeros =
+            Self::bin_constant_bundle(g, &vec![false; total_output_bitlen_per_field - base])?;
+        let mut padded_res_chunks = Vec::new();
+
+        for inp in res.chunks(base) {
+            padded_res_chunks.extend_from_slice(inp);
+            padded_res_chunks.extend_from_slice(&const_zeros);
+            if inp.len() != base {
+                let additional_padding =
+                    Self::bin_constant_bundle(g, &vec![false; base - inp.len()])?;
+                padded_res_chunks.extend_from_slice(&additional_padding);
+            }
+        }
+
+        for inp_1 in input_bits_1.chunks(base) {
+            results.extend(Self::compose_field_element::<_, F>(
+                g,
+                inp_1,
+                rands.next().unwrap(),
+            )?);
+        }
+        for inp_2 in input_bits_2.chunks(base) {
+            results.extend(Self::compose_field_element::<_, F>(
+                g,
+                inp_2,
+                rands.next().unwrap(),
+            )?);
+        }
+        for xs in padded_res_chunks.chunks_mut(total_output_bitlen_per_field) {
+            xs.reverse();
+
+            xs.rotate_right(rotation);
+            xs.reverse();
+            results.extend(Self::compose_field_element::<_, F>(
+                g,
+                xs,
+                rands.next().unwrap(),
+            )?);
+        }
+        Ok(results)
     }
 }
 

--- a/mpc-core/src/protocols/rep3_ring/gadgets/ohv.rs
+++ b/mpc-core/src/protocols/rep3_ring/gadgets/ohv.rs
@@ -42,7 +42,10 @@ where
     Ok((bits, e))
 }
 
-pub(crate) fn ohv<T: IntRing2k, N: Rep3Network>(
+/// Generates a one-hot-encoded vector of size k bits from a given secret shared index which is already decomposed into shared bits.
+/// The output is (r, e), where r is a binary sharing of the index of the set bit, wheras e is a vector of size 2^k with all bits zero except at index r.
+/// The algorithm is a rewrite of Protocol 5 from [https://eprint.iacr.org/2024/1317.pdf](https://eprint.iacr.org/2024/1317.pdf) for rep3.
+pub fn ohv<T: IntRing2k, N: Rep3Network>(
     k: usize,
     mut bits: Rep3RingShare<T>,
     io_context: &mut IoContext<N>,

--- a/mpc-core/src/protocols/rep3_ring/lut.rs
+++ b/mpc-core/src/protocols/rep3_ring/lut.rs
@@ -158,14 +158,16 @@ impl<N: Rep3Network> Rep3LookupTable<N> {
             len.next_power_of_two().ilog2()
         } as usize;
 
-        let e = match k {
-            1 => Self::ohv_from_index_internal::<Bit, _>(bits, k, network0, network1)?,
-            2 | 4 | 8 => Self::ohv_from_index_internal::<u8, _>(bits, k, network0, network1)?,
-            16 => Self::ohv_from_index_internal::<u16, _>(bits, k, network0, network1)?,
-            32 => Self::ohv_from_index_internal::<u32, _>(bits, k, network0, network1)?,
-            64 => Self::ohv_from_index_internal::<u64, _>(bits, k, network0, network1)?,
-            128 => Self::ohv_from_index_internal::<u128, _>(bits, k, network0, network1)?,
-            _ => panic!("Table is too large"),
+        let e = if k == 1 {
+            Self::ohv_from_index_internal::<Bit, _>(bits, k, network0, network1)?
+        } else if k <= 8 {
+            Self::ohv_from_index_internal::<u8, _>(bits, k, network0, network1)?
+        } else if k <= 16 {
+            Self::ohv_from_index_internal::<u16, _>(bits, k, network0, network1)?
+        } else if k <= 32 {
+            Self::ohv_from_index_internal::<u32, _>(bits, k, network0, network1)?
+        } else {
+            panic!("Table is too large")
         };
 
         conversion::bit_inject_from_bits_to_field_many::<F, _>(&e, network0)

--- a/tests/tests/mpc/rep3.rs
+++ b/tests/tests/mpc/rep3.rs
@@ -1296,7 +1296,7 @@ mod field_share {
     #[test]
     fn rep3_decompose_shared_field_many_via_yao() {
         const VEC_SIZE: usize = 10;
-        const TOTAL_BIT_SIZE: usize = 32;
+        const TOTAL_BIT_SIZE: usize = 64;
         const CHUNK_SIZE: usize = 14;
 
         let test_network = Rep3TestNetwork::default();
@@ -1410,57 +1410,48 @@ mod field_share {
     #[test]
     fn rep3_slice_and_and_rotated() {
         const VEC_SIZE: usize = 10;
-        const TOTAL_BIT_SIZE: usize = 64; //note there is some stuff hardcoded to u64 in this test case
+        const TOTAL_BIT_SIZE: usize = 32;
+        const ROTATION: usize = 2;
+        const BASE_BIT: usize = 6;
+        const BASE: usize = 1 << BASE_BIT;
+        const NUM_DECOMPS: usize = TOTAL_BIT_SIZE.div_ceil(BASE_BIT);
 
         let test_network = Rep3TestNetwork::default();
         let mut rng = thread_rng();
         let mask: BigUint = (BigUint::one() << TOTAL_BIT_SIZE) - BigUint::one();
         let x = (0..VEC_SIZE)
             .map(|_| {
-                let mut res = BigUint::from(ark_bn254::Fr::rand(&mut rng));
-                res &= &mask;
+                let res = BigUint::from(ark_bn254::Fr::rand(&mut rng)) & &mask;
                 ark_bn254::Fr::from(res)
             })
             .collect_vec();
-
         let x_shares = rep3::share_field_elements(&x, &mut rng);
+
         let y = (0..VEC_SIZE)
             .map(|_| {
-                let mut res = BigUint::from(ark_bn254::Fr::rand(&mut rng));
-                res &= &mask;
+                let res = BigUint::from(ark_bn254::Fr::rand(&mut rng)) & &mask;
                 ark_bn254::Fr::from(res)
             })
             .collect_vec();
         let y_shares = rep3::share_field_elements(&y, &mut rng);
-        let rotation = 2;
-        let base = 6;
-        let div: usize = 1 << base;
+
         let mut should_result = Vec::new();
         for (x, y) in x.into_iter().zip(y.into_iter()) {
             let mut x: BigUint = x.into();
             let mut y: BigUint = y.into();
-            let mut xs = Vec::new();
-            let mut ys = Vec::new();
-            let mut rs = Vec::new();
+            let mut xs = Vec::with_capacity(NUM_DECOMPS);
+            let mut ys = Vec::with_capacity(NUM_DECOMPS);
+            let mut rs = Vec::with_capacity(NUM_DECOMPS);
 
-            for _ in 0..TOTAL_BIT_SIZE.div_ceil(base) {
-                let res1 = &x % div;
+            for _ in 0..NUM_DECOMPS {
+                let res1 = &x % BASE;
                 xs.push(ark_bn254::Fr::from(res1.clone()));
-                x /= div;
-                let res2 = &y % div;
+                x /= BASE;
+                let res2 = &y % BASE;
                 ys.push(ark_bn254::Fr::from(res2.clone()));
-                y /= div;
-                let res = res1 & res2;
-                let res: u64 = if res == BigUint::zero() {
-                    0_u64
-                } else {
-                    res.to_u64_digits()[0]
-                };
-                let rotated = if rotation != 0 {
-                    (res >> rotation as u64) | (res << (64 - rotation) as u64)
-                } else {
-                    res
-                };
+                y /= BASE;
+                let res = u64::try_from(res1 & res2).unwrap();
+                let rotated = res.rotate_right(ROTATION as u32);
                 rs.push(ark_bn254::Fr::from(rotated));
             }
             should_result.extend(xs);
@@ -1482,7 +1473,8 @@ mod field_share {
                 let mut rep3 = IoContext::init(net).unwrap();
 
                 let decomposed =
-                    yao::slice_and_many(&x, &y, &mut rep3, base, rotation, TOTAL_BIT_SIZE).unwrap();
+                    yao::slice_and_many(&x, &y, &mut rep3, BASE_BIT, ROTATION, TOTAL_BIT_SIZE)
+                        .unwrap();
                 tx.send(decomposed)
             });
         }
@@ -1496,57 +1488,48 @@ mod field_share {
     #[test]
     fn rep3_slice_and_xor_rotated() {
         const VEC_SIZE: usize = 10;
-        const TOTAL_BIT_SIZE: usize = 64;
+        const TOTAL_BIT_SIZE: usize = 32;
+        const ROTATION: usize = 2;
+        const BASE_BIT: usize = 6;
+        const BASE: usize = 1 << BASE_BIT;
+        const NUM_DECOMPS: usize = TOTAL_BIT_SIZE.div_ceil(BASE_BIT);
 
         let test_network = Rep3TestNetwork::default();
         let mut rng = thread_rng();
         let mask: BigUint = (BigUint::one() << TOTAL_BIT_SIZE) - BigUint::one();
         let x = (0..VEC_SIZE)
             .map(|_| {
-                let mut res = BigUint::from(ark_bn254::Fr::rand(&mut rng));
-                res &= &mask;
+                let res = BigUint::from(ark_bn254::Fr::rand(&mut rng)) & &mask;
                 ark_bn254::Fr::from(res)
             })
             .collect_vec();
-
         let x_shares = rep3::share_field_elements(&x, &mut rng);
+
         let y = (0..VEC_SIZE)
             .map(|_| {
-                let mut res = BigUint::from(ark_bn254::Fr::rand(&mut rng));
-                res &= &mask;
+                let res = BigUint::from(ark_bn254::Fr::rand(&mut rng)) & &mask;
                 ark_bn254::Fr::from(res)
             })
             .collect_vec();
         let y_shares = rep3::share_field_elements(&y, &mut rng);
-        let rotation = 2;
-        let base = 6;
-        let div: usize = 1 << base;
+
         let mut should_result = Vec::new();
         for (x, y) in x.into_iter().zip(y.into_iter()) {
             let mut x: BigUint = x.into();
             let mut y: BigUint = y.into();
-            let mut xs = Vec::new();
-            let mut ys = Vec::new();
-            let mut rs = Vec::new();
+            let mut xs = Vec::with_capacity(NUM_DECOMPS);
+            let mut ys = Vec::with_capacity(NUM_DECOMPS);
+            let mut rs = Vec::with_capacity(NUM_DECOMPS);
 
-            for _ in 0..TOTAL_BIT_SIZE.div_ceil(base) {
-                let res1 = &x % div;
+            for _ in 0..NUM_DECOMPS {
+                let res1 = &x % BASE;
                 xs.push(ark_bn254::Fr::from(res1.clone()));
-                x /= div;
-                let res2 = &y % div;
+                x /= BASE;
+                let res2 = &y % BASE;
                 ys.push(ark_bn254::Fr::from(res2.clone()));
-                y /= div;
-                let res = res1 ^ res2;
-                let res: u64 = if res == BigUint::zero() {
-                    0_u64
-                } else {
-                    res.to_u64_digits()[0]
-                };
-                let rotated = if rotation != 0 {
-                    (res >> rotation as u64) | (res << (64 - rotation) as u64)
-                } else {
-                    res
-                };
+                y /= BASE;
+                let res = u64::try_from(res1 ^ res2).unwrap();
+                let rotated = res.rotate_right(ROTATION as u32);
                 rs.push(ark_bn254::Fr::from(rotated));
             }
             should_result.extend(xs);
@@ -1568,16 +1551,15 @@ mod field_share {
                 let mut rep3 = IoContext::init(net).unwrap();
 
                 let decomposed =
-                    yao::slice_xor_many(&x, &y, &mut rep3, base, rotation, TOTAL_BIT_SIZE).unwrap();
+                    yao::slice_xor_many(&x, &y, &mut rep3, BASE_BIT, ROTATION, TOTAL_BIT_SIZE)
+                        .unwrap();
                 tx.send(decomposed)
             });
         }
-
         let result1 = rx1.recv().unwrap();
         let result2 = rx2.recv().unwrap();
         let result3 = rx3.recv().unwrap();
         let is_result = rep3::combine_field_elements(&result1, &result2, &result3);
-
         assert_eq!(is_result, should_result);
     }
 


### PR DESCRIPTION
- Rewrites the proving key to have the lookup_read_counts_and_tags polynomials to be shared always as well. Consequently, prover performance became worse
- Includes code from the branches feat/mpc_lookup and feat/ultrahonk_priv_look as well
- Include the code for PR #307 