### PR TITLE
refactor: change co-noir --hasher CLI to be aligned with bb

### DIFF
--- a/co-noir/co-noir/Readme.md
+++ b/co-noir/co-noir/Readme.md
@@ -100,10 +100,10 @@ Here, `poseidon.gz.shared` is the REP3 input share, `shamir_poseidon.gz.shared` 
 To create a proof in MPC, one needs the extended witness (from GenerateWitness, SplitWitness, or TranslateWitness):
 
 ```bash
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party.toml --out proof.proof --public-input public_input
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party.toml --out proof.proof --public-input public_input
 ```
 
-Here, `poseidon.gz.shared` is the share of the witness, `poseidon.json` is the circuit file from Noir, `bn254_g1.dat` is the file storing the prover CRS and `party.toml` is the network configuration. As output, one creates the UltraHonk proof `proof.proof` and the output of the circuit `public_input.json`. The parameter `--hasher POSEIDON` defines that Poseidon2 is used as the transcript hasher, the other implemented option would be Keccak256.
+Here, `poseidon.gz.shared` is the share of the witness, `poseidon.json` is the circuit file from Noir, `bn254_g1.dat` is the file storing the prover CRS and `party.toml` is the network configuration. As output, one creates the UltraHonk proof `proof.proof` and the output of the circuit `public_input.json`. The parameter `--hasher poseidon2` defines that Poseidon2 is used as the transcript hasher, the other implemented option would be Keccak256.
 
 The corresponding Barretenberg command (from `barretenberg/cpp/build/bin`) is:
 
@@ -119,10 +119,10 @@ Note: Barretenberg does not require the file for storing the CRS, since Barreten
 To verify the created proof, we first need to create a verification key. This can be done with:
 
 ```bash
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher POSEIDON --vk test_vectors/poseidon/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher poseidon2 --vk test_vectors/poseidon/verification_key
 ```
 
-Here, `poseidon.json` is the circuit file from Noir, `bn254_g1.dat` is the file storing the prover CRS, and the output is written to `verification_key`. Again, `--hasher POSEIDON` defines that Poseidon2 is used as the transcript hasher.
+Here, `poseidon.json` is the circuit file from Noir, `bn254_g1.dat` is the file storing the prover CRS, and the output is written to `verification_key`. Again, `--hasher poseidon2` defines that Poseidon2 is used as the transcript hasher.
 
 The corresponding Barretenberg command (from `barretenberg/cpp/build/bin`) is:
 
@@ -138,10 +138,10 @@ Note: Barretenberg does not require the file for storing the CRS, since Barreten
 To verify the proof, just use:
 
 ```bash
-cargo run --release --bin co-noir -- verify --proof proof.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher POSEIDON --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher poseidon2 --crs test_vectors/bn254_g2.dat
 ```
 
-Here, `proof.proof` is the proof we want to verify, `verification_key` is the output of CreateVK, and `bn254_g2.dat` is the verifier CRS. Again, `--hasher POSEIDON` defines that Poseidon2 is used as the transcript hasher.
+Here, `proof.proof` is the proof we want to verify, `verification_key` is the output of CreateVK, and `bn254_g2.dat` is the verifier CRS. Again, `--hasher poseidon2` defines that Poseidon2 is used as the transcript hasher.
 
 The corresponding Barretenberg command (from `barretenberg/cpp/build/bin`) is:
 

--- a/co-noir/co-noir/examples/compare.sh
+++ b/co-noir/co-noir/examples/compare.sh
@@ -118,7 +118,7 @@ for f in "${test_cases[@]}"; do
   bash -c "(cd test_vectors/${f} && nargo execute) $PIPE"
 
   # -e to exit on first error
-  bash -c "${PLAINDRIVER} --prover-crs test_vectors/bn254_g1.dat --verifier-crs test_vectors/bn254_g2.dat --input test_vectors/${f}/Prover.toml --circuit test_vectors/${f}/target/${f}.json --hasher POSEIDON --out-dir test_vectors/${f} $PIPE" || failed=1
+  bash -c "${PLAINDRIVER} --prover-crs test_vectors/bn254_g1.dat --verifier-crs test_vectors/bn254_g2.dat --input test_vectors/${f}/Prover.toml --circuit test_vectors/${f}/target/${f}.json --hasher poseidon2 --out-dir test_vectors/${f} $PIPE" || failed=1
 
   if [ "$failed" -ne 0 ]
   then
@@ -128,7 +128,7 @@ for f in "${test_cases[@]}"; do
   run_proof_verification "$f" "poseidon"
 
   # Run with ZK:
-  bash -c "${PLAINDRIVER} --prover-crs test_vectors/bn254_g1.dat --verifier-crs test_vectors/bn254_g2.dat --input test_vectors/${f}/Prover.toml --circuit test_vectors/${f}/target/${f}.json --hasher POSEIDON --out-dir test_vectors/${f} --zk $PIPE" || failed=1
+  bash -c "${PLAINDRIVER} --prover-crs test_vectors/bn254_g1.dat --verifier-crs test_vectors/bn254_g2.dat --input test_vectors/${f}/Prover.toml --circuit test_vectors/${f}/target/${f}.json --hasher poseidon2 --out-dir test_vectors/${f} --zk $PIPE" || failed=1
 
   if [ "$failed" -ne 0 ]
   then
@@ -140,7 +140,7 @@ for f in "${test_cases[@]}"; do
   bash cleanup.sh
 
    # -e to exit on first error
-  bash -c "${PLAINDRIVER} --prover-crs test_vectors/bn254_g1.dat --verifier-crs test_vectors/bn254_g2.dat --input test_vectors/${f}/Prover.toml --circuit test_vectors/${f}/target/${f}.json --hasher KECCAK --out-dir test_vectors/${f} $PIPE"  || failed=1
+  bash -c "${PLAINDRIVER} --prover-crs test_vectors/bn254_g1.dat --verifier-crs test_vectors/bn254_g2.dat --input test_vectors/${f}/Prover.toml --circuit test_vectors/${f}/target/${f}.json --hasher keccak --out-dir test_vectors/${f} $PIPE"  || failed=1
 
   if [ "$failed" -ne 0 ]
   then
@@ -150,7 +150,7 @@ for f in "${test_cases[@]}"; do
   run_proof_verification "$f" "keccak"
    bash cleanup.sh
   # Run with ZK:
-  bash -c "${PLAINDRIVER} --prover-crs test_vectors/bn254_g1.dat --verifier-crs test_vectors/bn254_g2.dat --input test_vectors/${f}/Prover.toml --circuit test_vectors/${f}/target/${f}.json --hasher KECCAK --out-dir test_vectors/${f} --zk $PIPE" || failed=1
+  bash -c "${PLAINDRIVER} --prover-crs test_vectors/bn254_g1.dat --verifier-crs test_vectors/bn254_g2.dat --input test_vectors/${f}/Prover.toml --circuit test_vectors/${f}/target/${f}.json --hasher keccak --out-dir test_vectors/${f} --zk $PIPE" || failed=1
   if [ "$failed" -ne 0 ]
   then
     exit_code=1

--- a/co-noir/co-noir/examples/compare_mpc.sh
+++ b/co-noir/co-noir/examples/compare_mpc.sh
@@ -135,14 +135,14 @@ for f in "${test_cases[@]}"; do
   bash -c "cargo run --release --bin co-noir -- generate-witness --input test_vectors/${f}/Prover.toml.2.shared --circuit test_vectors/${f}/target/${f}.json --protocol REP3 --config configs/party3.toml --out test_vectors/${f}/${f}.gz.2.shared $PIPE"  || failed=1 &
    wait $(jobs -p)
   # run proving in MPC
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --public-input test_vectors/${f}/cosnark_public_input --fields-as-json $PIPE"  || failed=1&
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party2.toml --out test_vectors/${f}/cosnark_proof.1.proof  $PIPE"  || failed=1&
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party3.toml --out test_vectors/${f}/cosnark_proof.2.proof $PIPE"  || failed=1
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --public-input test_vectors/${f}/cosnark_public_input --fields-as-json $PIPE"  || failed=1&
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party2.toml --out test_vectors/${f}/cosnark_proof.1.proof  $PIPE"  || failed=1&
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party3.toml --out test_vectors/${f}/cosnark_proof.2.proof $PIPE"  || failed=1
   wait $(jobs -p)
   # Create verification key
-  bash -c "RUST_BACKTRACE=full cargo run --release --bin co-noir -- create-vk --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --hasher POSEIDON --vk test_vectors/${f}/cosnark_vk --fields-as-json $PIPE"  || failed=1
+  bash -c "RUST_BACKTRACE=full cargo run --release --bin co-noir -- create-vk --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --hasher poseidon2 --vk test_vectors/${f}/cosnark_vk --fields-as-json $PIPE"  || failed=1
   # verify proof
-  bash -c "RUST_BACKTRACE=full cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --public-input test_vectors/${f}/cosnark_public_input --hasher POSEIDON --crs test_vectors/bn254_g2.dat$PIPE"  || failed=1
+  bash -c "RUST_BACKTRACE=full cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --public-input test_vectors/${f}/cosnark_public_input --hasher poseidon2 --crs test_vectors/bn254_g2.dat$PIPE"  || failed=1
 
   if [ "$failed" -ne 0 ]
   then
@@ -154,12 +154,12 @@ for f in "${test_cases[@]}"; do
 
   echo "proving and verifying with ZK in co-noir and poseidon transcript"
   # run proving in MPC with ZK
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --public-input test_vectors/${f}/cosnark_public_input --zk $PIPE"  || failed=1&
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party2.toml --out test_vectors/${f}/zk_proof.1.proof --zk $PIPE"  || failed=1&
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party3.toml --out test_vectors/${f}/zk_proof.2.proof --zk $PIPE"  || failed=1
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --public-input test_vectors/${f}/cosnark_public_input --zk $PIPE"  || failed=1&
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party2.toml --out test_vectors/${f}/zk_proof.1.proof --zk $PIPE"  || failed=1&
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party3.toml --out test_vectors/${f}/zk_proof.2.proof --zk $PIPE"  || failed=1
   wait $(jobs -p)
   # verify proof
-  bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --public-input test_vectors/${f}/cosnark_public_input --hasher POSEIDON --crs test_vectors/bn254_g2.dat --has-zk $PIPE"  || failed=1
+  bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --public-input test_vectors/${f}/cosnark_public_input --hasher poseidon2 --crs test_vectors/bn254_g2.dat --has-zk $PIPE"  || failed=1
 
    if [ "$failed" -ne 0 ]
   then
@@ -179,14 +179,14 @@ for f in "${test_cases[@]}"; do
   bash -c "cargo run --release --bin co-noir -- generate-witness --input test_vectors/${f}/Prover.toml.2.shared --circuit test_vectors/${f}/target/${f}.json --protocol REP3 --config configs/party3.toml --out test_vectors/${f}/${f}.gz.2.shared $PIPE"  || failed=1
   wait $(jobs -p)
   # run proving in MPC
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --public-input test_vectors/${f}/cosnark_public_input $PIPE"  || failed=1&
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out test_vectors/${f}/cosnark_proof.1.proof  $PIPE"  || failed=1&
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out test_vectors/${f}/cosnark_proof.2.proof $PIPE"  || failed=1
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --public-input test_vectors/${f}/cosnark_public_input $PIPE"  || failed=1&
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out test_vectors/${f}/cosnark_proof.1.proof  $PIPE"  || failed=1&
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out test_vectors/${f}/cosnark_proof.2.proof $PIPE"  || failed=1
   wait $(jobs -p)
   # Create verification key
-  bash -c "cargo run --release --bin co-noir -- create-vk --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/${f}/cosnark_vk $PIPE"  || failed=1
+  bash -c "cargo run --release --bin co-noir -- create-vk --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/${f}/cosnark_vk $PIPE"  || failed=1
   # verify proof
-  bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --public-input test_vectors/${f}/cosnark_public_input --hasher KECCAK --crs test_vectors/bn254_g2.dat $PIPE"  || failed=1
+  bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --public-input test_vectors/${f}/cosnark_public_input --hasher keccak --crs test_vectors/bn254_g2.dat $PIPE"  || failed=1
 
     if [ "$failed" -ne 0 ]
   then
@@ -198,12 +198,12 @@ for f in "${test_cases[@]}"; do
 
   echo "proving and verifying with ZK in co-noir and keccak transcript"
   # run proving in MPC with ZK
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --public-input test_vectors/${f}/cosnark_public_input --zk $PIPE"  || failed=1&
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out test_vectors/${f}/cosnark_proof.1.proof --zk $PIPE"  || failed=1&
-  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out test_vectors/${f}/cosnark_proof.2.proof --zk $PIPE"  || failed=1
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --public-input test_vectors/${f}/cosnark_public_input --zk $PIPE"  || failed=1&
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out test_vectors/${f}/cosnark_proof.1.proof --zk $PIPE"  || failed=1&
+  bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out test_vectors/${f}/cosnark_proof.2.proof --zk $PIPE"  || failed=1
   wait $(jobs -p)
   # verify proof
-  bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --public-input test_vectors/${f}/cosnark_public_input --hasher KECCAK --crs test_vectors/bn254_g2.dat --has-zk $PIPE"  || failed=1
+  bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --public-input test_vectors/${f}/cosnark_public_input --hasher keccak --crs test_vectors/bn254_g2.dat --has-zk $PIPE"  || failed=1
 
     if [ "$failed" -ne 0 ]
   then

--- a/co-noir/co-noir/examples/compare_mpc_recursive.sh
+++ b/co-noir/co-noir/examples/compare_mpc_recursive.sh
@@ -134,14 +134,14 @@
 #   bash -c "cargo run --release --bin co-noir -- generate-witness --input test_vectors/${f}/Prover.toml.2.shared --circuit test_vectors/${f}/target/${f}.json --protocol REP3 --config configs/party3.toml --out test_vectors/${f}/${f}.gz.2.shared $PIPE"  || failed=1 &
 #    wait $(jobs -p)
 #   # run proving in MPC
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party1.toml --recursive --out test_vectors/${f}/cosnark_proof --public-input public_input $PIPE"  || failed=1&
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party2.toml --recursive --out test_vectors/${f}/cosnark_proof.1.proof  $PIPE"  || failed=1&
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party3.toml --recursive --out test_vectors/${f}/cosnark_proof.2.proof $PIPE"  || failed=1
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party1.toml --recursive --out test_vectors/${f}/cosnark_proof --public-input public_input $PIPE"  || failed=1&
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party2.toml --recursive --out test_vectors/${f}/cosnark_proof.1.proof  $PIPE"  || failed=1&
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party3.toml --recursive --out test_vectors/${f}/cosnark_proof.2.proof $PIPE"  || failed=1
 #   wait $(jobs -p)
 #   # Create verification key
-#   bash -c "cargo run --release --bin co-noir -- create-vk --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --hasher POSEIDON --recursive --vk test_vectors/${f}/cosnark_vk $PIPE"  || failed=1
+#   bash -c "cargo run --release --bin co-noir -- create-vk --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --hasher poseidon2 --recursive --vk test_vectors/${f}/cosnark_vk $PIPE"  || failed=1
 #   # verify proof
-#   bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --hasher POSEIDON --crs test_vectors/bn254_g2.dat$PIPE"  || failed=1
+#   bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --hasher poseidon2 --crs test_vectors/bn254_g2.dat$PIPE"  || failed=1
 
 #   if [ "$failed" -ne 0 ]
 #   then
@@ -153,12 +153,12 @@
 
 #   echo "proving and verifying with ZK in co-noir and poseidon transcript"
 #   # run proving in MPC with ZK
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party1.toml --recursive --out test_vectors/${f}/cosnark_proof --public-input public_input --zk $PIPE"  || failed=1&
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party2.toml --recursive --out test_vectors/${f}/zk_proof.1.proof --zk $PIPE"  || failed=1&
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party3.toml --recursive --out test_vectors/${f}/zk_proof.2.proof --zk $PIPE"  || failed=1
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party1.toml --recursive --out test_vectors/${f}/cosnark_proof --public-input public_input --zk $PIPE"  || failed=1&
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party2.toml --recursive --out test_vectors/${f}/zk_proof.1.proof --zk $PIPE"  || failed=1&
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party3.toml --recursive --out test_vectors/${f}/zk_proof.2.proof --zk $PIPE"  || failed=1
 #   wait $(jobs -p)
 #   # verify proof
-#   bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --hasher POSEIDON --crs test_vectors/bn254_g2.dat --has-zk $PIPE"  || failed=1
+#   bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --hasher poseidon2 --crs test_vectors/bn254_g2.dat --has-zk $PIPE"  || failed=1
 
 #    if [ "$failed" -ne 0 ]
 #   then
@@ -178,14 +178,14 @@
 #   bash -c "cargo run --release --bin co-noir -- generate-witness --input test_vectors/${f}/Prover.toml.2.shared --circuit test_vectors/${f}/target/${f}.json --protocol REP3 --config configs/party3.toml --out test_vectors/${f}/${f}.gz.2.shared $PIPE"  || failed=1
 #   wait $(jobs -p)
 #   # run proving in MPC
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --recursive --public-input public_input$PIPE"  || failed=1&
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out test_vectors/${f}/cosnark_proof.1.proof --recursive  $PIPE"  || failed=1&
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out test_vectors/${f}/cosnark_proof.2.proof --recursive $PIPE"  || failed=1
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --recursive --public-input public_input$PIPE"  || failed=1&
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out test_vectors/${f}/cosnark_proof.1.proof --recursive  $PIPE"  || failed=1&
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out test_vectors/${f}/cosnark_proof.2.proof --recursive $PIPE"  || failed=1
 #   wait $(jobs -p)
 #   # Create verification key
-#   bash -c "cargo run --release --bin co-noir -- create-vk --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --recursive --vk test_vectors/${f}/cosnark_vk $PIPE"  || failed=1
+#   bash -c "cargo run --release --bin co-noir -- create-vk --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --hasher keccak --recursive --vk test_vectors/${f}/cosnark_vk $PIPE"  || failed=1
 #   # verify proof
-#   bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --hasher KECCAK --crs test_vectors/bn254_g2.dat $PIPE"  || failed=1
+#   bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --hasher keccak --crs test_vectors/bn254_g2.dat $PIPE"  || failed=1
 
 #     if [ "$failed" -ne 0 ]
 #   then
@@ -197,12 +197,12 @@
 
 #   echo "proving and verifying with ZK in co-noir and keccak transcript"
 #   # run proving in MPC with ZK
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --recursive --public-input public_input --zk $PIPE"  || failed=1&
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out test_vectors/${f}/cosnark_proof.1.proof --recursive --zk $PIPE"  || failed=1&
-#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out test_vectors/${f}/cosnark_proof.2.proof --recursive --zk $PIPE"  || failed=1
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.0.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out test_vectors/${f}/cosnark_proof --recursive --public-input public_input --zk $PIPE"  || failed=1&
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.1.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out test_vectors/${f}/cosnark_proof.1.proof --recursive --zk $PIPE"  || failed=1&
+#   bash -c "cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/${f}/${f}.gz.2.shared --circuit test_vectors/${f}/target/${f}.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out test_vectors/${f}/cosnark_proof.2.proof --recursive --zk $PIPE"  || failed=1
 #   wait $(jobs -p)
 #   # verify proof
-#   bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --hasher KECCAK --crs test_vectors/bn254_g2.dat --has-zk $PIPE"  || failed=1
+#   bash -c "cargo run --release --bin co-noir -- verify --proof test_vectors/${f}/cosnark_proof --vk test_vectors/${f}/cosnark_vk --hasher keccak --crs test_vectors/bn254_g2.dat --has-zk $PIPE"  || failed=1
 
 #     if [ "$failed" -ne 0 ]
 #   then

--- a/co-noir/co-noir/examples/run_all_steps_poseidon.sh
+++ b/co-noir/co-noir/examples/run_all_steps_poseidon.sh
@@ -10,11 +10,11 @@ cargo run --release --bin co-noir -- build-proving-key --witness test_vectors/po
 cargo run --release --bin co-noir -- build-proving-key --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json  --protocol REP3 --config configs/party2.toml --out proving_key.1.shared &
 cargo run --release --bin co-noir -- build-proving-key --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json  --protocol REP3 --config configs/party3.toml --out proving_key.2.shared
 # run proving in MPC
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.0.shared --protocol REP3 --hasher KECCAK --config configs/party1.toml --crs test_vectors/bn254_g1.dat --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.1.shared --protocol REP3 --hasher KECCAK --config configs/party2.toml --crs test_vectors/bn254_g1.dat --out proof.1.proof &
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.2.shared --protocol REP3 --hasher KECCAK --config configs/party3.toml --crs test_vectors/bn254_g1.dat --out proof.2.proof
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.0.shared --protocol REP3 --hasher keccak --config configs/party1.toml --crs test_vectors/bn254_g1.dat --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.1.shared --protocol REP3 --hasher keccak --config configs/party2.toml --crs test_vectors/bn254_g1.dat --out proof.1.proof &
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.2.shared --protocol REP3 --hasher keccak --config configs/party3.toml --crs test_vectors/bn254_g1.dat --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/poseidon/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/poseidon/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_all_steps_poseidon_shamir.sh
+++ b/co-noir/co-noir/examples/run_all_steps_poseidon_shamir.sh
@@ -15,11 +15,11 @@ cargo run --release --bin co-noir -- build-proving-key --witness test_vectors/po
 cargo run --release --bin co-noir -- build-proving-key --witness test_vectors/poseidon/shamir_poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --protocol SHAMIR --config configs/party2.toml --out proving_key.1.shared &
 cargo run --release --bin co-noir -- build-proving-key --witness test_vectors/poseidon/shamir_poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --protocol SHAMIR --config configs/party3.toml --out proving_key.2.shared
 # run proving in MPC
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.0.shared --protocol SHAMIR --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.1.shared --protocol SHAMIR --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.2.shared --protocol SHAMIR --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.0.shared --protocol SHAMIR --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.1.shared --protocol SHAMIR --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.2.shared --protocol SHAMIR --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/poseidon/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/poseidon/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_build_and_proof_only_add3.sh
+++ b/co-noir/co-noir/examples/run_build_and_proof_only_add3.sh
@@ -1,11 +1,11 @@
 # split input into shares
 cargo run --release --bin co-noir -- split-witness --witness test_vectors/add3/add3.gz --circuit test_vectors/add3/add3.json --protocol REP3 --out-dir test_vectors/add3
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.0.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.1.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.2.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.0.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.1.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.2.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/add3/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/add3/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/add3/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/add3/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_build_and_proof_only_add3_shamir.sh
+++ b/co-noir/co-noir/examples/run_build_and_proof_only_add3_shamir.sh
@@ -1,11 +1,11 @@
 # split input into shares
 cargo run --release --bin co-noir -- split-witness --witness test_vectors/add3/add3.gz --circuit test_vectors/add3/add3.json --protocol SHAMIR --out-dir test_vectors/add3
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.0.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.1.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.2.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.0.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.1.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.2.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/add3/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/add3/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/add3/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/add3/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_build_and_proof_only_blackbox_poseidon_shamir.sh
+++ b/co-noir/co-noir/examples/run_build_and_proof_only_blackbox_poseidon_shamir.sh
@@ -1,11 +1,11 @@
 # split input into shares
 cargo run --release --bin co-noir -- split-witness --witness test_vectors/blackbox_poseidon2/blackbox_poseidon2.gz --circuit test_vectors/blackbox_poseidon2/blackbox_poseidon2.json --protocol SHAMIR --out-dir test_vectors/blackbox_poseidon2
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/blackbox_poseidon2/blackbox_poseidon2.gz.0.shared --circuit test_vectors/blackbox_poseidon2/blackbox_poseidon2.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/blackbox_poseidon2/blackbox_poseidon2.gz.1.shared --circuit test_vectors/blackbox_poseidon2/blackbox_poseidon2.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/blackbox_poseidon2/blackbox_poseidon2.gz.2.shared --circuit test_vectors/blackbox_poseidon2/blackbox_poseidon2.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/blackbox_poseidon2/blackbox_poseidon2.gz.0.shared --circuit test_vectors/blackbox_poseidon2/blackbox_poseidon2.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/blackbox_poseidon2/blackbox_poseidon2.gz.1.shared --circuit test_vectors/blackbox_poseidon2/blackbox_poseidon2.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/blackbox_poseidon2/blackbox_poseidon2.gz.2.shared --circuit test_vectors/blackbox_poseidon2/blackbox_poseidon2.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/blackbox_poseidon2/blackbox_poseidon2.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/blackbox_poseidon2/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/blackbox_poseidon2/blackbox_poseidon2.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/blackbox_poseidon2/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/blackbox_poseidon2/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/blackbox_poseidon2/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_build_and_proof_only_poseidon.sh
+++ b/co-noir/co-noir/examples/run_build_and_proof_only_poseidon.sh
@@ -1,11 +1,11 @@
 # split input into shares
 cargo run --release --bin co-noir -- split-witness --witness test_vectors/poseidon/poseidon.gz --circuit test_vectors/poseidon/poseidon.json --protocol REP3 --out-dir test_vectors/poseidon
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/poseidon/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/poseidon/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_build_and_proof_only_poseidon_shamir.sh
+++ b/co-noir/co-noir/examples/run_build_and_proof_only_poseidon_shamir.sh
@@ -1,11 +1,11 @@
 # split input into shares
 cargo run --release --bin co-noir -- split-witness --witness test_vectors/poseidon/poseidon.gz --circuit test_vectors/poseidon/poseidon.json --protocol SHAMIR --out-dir test_vectors/poseidon
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/poseidon/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/poseidon/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_full_add3.sh
+++ b/co-noir/co-noir/examples/run_full_add3.sh
@@ -12,11 +12,11 @@ cargo run --release --bin co-noir -- generate-witness --input test_vectors/add3/
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/add3/Prover.toml.2.shared --circuit test_vectors/add3/add3.json --protocol REP3 --config configs/party3.toml --out test_vectors/add3/add3.gz.2.shared
 wait $(jobs -p)
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.0.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.1.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.2.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.0.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.1.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3/add3.gz.2.shared --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/add3/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3/add3.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/add3/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/add3/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/add3/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_full_add3_assert.sh
+++ b/co-noir/co-noir/examples/run_full_add3_assert.sh
@@ -6,11 +6,11 @@ cargo run --release --bin co-noir -- generate-witness --input test_vectors/add3_
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/add3_assert/Prover.toml.2.shared --circuit test_vectors/add3_assert/add3_assert.json --protocol REP3 --config configs/party3.toml --out test_vectors/add3_assert/add3_assert.gz.2.shared
 wait $(jobs -p)
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3_assert/add3_assert.gz.0.shared --circuit test_vectors/add3_assert/add3_assert.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3_assert/add3_assert.gz.1.shared --circuit test_vectors/add3_assert/add3_assert.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3_assert/add3_assert.gz.2.shared --circuit test_vectors/add3_assert/add3_assert.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3_assert/add3_assert.gz.0.shared --circuit test_vectors/add3_assert/add3_assert.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3_assert/add3_assert.gz.1.shared --circuit test_vectors/add3_assert/add3_assert.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3_assert/add3_assert.gz.2.shared --circuit test_vectors/add3_assert/add3_assert.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3_assert/add3_assert.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/add3_assert/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3_assert/add3_assert.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/add3_assert/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/add3_assert/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/add3_assert/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_full_add3u64.sh
+++ b/co-noir/co-noir/examples/run_full_add3u64.sh
@@ -6,11 +6,11 @@ cargo run --release --bin co-noir -- generate-witness --input test_vectors/add3u
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/add3u64/Prover.toml.2.shared --circuit test_vectors/add3u64/add3u64.json --protocol REP3 --config configs/party3.toml --out test_vectors/add3u64/add3u64.gz.2.shared
 wait $(jobs -p)
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3u64/add3u64.gz.0.shared --circuit test_vectors/add3u64/add3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3u64/add3u64.gz.1.shared --circuit test_vectors/add3u64/add3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3u64/add3u64.gz.2.shared --circuit test_vectors/add3u64/add3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3u64/add3u64.gz.0.shared --circuit test_vectors/add3u64/add3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3u64/add3u64.gz.1.shared --circuit test_vectors/add3u64/add3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/add3u64/add3u64.gz.2.shared --circuit test_vectors/add3u64/add3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3u64/add3u64.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/add3u64/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/add3u64/add3u64.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/add3u64/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/add3u64/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/add3u64/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_full_mul3u64.sh
+++ b/co-noir/co-noir/examples/run_full_mul3u64.sh
@@ -6,11 +6,11 @@ cargo run --release --bin co-noir -- generate-witness --input test_vectors/mul3u
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/mul3u64/Prover.toml.2.shared --circuit test_vectors/mul3u64/mul3u64.json --protocol REP3 --config configs/party3.toml --out test_vectors/mul3u64/mul3u64.gz.2.shared
 wait $(jobs -p)
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/mul3u64/mul3u64.gz.0.shared --circuit test_vectors/mul3u64/mul3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/mul3u64/mul3u64.gz.1.shared --circuit test_vectors/mul3u64/mul3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/mul3u64/mul3u64.gz.2.shared --circuit test_vectors/mul3u64/mul3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/mul3u64/mul3u64.gz.0.shared --circuit test_vectors/mul3u64/mul3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/mul3u64/mul3u64.gz.1.shared --circuit test_vectors/mul3u64/mul3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/mul3u64/mul3u64.gz.2.shared --circuit test_vectors/mul3u64/mul3u64.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/mul3u64/mul3u64.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/mul3u64/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/mul3u64/mul3u64.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/mul3u64/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/mul3u64/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/mul3u64/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_full_poseidon.sh
+++ b/co-noir/co-noir/examples/run_full_poseidon.sh
@@ -6,11 +6,11 @@ cargo run --release --bin co-noir -- generate-witness --input test_vectors/posei
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon/Prover.toml.2.shared --circuit test_vectors/poseidon/poseidon.json --protocol REP3 --config configs/party3.toml --out test_vectors/poseidon/poseidon.gz.2.shared
 wait $(jobs -p)
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/poseidon/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/poseidon/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_full_poseidon_input2_with_merge.sh
+++ b/co-noir/co-noir/examples/run_full_poseidon_input2_with_merge.sh
@@ -11,11 +11,11 @@ cargo run --release --bin co-noir -- generate-witness --input test_vectors/posei
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon_input2/Prover.toml.2.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --protocol REP3 --config configs/party3.toml --out test_vectors/poseidon_input2/poseidon_input2.gz.2.shared
 wait $(jobs -p)
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon_input2/poseidon_input2.gz.0.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon_input2/poseidon_input2.gz.1.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon_input2/poseidon_input2.gz.2.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon_input2/poseidon_input2.gz.0.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon_input2/poseidon_input2.gz.1.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon_input2/poseidon_input2.gz.2.shared --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/poseidon_input2/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon_input2/poseidon_input2.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/poseidon_input2/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon_input2/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon_input2/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_full_poseidon_with_poseidon.sh
+++ b/co-noir/co-noir/examples/run_full_poseidon_with_poseidon.sh
@@ -6,11 +6,11 @@ cargo run --release --bin co-noir -- generate-witness --input test_vectors/posei
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/poseidon/Prover.toml.2.shared --circuit test_vectors/poseidon/poseidon.json --protocol REP3 --config configs/party3.toml --out test_vectors/poseidon/poseidon.gz.2.shared
 wait $(jobs -p)
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher POSEIDON --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher poseidon2 --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher POSEIDON --vk test_vectors/poseidon/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher poseidon2 --vk test_vectors/poseidon/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher POSEIDON --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher poseidon2 --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_full_poseidon_with_shamir.sh
+++ b/co-noir/co-noir/examples/run_full_poseidon_with_shamir.sh
@@ -11,11 +11,11 @@ cargo run --release --bin co-noir -- translate-witness --witness test_vectors/po
 cargo run --release --bin co-noir -- translate-witness --witness test_vectors/poseidon/poseidon.gz.2.shared --src-protocol REP3 --target-protocol SHAMIR --config configs/party3.toml --out test_vectors/poseidon/shamir_poseidon.gz.2.shared
 wait $(jobs -p)
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/shamir_poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/shamir_poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/shamir_poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/shamir_poseidon.gz.0.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/shamir_poseidon.gz.1.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/poseidon/shamir_poseidon.gz.2.shared --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/poseidon/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/poseidon/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_full_quantized.sh
+++ b/co-noir/co-noir/examples/run_full_quantized.sh
@@ -6,11 +6,11 @@ cargo run --release --bin co-noir -- generate-witness --input test_vectors/quant
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/quantized/Prover.toml.2.shared --circuit test_vectors/quantized/quantized.json --protocol REP3 --config configs/party3.toml --out test_vectors/quantized/quantized.gz.2.shared
 wait $(jobs -p)
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/quantized/quantized.gz.0.shared --circuit test_vectors/quantized/quantized.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/quantized/quantized.gz.1.shared --circuit test_vectors/quantized/quantized.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/quantized/quantized.gz.2.shared --circuit test_vectors/quantized/quantized.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/quantized/quantized.gz.0.shared --circuit test_vectors/quantized/quantized.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/quantized/quantized.gz.1.shared --circuit test_vectors/quantized/quantized.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/quantized/quantized.gz.2.shared --circuit test_vectors/quantized/quantized.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/quantized/quantized.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/quantized/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/quantized/quantized.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/quantized/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/quantized/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/quantized/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_full_ranges.sh
+++ b/co-noir/co-noir/examples/run_full_ranges.sh
@@ -6,11 +6,11 @@ cargo run --release --bin co-noir -- generate-witness --input test_vectors/range
 cargo run --release --bin co-noir -- generate-witness --input test_vectors/ranges/Prover.toml.2.shared --circuit test_vectors/ranges/ranges.json --protocol REP3 --config configs/party3.toml --out test_vectors/ranges/ranges.gz.2.shared
 wait $(jobs -p)
 # run proving in MPC
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/ranges/ranges.gz.0.shared --circuit test_vectors/ranges/ranges.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/ranges/ranges.gz.1.shared --circuit test_vectors/ranges/ranges.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/ranges/ranges.gz.2.shared --circuit test_vectors/ranges/ranges.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher KECCAK --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/ranges/ranges.gz.0.shared --circuit test_vectors/ranges/ranges.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/ranges/ranges.gz.1.shared --circuit test_vectors/ranges/ranges.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- build-and-generate-proof --witness test_vectors/ranges/ranges.gz.2.shared --circuit test_vectors/ranges/ranges.json --crs test_vectors/bn254_g1.dat --protocol REP3 --hasher keccak --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/ranges/ranges.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/ranges/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/ranges/ranges.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/ranges/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/ranges/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/ranges/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_proof_only_poseidon.sh
+++ b/co-noir/co-noir/examples/run_proof_only_poseidon.sh
@@ -1,11 +1,11 @@
 # split proving_key into shares
 cargo run --release --bin co-noir -- split-proving-key --witness test_vectors/poseidon/poseidon.gz --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol REP3 --out-dir .
 # run proving in MPC
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.0.shared --protocol REP3 --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.1.shared --protocol REP3 --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.2.shared --protocol REP3 --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.0.shared --protocol REP3 --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.1.shared --protocol REP3 --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.2.shared --protocol REP3 --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/poseidon/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/poseidon/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_proof_only_poseidon_shamir.sh
+++ b/co-noir/co-noir/examples/run_proof_only_poseidon_shamir.sh
@@ -1,11 +1,11 @@
 # split proving_key into shares
 cargo run --release --bin co-noir -- split-proving-key --witness test_vectors/poseidon/poseidon.gz --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --protocol SHAMIR --out-dir .
 # run proving in MPC
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.0.shared --protocol SHAMIR --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.1.shared --protocol SHAMIR --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.2.shared --protocol SHAMIR --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.0.shared --protocol SHAMIR --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.1.shared --protocol SHAMIR --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- generate-proof --proving-key proving_key.2.shared --protocol SHAMIR --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/poseidon/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/poseidon/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/examples/run_translate_proving_key.sh
+++ b/co-noir/co-noir/examples/run_translate_proving_key.sh
@@ -6,11 +6,11 @@ cargo run --release --bin co-noir -- translate-proving-key --proving-key proving
 cargo run --release --bin co-noir -- translate-proving-key --proving-key proving_key.2.shared --src-protocol REP3 --target-protocol SHAMIR --config configs/party3.toml --out shamir_proving_key.2.shared
 wait $(jobs -p)
 # run proving in MPC
-cargo run --release --bin co-noir -- generate-proof --proving-key shamir_proving_key.0.shared --protocol SHAMIR --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party1.toml --out proof.0.proof --public-input public_input &
-cargo run --release --bin co-noir -- generate-proof --proving-key shamir_proving_key.1.shared --protocol SHAMIR --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party2.toml --out proof.1.proof &
-cargo run --release --bin co-noir -- generate-proof --proving-key shamir_proving_key.2.shared --protocol SHAMIR --hasher KECCAK --crs test_vectors/bn254_g1.dat --config configs/party3.toml --out proof.2.proof
+cargo run --release --bin co-noir -- generate-proof --proving-key shamir_proving_key.0.shared --protocol SHAMIR --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party1.toml --out proof.0.proof --public-input public_input &
+cargo run --release --bin co-noir -- generate-proof --proving-key shamir_proving_key.1.shared --protocol SHAMIR --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party2.toml --out proof.1.proof &
+cargo run --release --bin co-noir -- generate-proof --proving-key shamir_proving_key.2.shared --protocol SHAMIR --hasher keccak --crs test_vectors/bn254_g1.dat --config configs/party3.toml --out proof.2.proof
 wait $(jobs -p)
 # Create verification key
-cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher KECCAK --vk test_vectors/poseidon/verification_key
+cargo run --release --bin co-noir -- create-vk --circuit test_vectors/poseidon/poseidon.json --crs test_vectors/bn254_g1.dat --hasher keccak --vk test_vectors/poseidon/verification_key
 # verify proof
-cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher KECCAK --crs test_vectors/bn254_g2.dat
+cargo run --release --bin co-noir -- verify --proof proof.0.proof --public-input public_input --vk test_vectors/poseidon/verification_key --hasher keccak --crs test_vectors/bn254_g2.dat

--- a/co-noir/co-noir/src/bin/co-noir.rs
+++ b/co-noir/co-noir/src/bin/co-noir.rs
@@ -42,10 +42,10 @@ pub enum MPCProtocol {
 
 /// An enum representing the transcript hasher to use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ValueEnum)]
-#[clap(rename_all = "UPPER")]
+#[clap(rename_all = "lower")]
 pub enum TranscriptHash {
     /// The Poseidon2 sponge hash function
-    POSEIDON,
+    POSEIDON2,
     // The Keccak256 hash function
     KECCAK,
 }
@@ -62,8 +62,8 @@ impl std::fmt::Display for MPCProtocol {
 impl std::fmt::Display for TranscriptHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TranscriptHash::POSEIDON => write!(f, "POSEIDON"),
-            TranscriptHash::KECCAK => write!(f, "KECCAK"),
+            TranscriptHash::POSEIDON2 => write!(f, "poseidon2"),
+            TranscriptHash::KECCAK => write!(f, "keccak"),
         }
     }
 }
@@ -1379,7 +1379,7 @@ fn run_generate_proof(config: GenerateProofConfig) -> color_eyre::Result<ExitCod
             )?;
 
             match hasher {
-                TranscriptHash::POSEIDON => {
+                TranscriptHash::POSEIDON2 => {
                     // execute prover in MPC
                     let start = Instant::now();
                     let (proof, public_inputs, net) =
@@ -1428,7 +1428,7 @@ fn run_generate_proof(config: GenerateProofConfig) -> color_eyre::Result<ExitCod
 
             // execute prover in MPC
             match hasher {
-                TranscriptHash::POSEIDON => {
+                TranscriptHash::POSEIDON2 => {
                     let start = Instant::now();
                     let (proof, public_input, net) =
                         ShamirCoUltraHonk::<_, _, Poseidon2Sponge>::prove(
@@ -1608,7 +1608,7 @@ fn run_build_and_generate_proof(
 
             tracing::info!("Starting proof generation...");
             let (proof, public_input) = match hasher {
-                TranscriptHash::POSEIDON => {
+                TranscriptHash::POSEIDON2 => {
                     let start = Instant::now();
                     let (proof, public_input, net) =
                         Rep3CoUltraHonk::<_, _, Poseidon2Sponge>::prove(
@@ -1660,7 +1660,7 @@ fn run_build_and_generate_proof(
 
             tracing::info!("Starting proof generation...");
             let (proof, public_input) = match hasher {
-                TranscriptHash::POSEIDON => {
+                TranscriptHash::POSEIDON2 => {
                     let start = Instant::now();
                     let (proof, public_input, net) =
                         ShamirCoUltraHonk::<_, _, Poseidon2Sponge>::prove(
@@ -1835,7 +1835,7 @@ fn run_generate_vk(config: CreateVKConfig) -> color_eyre::Result<ExitCode> {
     }
 
     let vk_u8 = match hasher {
-        TranscriptHash::POSEIDON => vk.to_buffer(),
+        TranscriptHash::POSEIDON2 => vk.to_buffer(),
         TranscriptHash::KECCAK => vk.to_buffer_keccak(),
     };
     out_file
@@ -1879,7 +1879,7 @@ fn run_verify(config: VerifyConfig) -> color_eyre::Result<ExitCode> {
     tracing::info!("Starting proof verification...");
     let start = Instant::now();
     let res = match hasher {
-        TranscriptHash::POSEIDON => {
+        TranscriptHash::POSEIDON2 => {
             UltraHonk::<_, Poseidon2Sponge>::verify(proof, &public_inputs, &vk, has_zk)
                 .context("while verifying proof")?
         }


### PR DESCRIPTION
`bb` with `--oracle_hash` accepts `"poseidon2", "keccak", "starknet"`
`co-noir` with `--hasher` accepts `"POSEIDON", "KECCAK"`

This PR makes `co-noir` with `--hasher` accept `"poseidon2", "keccak"`.