### PR TITLE
Workaround for performance regression in ark 0.5 upgrade

### DIFF
--- a/mpc-core/src/protocols/rep3/network.rs
+++ b/mpc-core/src/protocols/rep3/network.rs
@@ -364,7 +364,7 @@ impl Rep3Network for Rep3MpcNet {
     fn recv_many<F: CanonicalDeserialize>(&mut self, from: PartyID) -> std::io::Result<Vec<F>> {
         let data = self.recv_bytes(from)?;
 
-        let res = Vec::<F>::deserialize_uncompressed(&data[..])
+        let res = Vec::<F>::deserialize_uncompressed_unchecked(&data[..])
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
         Ok(res)

--- a/mpc-core/src/protocols/shamir/network.rs
+++ b/mpc-core/src/protocols/shamir/network.rs
@@ -185,7 +185,7 @@ impl ShamirNetwork for ShamirMpcNet {
     fn recv_many<F: CanonicalDeserialize>(&mut self, from: usize) -> std::io::Result<Vec<F>> {
         let data = self.recv_bytes(from)?;
 
-        let res = Vec::<F>::deserialize_uncompressed(&data[..])
+        let res = Vec::<F>::deserialize_uncompressed_unchecked(&data[..])
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
         Ok(res)
@@ -215,7 +215,7 @@ impl ShamirNetwork for ShamirMpcNet {
         for other_id in 0..self.num_parties {
             if other_id != self.id {
                 let data = self.recv_bytes(other_id)?;
-                let deser = F::deserialize_uncompressed(&data[..])
+                let deser = F::deserialize_uncompressed_unchecked(&data[..])
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
                 res.push(deser);
             } else {
@@ -253,7 +253,7 @@ impl ShamirNetwork for ShamirMpcNet {
         for r in 1..num {
             let other_id = (self.id + self.num_parties - r) % self.num_parties;
             let data = self.recv_bytes(other_id)?;
-            let deser = F::deserialize_uncompressed(&data[..])
+            let deser = F::deserialize_uncompressed_unchecked(&data[..])
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
             res.push(deser);
         }


### PR DESCRIPTION
In the upgrade to arkworks 0.5, now the `deserialize_uncompressed` function no longer manages to optimize out calls to `batch_verify`, where the check operation is empty (returning `Ok(())` instantly).
The temporary workaround is to disable these checks entirely, with the drawback that now also all other checks are disabled (e.g., for EC points). Since we are computing SNARKs, this should not have any large impact anyways, but is on the agenda to keep an eye on if this issue is resolved in the future.
