### PR TITLE
feat: Rep3 to Shamir bridge now does not require communication

### DIFF
--- a/co-circom/co-circom/src/lib.rs
+++ b/co-circom/co-circom/src/lib.rs
@@ -10,7 +10,7 @@ use circom_mpc_vm::{
 use co_circom_types::{CompressedRep3SharedWitness, Rep3InputType, ShamirInputType, SharedWitness};
 use color_eyre::eyre::{self, Context};
 use mpc_core::protocols::{
-    rep3::{self, Rep3ShareVecType},
+    rep3::{self, Rep3ShareVecType, id::PartyID},
     shamir::{ShamirPreprocessing, ShamirState},
 };
 use mpc_core::uint::FieldUint;
@@ -95,20 +95,40 @@ pub fn translate_witness<F: PrimeField, N: Network>(
     witness: CompressedRep3SharedWitness<F>,
     net: &N,
 ) -> eyre::Result<ShamirSharedWitness<F>> {
-    let witness = SharedWitness::from(witness);
-    // init MPC protocol
-    let num_parties = 3;
-    let threshold = 1;
-    let num_pairs = witness.witness.len();
-    let preprocessing = ShamirPreprocessing::new(num_parties, threshold, num_pairs, net)
-        .context("while shamir preprocessing")?;
-    let mut protocol = ShamirState::from(preprocessing);
-    // Translate witness to shamir shares
-    let translated_witness = protocol
-        .translate_primefield_addshare_vec(witness.witness, net)
-        .context("while translating witness")?;
-    let shamir_witness_share: ShamirSharedWitness<F> = SharedWitness {
-        public_inputs: witness.public_inputs,
+    let public_inputs = witness.public_inputs;
+    let translated_witness = match witness.witness {
+        Rep3ShareVecType::Replicated(vec) => {
+            ShamirState::translate_primefield_repshare_vec(vec, PartyID::try_from(net.id())?)
+        }
+        Rep3ShareVecType::SeededReplicated(replicated_seed_type) => {
+            let vec = replicated_seed_type.expand_vec()?;
+            ShamirState::translate_primefield_repshare_vec(vec, PartyID::try_from(net.id())?)
+        }
+        Rep3ShareVecType::Additive(vec) => {
+            // init MPC protocol
+            let preprocessing = ShamirPreprocessing::new(3, 1, vec.len(), net)
+                .context("while shamir preprocessing")?;
+            let mut protocol = ShamirState::from(preprocessing);
+            // Translate witness to shamir shares
+            protocol
+                .translate_primefield_addshare_vec(vec, net)
+                .context("while translating witness")?
+        }
+        Rep3ShareVecType::SeededAdditive(seeded_type) => {
+            let vec = seeded_type.expand_vec();
+            // init MPC protocol
+            let preprocessing = ShamirPreprocessing::new(3, 1, vec.len(), net)
+                .context("while shamir preprocessing")?;
+            let mut protocol = ShamirState::from(preprocessing);
+            // Translate witness to shamir shares
+            protocol
+                .translate_primefield_addshare_vec(vec, net)
+                .context("while translating witness")?
+        }
+    };
+
+    let shamir_witness_share = SharedWitness {
+        public_inputs,
         witness: translated_witness,
     };
 

--- a/co-noir/co-noir/src/bin/co-noir.rs
+++ b/co-noir/co-noir/src/bin/co-noir.rs
@@ -18,6 +18,7 @@ use figment::{
     Figment,
     providers::{Env, Format, Serialized, Toml},
 };
+use mpc_core::protocols::rep3::id::PartyID;
 use mpc_net::config::NetworkConfig;
 use mpc_net::config::NetworkConfigFile;
 use mpc_net::tcp::TcpNetwork;
@@ -1230,13 +1231,11 @@ fn run_translate_witness(config: TranslateWitnessConfig) -> color_eyre::Result<E
     let witness_share: Vec<Rep3Type<ark_bn254::Fr>> =
         bincode::deserialize_from(witness_file).context("while deserializing witness share")?;
 
-    // connect to network
-    let net = TcpNetwork::new(network_config).context("while connecting to network")?;
-
     // Translate witness to shamir shares
     tracing::info!("Starting witness translation...");
+    let id = PartyID::try_from(network_config.my_id)?;
     let start = Instant::now();
-    let shamir_witness_shares = co_noir::translate_witness(witness_share, &net)?;
+    let shamir_witness_shares = co_noir::translate_witness(witness_share, id);
     let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
     tracing::info!("Translate witness took {duration_ms} ms");
 
@@ -1265,13 +1264,11 @@ fn run_translate_proving_key(config: TranslateProvingKeyConfig) -> color_eyre::R
     let proving_key: ProvingKey<Rep3UltraHonkDriver, Bn254G1> =
         bincode::deserialize_from(proving_key_file).context("while deserializing witness share")?;
 
-    // connect to network
-    let net = TcpNetwork::new(network_config).context("while connecting to network")?;
-
     // Translate proving key to shamir shares
+    let id = PartyID::try_from(network_config.my_id)?;
     tracing::info!("Starting proving key translation...");
     let start = Instant::now();
-    let shamir_proving_key = co_noir::translate_proving_key(proving_key, &net)?;
+    let shamir_proving_key = co_noir::translate_proving_key(proving_key, id)?;
     let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
     tracing::info!("Translate proving key took {duration_ms} ms");
 

--- a/co-noir/co-noir/src/lib.rs
+++ b/co-noir/co-noir/src/lib.rs
@@ -120,7 +120,6 @@ pub fn translate_witness<F: PrimeField>(
 }
 
 /// Translate a REP3 shared proving key to a shamir shared proving key
-#[allow(clippy::complexity)]
 pub fn translate_proving_key<P: HonkCurve<TranscriptFieldType>>(
     proving_key: Rep3ProvingKey<P>,
     id: PartyID,

--- a/co-noir/co-noir/src/lib.rs
+++ b/co-noir/co-noir/src/lib.rs
@@ -90,10 +90,10 @@ pub fn generate_witness_rep3<N: Network>(
 }
 
 /// Translate a REP3 shared witness to a shamir shared witness
-pub fn translate_witness<F: PrimeField, N: Network>(
+pub fn translate_witness<F: PrimeField>(
     witness_share: Rep3SharedWitness<F>,
-    net: &N,
-) -> Result<ShamirSharedWitness<F>> {
+    id: PartyID,
+) -> ShamirSharedWitness<F> {
     // extract shares only
     let mut shares = vec![];
     for share in witness_share.iter() {
@@ -102,15 +102,8 @@ pub fn translate_witness<F: PrimeField, N: Network>(
         }
     }
 
-    let num_parties = 3;
-    let threshold = 1;
-    let num_pairs = shares.len();
-    let preprocessing = ShamirPreprocessing::new(num_parties, threshold, num_pairs, net)
-        .context("while shamir preprocessing")?;
-    let mut state = ShamirState::from(preprocessing);
-
     // Translate witness to shamir shares
-    let translated_shares = state.translate_primefield_repshare_vec(shares, net)?;
+    let translated_shares = ShamirState::translate_primefield_repshare_vec(shares, id);
 
     let mut result = Vec::with_capacity(witness_share.len());
     let mut iter = translated_shares.into_iter();
@@ -123,15 +116,14 @@ pub fn translate_witness<F: PrimeField, N: Network>(
             }
         }
     }
-
-    Ok(result)
+    result
 }
 
 /// Translate a REP3 shared proving key to a shamir shared proving key
 #[allow(clippy::complexity)]
-pub fn translate_proving_key<P: HonkCurve<TranscriptFieldType>, N: Network>(
+pub fn translate_proving_key<P: HonkCurve<TranscriptFieldType>>(
     proving_key: Rep3ProvingKey<P>,
-    net: &N,
+    id: PartyID,
 ) -> Result<ShamirProvingKey<P>>
 where
     P::ScalarField: FieldUint,
@@ -145,15 +137,8 @@ where
         .flat_map(|el| el.into_vec().into_iter())
         .collect::<Vec<_>>();
 
-    let num_parties = 3;
-    let threshold = 1;
-    let num_pairs = shares.len();
-    let preprocessing = ShamirPreprocessing::new(num_parties, threshold, num_pairs, net)
-        .context("while shamir preprocessing")?;
-    let mut state = ShamirState::from(preprocessing);
-
     // Translate witness to shamir shares
-    let translated_shares = state.translate_primefield_repshare_vec(shares, net)?;
+    let translated_shares = ShamirState::translate_primefield_repshare_vec(shares, id);
 
     if translated_shares.len() != PROVER_WITNESS_ENTITIES_SIZE * proving_key.circuit_size as usize {
         eyre::bail!("Invalid number of shares translated");

--- a/mpc-core/Cargo.toml
+++ b/mpc-core/Cargo.toml
@@ -1,19 +1,23 @@
 [package]
 name = "mpc-core"
 version = "0.10.0"
-publish.workspace = true
 authors.workspace = true
 edition.workspace = true
-repository.workspace = true
-homepage.workspace = true
-license.workspace = true
 rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-default = []
-dangerous = []
+[[bench]]
+harness = false
+name = "local_mul_vec"
+
+[[bench]]
+harness = false
+name = "rep3_to_shamir"
 
 [dependencies]
 ark-bls12-377 = { workspace = true }
@@ -27,29 +31,28 @@ bytes = { workspace = true }
 eyre = { workspace = true }
 fancy-garbling = { git = "https://github.com/GaloisInc/swanky", rev = "5ff648457218b74da9d8323b7ca47166ff5be4b3" }
 itertools = { workspace = true }
-mpc-net = { version = "0.5.0", path = "../mpc-net", default-features = false }
+mpc-net = { path = "../mpc-net", version = "0.5.0", default-features = false }
+nom = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
-scuttlebutt = { git = "https://github.com/GaloisInc/swanky", rev = "5ff648457218b74da9d8323b7ca47166ff5be4b3" }
-subtle = { workspace = true }
-serde = { workspace = true }
-taceo-ark-algebra = { workspace = true }
-sha3 = { workspace = true }
-tracing.workspace = true
-thiserror = { workspace = true }
-nom = { workspace = true }
 ruint = { workspace = true, features = ["ark-ff-06", "num-bigint"] }
+scuttlebutt = { git = "https://github.com/GaloisInc/swanky", rev = "5ff648457218b74da9d8323b7ca47166ff5be4b3" }
+serde = { workspace = true }
+sha3 = { workspace = true }
+subtle = { workspace = true }
+taceo-ark-algebra = { workspace = true }
+thiserror = { workspace = true }
+tracing.workspace = true
 
 [dev-dependencies]
 bincode = { workspace = true }
-mpc-net = { version = "0.5.0", path = "../mpc-net", features = ["local"] }
-paste.workspace = true
 criterion.workspace = true
+mpc-net = { path = "../mpc-net", version = "0.5.0", features = ["local"] }
+paste.workspace = true
 
-[[bench]]
-name = "local_mul_vec"
-harness = false
-
+[features]
+default = []
+dangerous = []

--- a/mpc-core/benches/rep3_to_shamir.rs
+++ b/mpc-core/benches/rep3_to_shamir.rs
@@ -1,0 +1,71 @@
+use ark_bn254::Fr;
+use ark_ff::{Field, UniformRand};
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
+};
+use mpc_core::protocols::{
+    rep3::{Rep3PrimeFieldShare, id::PartyID},
+    shamir::{ShamirPrimeFieldShare, ShamirState},
+};
+use rand::thread_rng;
+
+fn benchmark_translation(c: &mut Criterion) {
+    let available_threads = std::thread::available_parallelism().map_or(1, usize::from);
+    let mut thread_counts = vec![1, 8, available_threads];
+    thread_counts.sort_unstable();
+    thread_counts.dedup();
+
+    for threads in thread_counts {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .unwrap();
+        let mut group = c.benchmark_group(format!("rep3_to_shamir/{threads}_threads"));
+
+        for size in [256, 4096, 65536, 1_048_576] {
+            let mut rng = thread_rng();
+            let input = (0..size)
+                .map(|_| Rep3PrimeFieldShare::new(Fr::rand(&mut rng), Fr::rand(&mut rng)))
+                .collect::<Vec<_>>();
+            group.throughput(Throughput::Elements(size as u64));
+
+            group.bench_with_input(BenchmarkId::new("serial", size), &input, |b, input| {
+                b.iter_batched(
+                    || input.clone(),
+                    |input| black_box(translate_serial(black_box(input))),
+                    BatchSize::LargeInput,
+                )
+            });
+            group.bench_with_input(BenchmarkId::new("adaptive", size), &input, |b, input| {
+                b.iter_batched(
+                    || input.clone(),
+                    |input| {
+                        pool.install(|| {
+                            black_box(ShamirState::translate_primefield_repshare_vec(
+                                black_box(input),
+                                PartyID::ID0,
+                            ))
+                        })
+                    },
+                    BatchSize::LargeInput,
+                )
+            });
+        }
+        group.finish();
+    }
+}
+
+fn translate_serial(input: Vec<Rep3PrimeFieldShare<Fr>>) -> Vec<ShamirPrimeFieldShare<Fr>> {
+    // Translation coefficients for party 0, computed once as in the production implementation.
+    let x = Fr::from(2_u64) * Fr::from(3_u64).inverse().unwrap();
+    let y = Fr::from(2_u64).inverse().unwrap();
+    input
+        .into_iter()
+        .map(|share| ShamirPrimeFieldShare {
+            a: share.a * x + share.b * y,
+        })
+        .collect()
+}
+
+criterion_group!(benches, benchmark_translation);
+criterion_main!(benches);

--- a/mpc-core/src/protocols/bridges/rep3_to_shamir.rs
+++ b/mpc-core/src/protocols/bridges/rep3_to_shamir.rs
@@ -5,6 +5,10 @@ use crate::protocols::{
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use mpc_net::Network;
+use rayon::prelude::*;
+
+const PARALLEL_TRANSLATION_THRESHOLD: usize = 4096;
+const PARALLEL_TRANSLATION_MIN_LEN: usize = 1024;
 
 impl<F: PrimeField> ShamirState<F> {
     fn get_translation_points(id: PartyID) -> (F, F) {
@@ -42,12 +46,19 @@ impl<F: PrimeField> ShamirState<F> {
     ) -> Vec<ShamirPrimeFieldShare<F>> {
         let (x, y) = Self::get_translation_points(id);
 
-        input
-            .into_iter()
-            .map(|rep_share| ShamirPrimeFieldShare {
-                a: rep_share.a * x + rep_share.b * y,
-            })
-            .collect::<Vec<_>>()
+        let translate = |rep_share: Rep3PrimeFieldShare<F>| ShamirPrimeFieldShare {
+            a: rep_share.a * x + rep_share.b * y,
+        };
+
+        if input.len() < PARALLEL_TRANSLATION_THRESHOLD {
+            input.into_iter().map(translate).collect()
+        } else {
+            input
+                .into_par_iter()
+                .with_min_len(PARALLEL_TRANSLATION_MIN_LEN)
+                .map(translate)
+                .collect()
+        }
     }
 
     /// Translate a 3-party additive prime field share into a 3-party Shamir prime field share, where the underlying sharing polynomial is of degree 1 (i.e., the threshold t = 1).

--- a/mpc-core/src/protocols/rep3/arithmetic/types.rs
+++ b/mpc-core/src/protocols/rep3/arithmetic/types.rs
@@ -68,10 +68,16 @@ impl<F: PrimeField> Rep3PrimeFieldShare<F> {
 
     /// Promotes a public field element to a replicated share by setting the additive share of the party with id=0 and leaving all other shares to be 0. Thus, the replicated shares of party 0 and party 1 are set.
     pub fn promote_from_trivial(val: &F, id: PartyID) -> Self {
+        Self::promote_from_trivial_with_scalar(val, &F::zero(), id)
+    }
+
+    /// Promotes a public field element to a replicated share with additive shares `val` for party 0, `scalar` for party 1, and `-scalar` for party 2, which sum to `val`.
+    pub fn promote_from_trivial_with_scalar(val: &F, scalar: &F, id: PartyID) -> Self {
+        let neg_scalar = -*scalar;
         match id {
-            PartyID::ID0 => Self::new(*val, F::zero()),
-            PartyID::ID1 => Self::new(F::zero(), *val),
-            PartyID::ID2 => Self::zero_share(),
+            PartyID::ID0 => Self::new(*val, neg_scalar),
+            PartyID::ID1 => Self::new(*scalar, *val),
+            PartyID::ID2 => Self::new(neg_scalar, *scalar),
         }
     }
 }

--- a/tests/tests/mpc/bridges.rs
+++ b/tests/tests/mpc/bridges.rs
@@ -2,10 +2,9 @@ mod translate_share {
     use ark_std::UniformRand;
     use itertools::Itertools;
     use mpc_core::protocols::{
-        rep3::{self},
-        shamir::{self, ShamirPreprocessing, ShamirState},
+        rep3::{self, id::PartyID},
+        shamir::{self, ShamirState},
     };
-    use mpc_net::local::LocalNetwork;
     use rand::thread_rng;
     use std::{sync::mpsc, thread};
 
@@ -13,35 +12,36 @@ mod translate_share {
 
     #[test]
     fn fieldshare() {
-        let nets = LocalNetwork::new_3_parties();
         let mut rng = thread_rng();
         let x = ark_bn254::Fr::rand(&mut rng);
         let x_shares = rep3::share_field_element(x, &mut rng);
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
+        for (i, (tx, x)) in [tx1, tx2, tx3].into_iter().zip(x_shares).enumerate() {
             thread::spawn(move || {
-                let preprocessing = ShamirPreprocessing::new(3, 1, 1, &net).unwrap();
-                let mut shamir = ShamirState::from(preprocessing);
-                let share = shamir.translate_primefield_repshare(x, &net);
-                tx.send(share.unwrap())
+                let share =
+                    ShamirState::translate_primefield_repshare(x, PartyID::try_from(i).unwrap());
+                tx.send(share)
             });
         }
         let result1 = rx1.recv().unwrap();
         let result2 = rx2.recv().unwrap();
         let result3 = rx3.recv().unwrap();
 
-        let is_result =
-            shamir::combine_field_element(&[result1, result2, result3], &(1..=3).collect_vec(), 1)
-                .unwrap();
+        let is_result0 =
+            shamir::combine_field_element(&[result1, result2], &(1..3).collect_vec(), 1).unwrap();
+        let is_result1 =
+            shamir::combine_field_element(&[result2, result3], &(2..=3).collect_vec(), 1).unwrap();
+        let is_result2 = shamir::combine_field_element(&[result1, result3], &[1, 3], 1).unwrap();
 
-        assert_eq!(is_result, x);
+        assert_eq!(is_result0, x);
+        assert_eq!(is_result1, x);
+        assert_eq!(is_result2, x);
     }
 
     #[test]
     fn fieldshare_vec() {
-        let nets = LocalNetwork::new_3_parties();
         let mut rng = thread_rng();
         let x = (0..VEC_SIZE)
             .map(|_| ark_bn254::Fr::rand(&mut rng))
@@ -50,50 +50,61 @@ mod translate_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
+        for (i, (tx, x)) in [tx1, tx2, tx3].into_iter().zip(x_shares).enumerate() {
             thread::spawn(move || {
-                let preprecessing = ShamirPreprocessing::new(3, 1, x.len(), &net).unwrap();
-                let mut shamir = ShamirState::from(preprecessing);
-                let share = shamir.translate_primefield_repshare_vec(x, &net);
-                tx.send(share.unwrap())
+                let share = ShamirState::translate_primefield_repshare_vec(
+                    x,
+                    PartyID::try_from(i).unwrap(),
+                );
+                tx.send(share)
             });
         }
         let result1 = rx1.recv().unwrap();
         let result2 = rx2.recv().unwrap();
         let result3 = rx3.recv().unwrap();
 
-        let is_result =
-            shamir::combine_field_elements(&[result1, result2, result3], &(1..=3).collect_vec(), 1)
+        let is_result0 = shamir::combine_field_elements(
+            &[result1.clone(), result2.clone()],
+            &(1..3).collect_vec(),
+            1,
+        )
+        .unwrap();
+        let is_result1 =
+            shamir::combine_field_elements(&[result2, result3.clone()], &(2..=3).collect_vec(), 1)
                 .unwrap();
+        let is_result2 = shamir::combine_field_elements(&[result1, result3], &[1, 3], 1).unwrap();
 
-        assert_eq!(is_result, x);
+        assert_eq!(is_result0, x);
+        assert_eq!(is_result1, x);
+        assert_eq!(is_result2, x);
     }
 
     #[test]
     fn pointshare() {
-        let nets = LocalNetwork::new_3_parties();
         let mut rng = thread_rng();
         let x = ark_bn254::G1Projective::rand(&mut rng);
         let x_shares = rep3::share_curve_point(x, &mut rng);
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
+        for (i, (tx, x)) in [tx1, tx2, tx3].into_iter().zip(x_shares).enumerate() {
             thread::spawn(move || {
-                let preprecessing = ShamirPreprocessing::new(3, 1, 1, &net).unwrap();
-                let mut shamir = ShamirState::from(preprecessing);
-                let share = shamir.translate_point_repshare(x, &net);
-                tx.send(share.unwrap())
+                let share = ShamirState::translate_point_repshare(x, PartyID::try_from(i).unwrap());
+                tx.send(share)
             });
         }
         let result1 = rx1.recv().unwrap();
         let result2 = rx2.recv().unwrap();
         let result3 = rx3.recv().unwrap();
 
-        let is_result =
-            shamir::combine_curve_point(&[result1, result2, result3], &(1..=3).collect_vec(), 1)
-                .unwrap();
+        let is_result0 =
+            shamir::combine_curve_point(&[result1, result2], &(1..3).collect_vec(), 1).unwrap();
+        let is_result1 =
+            shamir::combine_curve_point(&[result2, result3], &(2..=3).collect_vec(), 1).unwrap();
+        let is_result2 = shamir::combine_curve_point(&[result1, result3], &[1, 3], 1).unwrap();
 
-        assert_eq!(is_result, x);
+        assert_eq!(is_result0, x);
+        assert_eq!(is_result1, x);
+        assert_eq!(is_result2, x);
     }
 }

--- a/tests/tests/mpc/bridges.rs
+++ b/tests/tests/mpc/bridges.rs
@@ -8,8 +8,6 @@ mod translate_share {
     use rand::thread_rng;
     use std::{sync::mpsc, thread};
 
-    const VEC_SIZE: usize = 10;
-
     #[test]
     fn fieldshare() {
         let mut rng = thread_rng();
@@ -43,40 +41,44 @@ mod translate_share {
     #[test]
     fn fieldshare_vec() {
         let mut rng = thread_rng();
-        let x = (0..VEC_SIZE)
-            .map(|_| ark_bn254::Fr::rand(&mut rng))
-            .collect_vec();
-        let x_shares = rep3::share_field_elements(&x, &mut rng);
-        let (tx1, rx1) = mpsc::channel();
-        let (tx2, rx2) = mpsc::channel();
-        let (tx3, rx3) = mpsc::channel();
-        for (i, (tx, x)) in [tx1, tx2, tx3].into_iter().zip(x_shares).enumerate() {
-            thread::spawn(move || {
-                let share = ShamirState::translate_primefield_repshare_vec(
-                    x,
-                    PartyID::try_from(i).unwrap(),
+        for size in [0, 10, 4095, 4096, 16384] {
+            let secrets = (0..size)
+                .map(|_| ark_bn254::Fr::rand(&mut rng))
+                .collect_vec();
+            let rep3_shares = rep3::share_field_elements(&secrets, &mut rng);
+            let mut translated = Vec::with_capacity(3);
+
+            for (party, shares) in rep3_shares.into_iter().enumerate() {
+                let id = PartyID::try_from(party).unwrap();
+                let expected = shares
+                    .iter()
+                    .map(|share| ShamirState::translate_primefield_repshare(*share, id))
+                    .collect_vec();
+                let actual = ShamirState::translate_primefield_repshare_vec(shares, id);
+
+                assert_eq!(
+                    actual, expected,
+                    "translation mismatch for party {party}, size {size}"
                 );
-                tx.send(share)
-            });
-        }
-        let result1 = rx1.recv().unwrap();
-        let result2 = rx2.recv().unwrap();
-        let result3 = rx3.recv().unwrap();
+                translated.push(actual);
+            }
 
-        let is_result0 = shamir::combine_field_elements(
-            &[result1.clone(), result2.clone()],
-            &(1..3).collect_vec(),
-            1,
-        )
-        .unwrap();
-        let is_result1 =
-            shamir::combine_field_elements(&[result2, result3.clone()], &(2..=3).collect_vec(), 1)
+            for (parties, points) in [([0, 1], [1, 2]), ([1, 2], [2, 3]), ([0, 2], [1, 3])] {
+                let reconstructed = shamir::combine_field_elements(
+                    &[
+                        translated[parties[0]].clone(),
+                        translated[parties[1]].clone(),
+                    ],
+                    &points,
+                    1,
+                )
                 .unwrap();
-        let is_result2 = shamir::combine_field_elements(&[result1, result3], &[1, 3], 1).unwrap();
-
-        assert_eq!(is_result0, x);
-        assert_eq!(is_result1, x);
-        assert_eq!(is_result2, x);
+                assert_eq!(
+                    reconstructed, secrets,
+                    "reconstruction mismatch for size {size}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core MPC share translation math and APIs used when bridging REP3 witnesses/keys to Shamir proving; incorrect coefficients would break proofs without obvious runtime errors.
> 
> **Overview**
> **REP3 replicated shares can be converted to Shamir (t=1) shares locally** by applying fixed per-party coefficients (`get_translation_points`) to each `Rep3PrimeFieldShare` / point share, instead of Shamir preprocessing and `degree_reduce` over the network.
> 
> `translate_primefield_repshare`, `translate_primefield_repshare_vec`, and `translate_point_repshare` are now static-style APIs taking `PartyID` only (no `ShamirState` mut + `Network`). Vector translation uses **rayon** when length ≥ 4096. **Additive** REP3 witness encodings still use the old networked `translate_primefield_addshare_vec` path in `co-circom`.
> 
> **co-noir** witness and proving-key translation drop TCP setup and call the local translators with `PartyID` from network config. **co-circom** `translate_witness` matches on `Rep3ShareVecType` for replicated vs additive paths.
> 
> Supporting changes: `promote_from_trivial_with_scalar` on REP3 field shares, expanded bridge tests (sizes including parallel threshold), and a `rep3_to_shamir` criterion bench (serial vs adaptive).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f57fe6d468e591f3fad0777d6b320600f273121b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->