### PR TITLE
Reduce work for Groth16 REP3 by working over un-replicated shares as much as possible

### DIFF
--- a/co-circom/co-groth16/src/groth16.rs
+++ b/co-circom/co-groth16/src/groth16.rs
@@ -118,14 +118,16 @@ where
             )
         }
 
-        let private_witness = Arc::new(private_witness.witness);
-        let h = self.witness_map_from_matrices(&zkey, &public_inputs, &private_witness)?;
+        let h = self.witness_map_from_matrices(&zkey, &public_inputs, &private_witness.witness)?;
         let (r, s) = (self.driver.rand()?, self.driver.rand()?);
 
-        let private_witness = Arc::into_inner(private_witness).unwrap();
-        let private_witness_half_share =
-            private_witness.into_iter().map(T::to_half_share).collect();
-        let private_witness = Arc::new(private_witness_half_share);
+        let private_witness_half_share = private_witness
+            .witness
+            .into_iter()
+            .map(T::to_half_share)
+            .collect();
+
+        let private_witness_hs = Arc::new(private_witness_half_share);
 
         self.create_proof_with_assignment(
             Arc::clone(&zkey),
@@ -133,7 +135,7 @@ where
             s,
             h,
             public_inputs,
-            private_witness,
+            private_witness_hs,
         )
     }
 

--- a/co-circom/co-groth16/src/groth16.rs
+++ b/co-circom/co-groth16/src/groth16.rs
@@ -123,7 +123,8 @@ where
         let (r, s) = (self.driver.rand()?, self.driver.rand()?);
 
         let private_witness = Arc::into_inner(private_witness).unwrap();
-        let private_witness_half_share = T::to_half_share_vec(private_witness);
+        let private_witness_half_share =
+            private_witness.into_iter().map(T::to_half_share).collect();
         let private_witness = Arc::new(private_witness_half_share);
 
         self.create_proof_with_assignment(
@@ -420,9 +421,7 @@ where
         // TODO we should move this to seperate thread so that we not block here
         // we can do some additional work so we don't necessary need to block
         let rs_span = tracing::debug_span!("r*s with networking").entered();
-        // TODO: mul local only
-        let rs = self.driver.mul(r, s)?;
-        let rs = T::to_half_share(rs);
+        let rs = self.driver.local_mul_vec(vec![r], vec![s]).pop().unwrap();
         let r_s_delta_g1 = T::scalar_mul_public_point_hs(&delta_g1, rs);
         rs_span.exit();
 

--- a/co-circom/co-groth16/src/groth16.rs
+++ b/co-circom/co-groth16/src/groth16.rs
@@ -1,6 +1,5 @@
 //! A Groth16 proof protocol that uses a collaborative MPC protocol to generate the proof.
 use ark_ec::pairing::Pairing;
-use ark_ec::scalar_mul::variable_base::VariableBaseMSM;
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{FftField, PrimeField};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
@@ -123,6 +122,10 @@ where
         let h = self.witness_map_from_matrices(&zkey, &public_inputs, &private_witness)?;
         let (r, s) = (self.driver.rand()?, self.driver.rand()?);
 
+        let private_witness = Arc::into_inner(private_witness).unwrap();
+        let private_witness_half_share = T::to_half_share_vec(private_witness);
+        let private_witness = Arc::new(private_witness_half_share);
+
         self.create_proof_with_assignment(
             Arc::clone(&zkey),
             r,
@@ -155,7 +158,7 @@ where
         zkey: &ZKey<P>,
         public_inputs: &[P::ScalarField],
         private_witness: &[T::ArithmeticShare],
-    ) -> Result<Vec<P::ScalarField>> {
+    ) -> Result<Vec<T::ArithmeticHalfShare>> {
         let num_constraints = zkey.num_constraints;
         let num_inputs = zkey.n_public + 1;
         let power = zkey.pow;
@@ -254,8 +257,8 @@ where
             ab.par_iter_mut()
                 .zip_eq(c_roots.par_iter())
                 .with_min_len(512)
-                .for_each(|(share, pow)| {
-                    *share *= pow;
+                .for_each(|(share, pow): (&mut T::ArithmeticHalfShare, _)| {
+                    *share *= *pow;
                 });
             dist_pows_span.exit();
             let fft_span = tracing::debug_span!("c: fft in dist pows").entered();
@@ -276,8 +279,8 @@ where
         ab.par_iter_mut()
             .zip_eq(c.par_iter())
             .with_min_len(512)
-            .for_each(|(a, b)| {
-                *a -= b;
+            .for_each(|(a, b): (&mut T::ArithmeticHalfShare, _)| {
+                *a -= *b;
             });
         compute_ab_span.exit();
         Ok(ab)
@@ -285,27 +288,27 @@ where
 
     fn calculate_coeff<C>(
         id: T::PartyID,
-        initial: T::PointShare<C>,
+        initial: T::PointHalfShare<C>,
         query: &[C::Affine],
         vk_param: C::Affine,
         input_assignment: &[P::ScalarField],
-        aux_assignment: &[T::ArithmeticShare],
-    ) -> T::PointShare<C>
+        aux_assignment: &[T::ArithmeticHalfShare],
+    ) -> T::PointHalfShare<C>
     where
         C: CurveGroup<ScalarField = P::ScalarField>,
     {
         let pub_len = input_assignment.len();
 
         let (priv_acc, pub_acc) = rayon::join(
-            || T::msm_public_points(&query[1 + pub_len..], aux_assignment),
+            || T::msm_public_points_hs(&query[1 + pub_len..], aux_assignment),
             || C::msm_unchecked(&query[1..=pub_len], input_assignment),
         );
 
         let mut res = initial;
-        T::add_assign_points_public(id, &mut res, &query[0].into_group());
-        T::add_assign_points_public(id, &mut res, &vk_param.into_group());
-        T::add_assign_points_public(id, &mut res, &pub_acc);
-        T::add_assign_points(&mut res, &priv_acc);
+        T::add_assign_points_public_hs(id, &mut res, &query[0].into_group());
+        T::add_assign_points_public_hs(id, &mut res, &vk_param.into_group());
+        T::add_assign_points_public_hs(id, &mut res, &pub_acc);
+        res += priv_acc;
         res
     }
 
@@ -315,9 +318,9 @@ where
         zkey: Arc<ZKey<P>>,
         r: T::ArithmeticShare,
         s: T::ArithmeticShare,
-        h: Vec<P::ScalarField>,
+        h: Vec<T::ArithmeticHalfShare>,
         input_assignment: Arc<Vec<P::ScalarField>>,
-        aux_assignment: Arc<Vec<T::ArithmeticShare>>,
+        aux_assignment: Arc<Vec<T::ArithmeticHalfShare>>,
     ) -> Result<(Groth16Proof<P>, T)> {
         let delta_g1 = zkey.delta_g1.into_group();
         let (l_acc_tx, l_acc_rx) = oneshot::channel();
@@ -348,7 +351,8 @@ where
             let compute_a =
                 tracing::debug_span!("compute A in create proof with assignment").entered();
             // Compute A
-            let r_g1 = T::scalar_mul_public_point(&delta_g1, r);
+            let r = T::to_half_share(r);
+            let r_g1 = T::scalar_mul_public_point_hs(&delta_g1, r);
             let r_g1 = Self::calculate_coeff(
                 party_id,
                 r_g1,
@@ -366,7 +370,8 @@ where
                 tracing::debug_span!("compute B/G1 in create proof with assignment").entered();
             // Compute B in G1
             // In original implementation this is skipped if r==0, however r is shared in our case
-            let s_g1 = T::scalar_mul_public_point(&delta_g1, s);
+            let s = T::to_half_share(s);
+            let s_g1 = T::scalar_mul_public_point_hs(&delta_g1, s);
             let s_g1 = Self::calculate_coeff(
                 party_id,
                 s_g1,
@@ -383,7 +388,8 @@ where
             let compute_b =
                 tracing::debug_span!("compute B/G2 in create proof with assignment").entered();
             // Compute B in G2
-            let s_g2 = T::scalar_mul_public_point(&delta_g2, s);
+            let s = T::to_half_share(s);
+            let s_g2 = T::scalar_mul_public_point_hs(&delta_g2, s);
             let s_g2 = Self::calculate_coeff(
                 party_id,
                 s_g2,
@@ -398,7 +404,7 @@ where
 
         rayon::spawn(move || {
             let msm_l_query = tracing::debug_span!("msm l_query").entered();
-            let result = T::msm_public_points(&l_query.l_query, &aux_assignment4);
+            let result = T::msm_public_points_hs(&l_query.l_query, &aux_assignment4);
             l_acc_tx.send(result).expect("channel not dropped");
             msm_l_query.exit();
         });
@@ -406,7 +412,7 @@ where
         rayon::spawn(move || {
             let msm_h_query = tracing::debug_span!("msm h_query").entered();
             //perform the msm for h
-            let result = P::G1::msm_unchecked(&h_query.h_query, &h);
+            let result = T::msm_public_points_hs(&h_query.h_query, &h);
             h_acc_tx.send(result).expect("channel not dropped");
             msm_h_query.exit();
         });
@@ -414,8 +420,10 @@ where
         // TODO we should move this to seperate thread so that we not block here
         // we can do some additional work so we don't necessary need to block
         let rs_span = tracing::debug_span!("r*s with networking").entered();
+        // TODO: mul local only
         let rs = self.driver.mul(r, s)?;
-        let r_s_delta_g1 = T::scalar_mul_public_point(&delta_g1, rs);
+        let rs = T::to_half_share(rs);
+        let r_s_delta_g1 = T::scalar_mul_public_point_hs(&delta_g1, rs);
         rs_span.exit();
 
         let g_a = r_g1_rx.blocking_recv()?;
@@ -426,19 +434,20 @@ where
         network_round.exit();
 
         let last_round = tracing::debug_span!("finish - open two points and some adds").entered();
-        let s_g_a = T::scalar_mul_public_point(&g_a_opened, s);
+        let s = T::to_half_share(s);
+        let s_g_a = T::scalar_mul_public_point_hs(&g_a_opened, s);
 
         let mut g_c = s_g_a;
-        T::add_assign_points(&mut g_c, &r_g1_b);
-        T::sub_assign_points(&mut g_c, &r_s_delta_g1);
+        g_c += r_g1_b;
+        g_c -= r_s_delta_g1;
         let l_aux_acc = l_acc_rx.blocking_recv().expect("channel not dropped");
-        T::add_assign_points(&mut g_c, &l_aux_acc);
+        g_c += l_aux_acc;
 
         let h_acc = h_acc_rx.blocking_recv()?;
-        let g_c = T::add_points_half_share(g_c, &h_acc);
+        g_c += h_acc;
 
         let g2_b = s_g2_rx.blocking_recv()?;
-        let (g_c_opened, g2_b_opened) = self.driver.open_two_points(g_c, g2_b)?;
+        let (g_c_opened, g2_b_opened) = self.driver.open_two_half_points(g_c, g2_b)?;
         last_round.exit();
 
         Ok((

--- a/co-circom/co-groth16/src/mpc.rs
+++ b/co-circom/co-groth16/src/mpc.rs
@@ -31,7 +31,7 @@ pub trait CircomGroth16Prover<P: Pairing>: Send + Sized {
         + DomainCoeff<P::ScalarField>
         + 'static;
 
-    /// The arithmetic half share type
+    /// The arithmetic half share type. For Rep3 this is an unreplicated additive share. For Shamir this is a degree-2t sharing.
     type ArithmeticHalfShare: CanonicalSerialize
         + CanonicalDeserialize
         + Copy
@@ -99,8 +99,8 @@ pub trait CircomGroth16Prover<P: Pairing>: Send + Sized {
         roots: &[P::ScalarField],
     );
 
+    /// Converts a shared value to a half shared value. Local interaction only.
     fn to_half_share(a: Self::ArithmeticShare) -> Self::ArithmeticHalfShare;
-    fn to_half_share_vec(a: Vec<Self::ArithmeticShare>) -> Vec<Self::ArithmeticHalfShare>;
 
     /// Perform msm between `points` and `scalars`
     fn msm_public_points<C>(

--- a/co-circom/co-groth16/src/mpc/plain.rs
+++ b/co-circom/co-groth16/src/mpc/plain.rs
@@ -57,10 +57,6 @@ impl<P: Pairing> CircomGroth16Prover<P> for PlainGroth16Driver {
         a
     }
 
-    fn to_half_share_vec(a: Vec<Self::ArithmeticShare>) -> Vec<<P as Pairing>::ScalarField> {
-        a
-    }
-
     fn msm_public_points_hs<C>(
         points: &[C::Affine],
         scalars: &[Self::ArithmeticHalfShare],

--- a/co-circom/co-groth16/src/mpc/plain.rs
+++ b/co-circom/co-groth16/src/mpc/plain.rs
@@ -12,8 +12,14 @@ pub struct PlainGroth16Driver;
 
 impl<P: Pairing> CircomGroth16Prover<P> for PlainGroth16Driver {
     type ArithmeticShare = P::ScalarField;
+    type ArithmeticHalfShare = P::ScalarField;
 
     type PointShare<C>
+        = C
+    where
+        C: CurveGroup;
+
+    type PointHalfShare<C>
         = C
     where
         C: CurveGroup;
@@ -45,6 +51,24 @@ impl<P: Pairing> CircomGroth16Prover<P> for PlainGroth16Driver {
             }
         }
         acc
+    }
+
+    fn to_half_share(a: Self::ArithmeticShare) -> <P as Pairing>::ScalarField {
+        a
+    }
+
+    fn to_half_share_vec(a: Vec<Self::ArithmeticShare>) -> Vec<<P as Pairing>::ScalarField> {
+        a
+    }
+
+    fn msm_public_points_hs<C>(
+        points: &[C::Affine],
+        scalars: &[Self::ArithmeticHalfShare],
+    ) -> Self::PointShare<C>
+    where
+        C: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
+    {
+        C::msm_unchecked(points, scalars)
     }
 
     fn promote_to_trivial_shares(
@@ -104,7 +128,7 @@ impl<P: Pairing> CircomGroth16Prover<P> for PlainGroth16Driver {
         a + b
     }
 
-    fn add_assign_points_public<C: CurveGroup>(
+    fn add_assign_points_public_hs<C: CurveGroup>(
         _: Self::PartyID,
         a: &mut Self::PointShare<C>,
         b: &C,
@@ -134,7 +158,7 @@ impl<P: Pairing> CircomGroth16Prover<P> for PlainGroth16Driver {
         *a -= b;
     }
 
-    fn open_two_points(
+    fn open_two_half_points(
         &mut self,
         a: Self::PointShare<P::G1>,
         b: Self::PointShare<P::G2>,
@@ -149,5 +173,12 @@ impl<P: Pairing> CircomGroth16Prover<P> for PlainGroth16Driver {
         r: Self::ArithmeticShare,
     ) -> super::IoResult<(P::G1, Self::PointShare<P::G1>)> {
         Ok((*g_a, *g1_b * r))
+    }
+
+    fn scalar_mul_public_point_hs<C>(a: &C, b: Self::ArithmeticHalfShare) -> Self::PointHalfShare<C>
+    where
+        C: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
+    {
+        *a * b
     }
 }

--- a/co-circom/co-groth16/src/mpc/rep3.rs
+++ b/co-circom/co-groth16/src/mpc/rep3.rs
@@ -217,10 +217,6 @@ impl<P: Pairing, N: Rep3Network> CircomGroth16Prover<P> for Rep3Groth16Driver<N>
         a.a
     }
 
-    fn to_half_share_vec(a: Vec<Self::ArithmeticShare>) -> Vec<<P as Pairing>::ScalarField> {
-        a.into_iter().map(|x| x.a).collect()
-    }
-
     fn msm_public_points_hs<C>(
         points: &[C::Affine],
         scalars: &[Self::ArithmeticHalfShare],

--- a/co-circom/co-groth16/src/mpc/rep3.rs
+++ b/co-circom/co-groth16/src/mpc/rep3.rs
@@ -61,19 +61,18 @@ impl<P: Pairing, N: Rep3Network> CircomGroth16Prover<P> for Rep3Groth16Driver<N>
         public_inputs: &[P::ScalarField],
         private_witness: &[Self::ArithmeticShare],
     ) -> Self::ArithmeticShare {
-        lhs.into_par_iter()
-            .map(|(coeff, index)| {
-                if index < &public_inputs.len() {
-                    let val = public_inputs[*index];
-                    let mul_result = val * coeff;
-                    Self::ArithmeticShare::promote_from_trivial(&mul_result, party_id)
-                } else {
-                    let current_witness = private_witness[*index - public_inputs.len()];
-                    arithmetic::mul_public(current_witness, *coeff)
-                }
-            })
-            .fold(Self::ArithmeticShare::default, arithmetic::add)
-            .reduce(Self::ArithmeticShare::default, arithmetic::add)
+        let mut acc = Self::ArithmeticShare::default();
+        for (coeff, index) in lhs {
+            if index < &public_inputs.len() {
+                let val = public_inputs[*index];
+                let mul_result = val * coeff;
+                arithmetic::add_assign_public(&mut acc, mul_result, party_id);
+            } else {
+                let current_witness = private_witness[*index - public_inputs.len()];
+                arithmetic::add_assign(&mut acc, arithmetic::mul_public(current_witness, *coeff));
+            }
+        }
+        acc
     }
 
     fn promote_to_trivial_shares(

--- a/co-circom/co-groth16/src/mpc/rep3.rs
+++ b/co-circom/co-groth16/src/mpc/rep3.rs
@@ -34,8 +34,14 @@ impl<N: Rep3Network> Rep3Groth16Driver<N> {
 
 impl<P: Pairing, N: Rep3Network> CircomGroth16Prover<P> for Rep3Groth16Driver<N> {
     type ArithmeticShare = Rep3PrimeFieldShare<P::ScalarField>;
+    type ArithmeticHalfShare = P::ScalarField;
     type PointShare<C>
         = Rep3PointShare<C>
+    where
+        C: CurveGroup;
+
+    type PointHalfShare<C>
+        = C
     where
         C: CurveGroup;
 
@@ -136,12 +142,16 @@ impl<P: Pairing, N: Rep3Network> CircomGroth16Prover<P> for Rep3Groth16Driver<N>
         a + b
     }
 
-    fn add_assign_points_public<C: CurveGroup>(
+    fn add_assign_points_public_hs<C: CurveGroup>(
         id: Self::PartyID,
-        a: &mut Self::PointShare<C>,
+        a: &mut Self::PointHalfShare<C>,
         b: &C,
     ) {
-        pointshare::add_assign_public(a, b, id)
+        match id {
+            PartyID::ID0 => *a += b,
+            PartyID::ID1 => {}
+            PartyID::ID2 => {}
+        }
     }
 
     fn open_point<C>(&mut self, a: &Self::PointShare<C>) -> IoResult<C>
@@ -166,35 +176,65 @@ impl<P: Pairing, N: Rep3Network> CircomGroth16Prover<P> for Rep3Groth16Driver<N>
         pointshare::sub_assign(a, b);
     }
 
-    fn open_two_points(
-        &mut self,
-        a: P::G1,
-        b: Self::PointShare<P::G2>,
-    ) -> std::io::Result<(P::G1, P::G2)> {
+    fn open_two_half_points(&mut self, a: P::G1, b: P::G2) -> std::io::Result<(P::G1, P::G2)> {
         let mut s1 = a;
-        let s2 = b.b;
+        let mut s2 = b;
         let (r1, r2) = std::thread::scope(|s| {
             let r1 = s.spawn(|| self.io_context0.network.broadcast(s1));
-            let r2 = s.spawn(|| self.io_context1.network.reshare(s2));
+            let r2 = s.spawn(|| self.io_context1.network.broadcast(s2));
             (r1.join().expect("can join"), r2.join().expect("can join"))
         });
         let (r1b, r1c) = r1?;
-        let mut r2 = r2?;
+        let (r2b, r2c) = r2?;
         s1 += r1b + r1c;
-        r2 += b.a + b.b;
-        Ok((s1, r2))
+        s2 += r2b + r2c;
+        Ok((s1, s2))
     }
 
     fn open_point_and_scalar_mul(
         &mut self,
-        g_a: &Self::PointShare<P::G1>,
-        g1_b: &Self::PointShare<P::G1>,
+        g_a: &Self::PointHalfShare<P::G1>,
+        g1_b: &Self::PointHalfShare<P::G1>,
         r: Self::ArithmeticShare,
-    ) -> std::io::Result<(<P as Pairing>::G1, Self::PointShare<P::G1>)> {
+    ) -> std::io::Result<(<P as Pairing>::G1, Self::PointHalfShare<P::G1>)> {
         std::thread::scope(|s| {
-            let opened = s.spawn(|| pointshare::open_point(g_a, &mut self.io_context0));
-            let mul_result = pointshare::scalar_mul(g1_b, r, &mut self.io_context1)?;
-            Ok((opened.join().expect("can join")?, mul_result))
+            let opened = s.spawn(|| self.io_context0.network.broadcast(*g_a));
+            let g1_b_hs = s.spawn(|| self.io_context1.network.reshare(*g1_b));
+            let point = Rep3PointShare {
+                a: *g1_b,
+                b: g1_b_hs.join().expect("can join")?,
+            };
+            let mul_result = pointshare::scalar_mul_local(&point, r, &mut self.io_context1.rngs);
+
+            let (g_a_1, g_a_2) = opened.join().expect("can join")?;
+            let open_res = g_a_1 + g_a_2 + g_a;
+
+            Ok((open_res, mul_result))
         })
+    }
+
+    fn to_half_share(a: Self::ArithmeticShare) -> <P as Pairing>::ScalarField {
+        a.a
+    }
+
+    fn to_half_share_vec(a: Vec<Self::ArithmeticShare>) -> Vec<<P as Pairing>::ScalarField> {
+        a.into_iter().map(|x| x.a).collect()
+    }
+
+    fn msm_public_points_hs<C>(
+        points: &[C::Affine],
+        scalars: &[Self::ArithmeticHalfShare],
+    ) -> Self::PointHalfShare<C>
+    where
+        C: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
+    {
+        C::msm_unchecked(points, scalars)
+    }
+
+    fn scalar_mul_public_point_hs<C>(a: &C, b: Self::ArithmeticHalfShare) -> Self::PointHalfShare<C>
+    where
+        C: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
+    {
+        *a * b
     }
 }

--- a/co-circom/co-groth16/src/mpc/shamir.rs
+++ b/co-circom/co-groth16/src/mpc/shamir.rs
@@ -217,10 +217,6 @@ impl<P: Pairing, N: ShamirNetwork> CircomGroth16Prover<P>
         a.inner()
     }
 
-    fn to_half_share_vec(a: Vec<Self::ArithmeticShare>) -> Vec<<P as Pairing>::ScalarField> {
-        a.into_iter().map(|x| x.inner()).collect()
-    }
-
     fn msm_public_points_hs<C>(
         points: &[C::Affine],
         scalars: &[Self::ArithmeticHalfShare],

--- a/co-circom/co-groth16/src/mpc/shamir.rs
+++ b/co-circom/co-groth16/src/mpc/shamir.rs
@@ -62,18 +62,19 @@ impl<P: Pairing, N: ShamirNetwork> CircomGroth16Prover<P>
         public_inputs: &[P::ScalarField],
         private_witness: &[Self::ArithmeticShare],
     ) -> Self::ArithmeticShare {
-        let mut acc = Self::ArithmeticShare::default();
-        for (coeff, index) in lhs {
-            if index < &public_inputs.len() {
-                let val = public_inputs[*index];
-                let mul_result = val * coeff;
-                arithmetic::add_assign_public(&mut acc, mul_result);
-            } else {
-                let current_witness = private_witness[*index - public_inputs.len()];
-                arithmetic::add_assign(&mut acc, arithmetic::mul_public(current_witness, *coeff));
-            }
-        }
-        acc
+        lhs.into_par_iter()
+            .map(|(coeff, index)| {
+                if index < &public_inputs.len() {
+                    let val = public_inputs[*index];
+                    let mul_result = val * coeff;
+                    arithmetic::promote_to_trivial_share(mul_result)
+                } else {
+                    let current_witness = private_witness[*index - public_inputs.len()];
+                    arithmetic::mul_public(current_witness, *coeff)
+                }
+            })
+            .fold(Self::ArithmeticShare::default, arithmetic::add)
+            .reduce(Self::ArithmeticShare::default, arithmetic::add)
     }
 
     fn promote_to_trivial_shares(

--- a/co-circom/co-groth16/src/mpc/shamir.rs
+++ b/co-circom/co-groth16/src/mpc/shamir.rs
@@ -213,6 +213,7 @@ impl<P: Pairing, N: ShamirNetwork> CircomGroth16Prover<P>
         })
     }
 
+    /// For Shamir sharing, a valid degree-t share is always a valid degree-2t share.
     fn to_half_share(a: Self::ArithmeticShare) -> <P as Pairing>::ScalarField {
         a.inner()
     }

--- a/mpc-core/src/protocols/rep3/pointshare.rs
+++ b/mpc-core/src/protocols/rep3/pointshare.rs
@@ -14,6 +14,7 @@ pub use types::Rep3PointShare;
 use super::{
     id::PartyID,
     network::{IoContext, Rep3Network},
+    rngs::Rep3CorrelatedRng,
     IoResult, Rep3PrimeFieldShare,
 };
 
@@ -77,6 +78,15 @@ pub fn scalar_mul_public_scalar<C: CurveGroup>(
     b: C::ScalarField,
 ) -> PointShare<C> {
     a * b
+}
+
+/// Perform local part of scalar multiplication
+pub fn scalar_mul_local<C: CurveGroup>(
+    a: &PointShare<C>,
+    b: FieldShare<C::ScalarField>,
+    rng: &mut Rep3CorrelatedRng,
+) -> C {
+    b * a + rng.rand.masking_ec_element::<C>()
 }
 
 /// Perform scalar multiplication

--- a/mpc-core/src/protocols/shamir.rs
+++ b/mpc-core/src/protocols/shamir.rs
@@ -466,10 +466,8 @@ impl<F: PrimeField, N: ShamirNetwork> ShamirProtocol<F, N> {
         Ok(ShamirShare::convert_vec_rev(my_shares))
     }
 
-    pub(crate) fn degree_reduce_point<C>(
-        &mut self,
-        mut input: C,
-    ) -> std::io::Result<ShamirPointShare<C>>
+    /// Reduces the degree of a point share C from 2*t to t
+    pub fn degree_reduce_point<C>(&mut self, mut input: C) -> std::io::Result<ShamirPointShare<C>>
     where
         C: CurveGroup + std::ops::Mul<F, Output = C> + for<'a> std::ops::Mul<&'a F, Output = C>,
     {

--- a/mpc-core/src/protocols/shamir/pointshare.rs
+++ b/mpc-core/src/protocols/shamir/pointshare.rs
@@ -79,6 +79,11 @@ pub fn scalar_mul_public_scalar<C: CurveGroup>(
     a * b
 }
 
+/// Performs local part of scalar multiplication between a point share and a field share.
+pub fn scalar_mul_local<C: CurveGroup>(a: &PointShare<C>, b: ShamirShare<C::ScalarField>) -> C {
+    (b * a).a
+}
+
 /// Performs scalar multiplication between a point share and a field share.
 pub fn scalar_mul<C: CurveGroup, N: ShamirNetwork>(
     a: &PointShare<C>,


### PR DESCRIPTION
- **wip on groth16 improvements**
- **move rs to local mul**
- **feat: multi threaded eval constraint in groth16**
- **Revert "feat: multi threaded eval constraint in groth16"**
