### PR TITLE
dk/fix/merkle parallelization

### DIFF
--- a/mpc-core/src/gadgets/merkle_tree/shamir.rs
+++ b/mpc-core/src/gadgets/merkle_tree/shamir.rs
@@ -34,14 +34,12 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         while len > 1 {
             debug_assert_eq!(len % ARITY, 0);
             len /= ARITY;
-            for inp in input.chunks_exact_mut(T).take(len) {
-                // Sponge mode
-                self.shamir_permutation_in_place_with_precomputation_packed(
-                    inp,
-                    &mut precomp,
-                    driver,
-                )?;
-            }
+            // Sponge mode
+            self.shamir_permutation_in_place_with_precomputation_packed(
+                &mut input[..T * len],
+                &mut precomp,
+                driver,
+            )?;
             // Only take first element as output and pad with 0 for sponge
             for i in 0..len / ARITY {
                 for j in 0..ARITY {
@@ -90,15 +88,16 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         while len > 1 {
             debug_assert_eq!(len % ARITY, 0);
             len /= ARITY;
-            for inp in input.chunks_exact_mut(T).take(len) {
-                // Compression mode
-                let feed_forward = inp[0];
-                self.shamir_permutation_in_place_with_precomputation_packed(
-                    inp,
-                    &mut precomp,
-                    driver,
-                )?;
-                inp[0] += feed_forward;
+            let ff = input.clone();
+            // Compression mode
+            self.shamir_permutation_in_place_with_precomputation_packed(
+                &mut input[..T * len],
+                &mut precomp,
+                driver,
+            )?;
+            // Feedforward
+            for i in 0..len {
+                input[T * i] += ff[T * i];
             }
             // Only take first element as output and pad with 0 for compression
             for i in 0..len / ARITY {


### PR DESCRIPTION
- **feat: also allow circom-compatible way to handle link library via cli (#285)**
- **feat: implement many featuers for the co-brillig rep3 backend (#284)**
- **chore: Cleanup some code in the co-brillig MPC trait**
- **feat: Bump Nargo to version v1.0.0-beta.0 (#286)**
- **feat(!): first version of shared if by forking brillig**
- **test: added to_radix32 test**
- **fix: fixed a bug where the constant for linear terms was ignored**
- **feat: added debug binary for rep3 noir witness extension**
- **chore: clippy**
- **build(deps): cargo machete**
- **chore: bump to_radix test to v1.0.0-beta.0**
- **chore: update a testvector**
- **feat: shamir impls**
- **fix: removed compiler transform as it breaks with nargo execute**
- **refactor!: removed acvm in trait names of solver**
- **chore: applied cargo clippy version 1.83**
- **docs: update README to reflect existance of coNoir (#288)**
- **fix: dont ignore network write errors in tokio taks, log them instead**
- **fix: increase max frame length to 1Tb**
- **feat: implement a radix sort in MPC and use it for range checks in co-noir (#290)**
- **feat: Add functionality to reshare a vector of fieldshares from two parties to a 3rd (#292)**
- **chore: release main (#267)**
- **feat: add binary division in gc**
- **feat: add shared/shared to co-brillig**
- **feat: add shared/public int division**
- **feat: add public/shared int division**
- **feat: to_radix for public radix**
- **feat: to_radix for public val/shared radix**
- **feat: to_radix for shared val/shared radix**
- **feat: bits case for shared/public**
- **feat: works for unique num_bits**
- **feat: handle different num_bits**
- **feat: test case with diff. uints**
- **feat: move batch decompose into a separate fct**
- **chore: Define upper bound for decompose arithmetic_many, clean up some code and prevent division by 0 in testcases**
- **fix: to_radix for weird constelations**
- **fix: Fix a bug preventing constants from being used in garbled circuits. TODO: Adapt the division circuits to use constants whenever possible**
- **feat: Add possibility to lazily initialize constants in garbled circuits to only send them once**
- **chore: remove silly constructions and use constant instead**
- **feat!: Bump Nargo to version v1.0.0-beta.1**
- **feat: add command to download a CRS with a given number of points to the co-noir binary (#301)**
- **refactor!: ChannelHandle no longer takes `&mut self` on send/recv methods, but now just takes `&self` (#303)**
- **feat: add possibility to generate recursive proofs**
- **feat: add generating recursive friendly vk; rename stuff to match bb**
- **docs: Corrected examples folder in Readme.md (#298)**
- **feat!: implemented bitwise_and, bitwise_xor and bitwise_not in the co-noir witness extension solver**
- **feat: Add bitwise blackbox functions to the acir_format parser**
- **feat: Add MPC functionality to slice a shared value**
- **feat: Modify co-builder to allow logic constraints (only working in plain so far)**
- **feat: Add testcase for blackbox and/not/xor**
- **feat: implement one lookup_acc case**
- **feat: make check on zkey opt in with config value (#297)**
- **feat: Add lookup table based on MAESTRO to the MPC core (#307)**
- **feat!: Adapt the ultrahonk mpc prover to also have the lookup related witness columns as private values**
- **feat: replace getting table index from LUT with calculating it from keys**
- **feat!: Add extra functionality to rewrite the lookup_read_counts_tags to shared LUTs**
- **feat: Adapt the construct_lookup_read_counts for private lookup tables**
- **fix: Fix splitting/reading proving key in co-noir binary**
- **feat: Starting to adapt the co-builder for handling shared LUTs**
- **feat: Bridge the co-builder and adapted proving-key generation and fix some issues**
- **feat: adapt compare_MPC to include blackbox_and/xor**
- **feat: Fixes and cleanup in shared LUTs**
- **feat: Cleanup the mpc-core and builder after shared LUT integration**
- **feat: Add RAM operations to plain coNoir**
- **feat: Extend ROM access for coNoir to the MPC setting of having shared indices**
- **feat!: Move poseidon2 from ultrahonk to mpc-core**
- **feat!: Add rep3 and shamir implementations of poseidon2 to mpc-core**
- **feat: Add bencher for rep3/shamir implementations of poseidon2 to co-circom**
- **feat: Add blackbox_poseidon2 handling to co-noir**
- **feat: Add poseidon2 testcases (with and without blackbox function)**
- **feat: add shamir proving testcase for bb_poseidon2**
- **fix: replace Hashmap with BTreeMap in circuit parsing of coNoir to make circuits deterministic. BB is not deterministic here...**
- **feat: Add some more missing BinaryIntOps to co-brillig (#315)**
- **feat!: add RAM operations on shared indices (#314)**
- **fix: Fix a bug with shifting BigUints in Range constraints (#318)**
- **refactor!: input shares are always rep3 and not compressed**
- **refactor!: co-circom lib usability improvents, added lib usage examples**
- **refactor!: co-noir lib usability improvents, added lib usage examples**
- **refactor: some misc changes and added typestate pattern for co-noir and co-circom**
- **chore: unified info level tracing in co-circom and co-noir binaries**
- **fix: dont iter over split_witness Result instead of shares, removed Result from ret type**
- **chore: fixed some small code quality issues**
- **chore: removed file/dir exists check functions from binaries**
- **feat!: optimize radix sort to take private and public inputs, such that public inputs do not have to be decomposed/bitinjected (#319)**
- **feat: Add more poseidon2 instances (t=2, t=3, t=4)**
- **feat: Add packed shamir version of poseidon2**
- **feat: Add packed rep3 version of poseidon2**
- **feat: Add Merkle tree implemenations using Poseidon2**
- **feat: Add Merkle trees to poseidon2 bench file**
- **feat: better network handling in poseidon bench binary**
- **fix: no longer measure quinn network shutdown**
- **feat!: ark to 0.5.0, co-noir witext works with 1.0.0-beta.2**
- **feat!: adapt prover and verifier to BB 0.72.1**
- **fix: enable parallelization for poseidon merkle tree implementations**
