### PR TITLE
ci: add GITHUB_TOKEN env to CI to allow more downloads via github API

### DIFF
--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -30,6 +30,8 @@ jobs:
         run: cargo generate-lockfile
       - name: cargo test --locked
         run: cargo test --profile=ci-dev --locked --all-features --all-targets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # https://twitter.com/alcuadrado/status/1571291687837732873
   update:
     runs-on: ubuntu-latest
@@ -53,6 +55,7 @@ jobs:
         run: cargo test --profile=ci-dev --locked --all-features --all-targets
         env:
           RUSTFLAGS: -D deprecated
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   nightly-lints:
     name: Nightly lints
     runs-on: ubuntu-latest
@@ -67,10 +70,14 @@ jobs:
         run: |
           cargo clippy --workspace --tests --examples --benches -q --color=never 2> clippy.txt
           sed -i '/^remote: Hello from chartered/d' clippy.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build documentation
         id: nightly-doc
         run: |
           cargo doc --workspace --no-deps -q --color=never 2> doc.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Write to Job Summary
         id: report
         shell: bash

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -30,5 +30,9 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build documentation
         run: cargo doc --workspace --no-deps
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Test with default features
         run: cargo test --workspace --profile ci-dev --all-features
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   test-groth16-examples:
     name: Test groth16 examples
     runs-on: ubuntu-latest
@@ -40,6 +42,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Test groth16 examples
         run: cd co-circom/co-circom/examples/groth16 && ./run.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   test-plonk-examples:
     name: Test plonk examples
     runs-on: ubuntu-latest
@@ -52,6 +56,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Test plonk examples
         run: cd co-circom/co-circom/examples/plonk && ./run.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   test-noir-examples:
     name: Test noir examples
     runs-on: ubuntu-latest
@@ -64,3 +70,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Test noir examples
         run: cd co-noir/co-noir/examples && ./run.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
not sure if [release.yml](https://github.com/TaceoLabs/co-snarks/blob/main/.github/workflows/release.yml) also needs the token?