### PR TITLE
refactor: agree on a common name for batched MPC operations

### DIFF
--- a/co-circom/circom-mpc-vm/src/mpc/batched_rep3.rs
+++ b/co-circom/circom-mpc-vm/src/mpc/batched_rep3.rs
@@ -154,7 +154,7 @@ impl<F: PrimeField, N: Network> VmCircomWitnessExtension<F>
                 .collect_vec()
                 .into()),
             (BatchedRep3VmType::Arithmetic(a), BatchedRep3VmType::Arithmetic(b)) => {
-                Ok(arithmetic::mul_vec(&a, &b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::mul_many(&a, &b, self.net0, &mut self.state0)?.into())
             }
         }
     }

--- a/co-circom/co-groth16/src/groth16.rs
+++ b/co-circom/co-groth16/src/groth16.rs
@@ -280,7 +280,7 @@ impl<P: Pairing, T: CircomGroth16Prover<P>> CoGroth16<P, T> {
         );
 
         let rs_span = tracing::debug_span!("r*s without networking").entered();
-        let rs = T::local_mul_vec(vec![r], vec![s], state0).pop().unwrap();
+        let rs = T::local_mul_many(vec![r], vec![s], state0).pop().unwrap();
         let r_s_delta_g1 = T::scalar_mul_public_point_hs(&delta_g1, rs);
         rs_span.exit();
 

--- a/co-circom/co-groth16/src/groth16/reduction.rs
+++ b/co-circom/co-groth16/src/groth16/reduction.rs
@@ -139,7 +139,7 @@ impl R1CSToQAP for CircomReduction {
             },
             || {
                 let local_mul_vec_span = tracing::debug_span!("c: local_mul_vec").entered();
-                let mut ab = T::local_mul_vec(a, b, state);
+                let mut ab = T::local_mul_many(a, b, state);
                 local_mul_vec_span.exit();
                 let ifft_span = tracing::debug_span!("c: ifft in dist pows").entered();
                 domain.ifft_in_place(&mut ab);
@@ -161,7 +161,7 @@ impl R1CSToQAP for CircomReduction {
 
         let local_ab_span = tracing::debug_span!("ab: local_mul_vec").entered();
         // same as above. No IO task is run at the moment.
-        let mut ab = T::local_mul_vec(a, b, state);
+        let mut ab = T::local_mul_many(a, b, state);
         local_ab_span.exit();
         let compute_ab_span = tracing::debug_span!("compute ab").entered();
         ab.par_iter_mut()
@@ -262,7 +262,7 @@ impl R1CSToQAP for LibSnarkReduction {
                         b
                     },
                 );
-                T::local_mul_vec(a, b, state)
+                T::local_mul_many(a, b, state)
             },
             || {
                 let mut c = evaluate_constraint_half_share::<P, T>(

--- a/co-circom/co-groth16/src/mpc.rs
+++ b/co-circom/co-groth16/src/mpc.rs
@@ -80,7 +80,7 @@ pub trait CircomGroth16Prover<P: Pairing>: Send + Sized {
     ///
     /// # Security
     /// You must *NOT* perform additional non-linear operations on the result of this function.
-    fn local_mul_vec(
+    fn local_mul_many(
         a: Vec<Self::ArithmeticShare>,
         b: Vec<Self::ArithmeticShare>,
         state: &mut Self::State,

--- a/co-circom/co-groth16/src/mpc/plain.rs
+++ b/co-circom/co-groth16/src/mpc/plain.rs
@@ -79,7 +79,7 @@ impl<P: Pairing> CircomGroth16Prover<P> for PlainGroth16Driver {
         public_values.to_vec()
     }
 
-    fn local_mul_vec(
+    fn local_mul_many(
         a: Vec<Self::ArithmeticShare>,
         b: Vec<Self::ArithmeticShare>,
         _: &mut Self::State,

--- a/co-circom/co-groth16/src/mpc/rep3.rs
+++ b/co-circom/co-groth16/src/mpc/rep3.rs
@@ -83,12 +83,12 @@ impl<P: Pairing> CircomGroth16Prover<P> for Rep3Groth16Driver {
             .collect()
     }
 
-    fn local_mul_vec(
+    fn local_mul_many(
         a: Vec<Self::ArithmeticShare>,
         b: Vec<Self::ArithmeticShare>,
         state: &mut Self::State,
     ) -> Vec<P::ScalarField> {
-        arithmetic::local_mul_vec(&a, &b, state)
+        arithmetic::local_mul_many(&a, &b, state)
     }
 
     fn distribute_powers_and_mul_by_const(

--- a/co-circom/co-groth16/src/mpc/shamir.rs
+++ b/co-circom/co-groth16/src/mpc/shamir.rs
@@ -73,12 +73,12 @@ impl<P: Pairing> CircomGroth16Prover<P> for ShamirGroth16Driver {
         arithmetic::promote_to_trivial_shares(public_values)
     }
 
-    fn local_mul_vec(
+    fn local_mul_many(
         a: Vec<Self::ArithmeticShare>,
         b: Vec<Self::ArithmeticShare>,
         _: &mut Self::State,
     ) -> Vec<P::ScalarField> {
-        arithmetic::local_mul_vec(&a, &b)
+        arithmetic::local_mul_many(&a, &b)
     }
 
     fn distribute_powers_and_mul_by_const(

--- a/co-circom/co-plonk/src/mpc.rs
+++ b/co-circom/co-plonk/src/mpc.rs
@@ -53,15 +53,15 @@ pub trait CircomPlonkProver<P: Pairing> {
     ///
     /// # Security
     /// If you want to perform additional non-linear operations on the result of this function,
-    /// you *MUST* call [`CircomPlonkProver::io_round_mul_vec`] first. Only then the relevant network round is performed.
-    fn local_mul_vec(
+    /// you *MUST* call [`CircomPlonkProver::io_round_mul_many`] first. Only then the relevant network round is performed.
+    fn local_mul_many(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         state: &mut Self::State,
     ) -> Vec<P::ScalarField>;
 
-    /// Performs networking round of `local_mul_vec`
-    fn io_round_mul_vec<N: Network>(
+    /// Performs networking round of `local_mul_many`
+    fn io_round_mul_many<N: Network>(
         a: Vec<P::ScalarField>,
         net: &N,
         state: &mut Self::State,
@@ -69,8 +69,8 @@ pub trait CircomPlonkProver<P: Pairing> {
 
     /// Performs element-wise multiplication of two vectors of shared values.
     ///
-    /// Use this function for small vecs. For large vecs see [`CircomPlonkProver::local_mul_vec`]
-    fn mul_vec<N: Network>(
+    /// Use this function for small vecs. For large vecs see [`CircomPlonkProver::local_mul_many`]
+    fn mul_many<N: Network>(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         net: &N,
@@ -79,8 +79,8 @@ pub trait CircomPlonkProver<P: Pairing> {
 
     /// Performs element-wise multiplication of three vectors of shared values.
     ///
-    /// Use this function for small vecs. For large vecs see [`CircomPlonkProver::local_mul_vec`]
-    fn mul_vecs<N: Network>(
+    /// Use this function for small vecs. For large vecs see [`CircomPlonkProver::local_mul_many`]
+    fn mul_many_pairs<N: Network>(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         c: &[Self::ArithmeticShare],
@@ -89,7 +89,7 @@ pub trait CircomPlonkProver<P: Pairing> {
     ) -> eyre::Result<Vec<Self::ArithmeticShare>>;
 
     /// Convenience method for \[a\] + \[b\] * \[c\]
-    fn add_mul_vec<N: Network>(
+    fn add_mul_many<N: Network>(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         c: &[Self::ArithmeticShare],

--- a/co-circom/co-plonk/src/mpc/plain.rs
+++ b/co-circom/co-plonk/src/mpc/plain.rs
@@ -51,7 +51,7 @@ impl<P: Pairing> CircomPlonkProver<P> for PlainPlonkDriver {
         }
     }
 
-    fn local_mul_vec(
+    fn local_mul_many(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         _: &mut Self::State,
@@ -59,7 +59,7 @@ impl<P: Pairing> CircomPlonkProver<P> for PlainPlonkDriver {
         izip!(a, b).map(|(a, b)| *a * *b).collect()
     }
 
-    fn io_round_mul_vec<N: Network>(
+    fn io_round_mul_many<N: Network>(
         a: Vec<P::ScalarField>,
         _: &N,
         _: &mut Self::State,
@@ -74,7 +74,7 @@ impl<P: Pairing> CircomPlonkProver<P> for PlainPlonkDriver {
         shared * public
     }
 
-    fn mul_vec<N: Network>(
+    fn mul_many<N: Network>(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         _: &N,
@@ -83,7 +83,7 @@ impl<P: Pairing> CircomPlonkProver<P> for PlainPlonkDriver {
         Ok(izip!(a, b).map(|(a, b)| *a * *b).collect())
     }
 
-    fn mul_vecs<N: Network>(
+    fn mul_many_pairs<N: Network>(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         c: &[Self::ArithmeticShare],
@@ -93,7 +93,7 @@ impl<P: Pairing> CircomPlonkProver<P> for PlainPlonkDriver {
         Ok(izip!(a, b, c).map(|(a, b, c)| *a * *b * *c).collect())
     }
 
-    fn add_mul_vec<N: Network>(
+    fn add_mul_many<N: Network>(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         c: &[Self::ArithmeticShare],

--- a/co-circom/co-plonk/src/mpc/rep3.rs
+++ b/co-circom/co-plonk/src/mpc/rep3.rs
@@ -52,15 +52,15 @@ impl<P: Pairing> CircomPlonkProver<P> for Rep3PlonkDriver {
         arithmetic::mul_public(shared, public)
     }
 
-    fn local_mul_vec(
+    fn local_mul_many(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         state: &mut Self::State,
     ) -> Vec<P::ScalarField> {
-        arithmetic::local_mul_vec::<P::ScalarField>(a, b, state)
+        arithmetic::local_mul_many::<P::ScalarField>(a, b, state)
     }
 
-    fn io_round_mul_vec<N: Network>(
+    fn io_round_mul_many<N: Network>(
         a: Vec<P::ScalarField>,
         net: &N,
         _: &mut Self::State,
@@ -68,35 +68,35 @@ impl<P: Pairing> CircomPlonkProver<P> for Rep3PlonkDriver {
         arithmetic::reshare_vec(a, net)
     }
 
-    fn mul_vec<N: Network>(
+    fn mul_many<N: Network>(
         lhs: &[Self::ArithmeticShare],
         rhs: &[Self::ArithmeticShare],
         net: &N,
         state: &mut Self::State,
     ) -> eyre::Result<Vec<Self::ArithmeticShare>> {
-        arithmetic::mul_vec(lhs, rhs, net, state)
+        arithmetic::mul_many(lhs, rhs, net, state)
     }
 
-    fn mul_vecs<N: Network>(
+    fn mul_many_pairs<N: Network>(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         c: &[Self::ArithmeticShare],
         net: &N,
         state: &mut Self::State,
     ) -> eyre::Result<Vec<Self::ArithmeticShare>> {
-        let tmp = arithmetic::mul_vec(a, b, net, state)?;
-        arithmetic::mul_vec(&tmp, c, net, state)
+        let tmp = arithmetic::mul_many(a, b, net, state)?;
+        arithmetic::mul_many(&tmp, c, net, state)
     }
 
-    fn add_mul_vec<N: Network>(
+    fn add_mul_many<N: Network>(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         c: &[Self::ArithmeticShare],
         net: &N,
         state: &mut Self::State,
     ) -> eyre::Result<Vec<Self::ArithmeticShare>> {
-        let mut result = arithmetic::mul_vec(b, c, net, state)?;
-        arithmetic::add_vec_assign(&mut result, a);
+        let mut result = arithmetic::mul_many(b, c, net, state)?;
+        arithmetic::add_many_assign(&mut result, a);
         Ok(result)
     }
 
@@ -187,8 +187,8 @@ impl<P: Pairing> CircomPlonkProver<P> for Rep3PlonkDriver {
         net: &N,
         state: &mut Self::State,
     ) -> eyre::Result<Vec<Self::ArithmeticShare>> {
-        let arr = arithmetic::mul_vec(arr1, arr2, net, state)?;
-        let arr = arithmetic::mul_vec(&arr, arr3, net, state)?;
+        let arr = arithmetic::mul_many(arr1, arr2, net, state)?;
+        let arr = arithmetic::mul_many(&arr, arr3, net, state)?;
         // Do the multiplications of inp[i] * inp[i-1] in constant rounds
         let len = arr.len();
 
@@ -198,9 +198,9 @@ impl<P: Pairing> CircomPlonkProver<P> for Rep3PlonkDriver {
         }
         let r_inv = arithmetic::inv_vec(&r, net, state)?;
         let r_inv0 = vec![r_inv[0]; len];
-        let mut unblind = arithmetic::mul_vec(&r_inv0, &r[1..], net, state)?;
+        let mut unblind = arithmetic::mul_many(&r_inv0, &r[1..], net, state)?;
 
-        let mul = arithmetic::mul_vec(&r[..len], &arr, net, state)?;
+        let mul = arithmetic::mul_many(&r[..len], &arr, net, state)?;
         let mut open = arithmetic::mul_open_vec(&mul, &r_inv[1..], net, state)?;
 
         for i in 1..open.len() {

--- a/co-circom/co-plonk/src/mpc/shamir.rs
+++ b/co-circom/co-plonk/src/mpc/shamir.rs
@@ -54,15 +54,15 @@ impl<P: Pairing> CircomPlonkProver<P> for ShamirPlonkDriver {
         arithmetic::mul_public(shared, public)
     }
 
-    fn local_mul_vec(
+    fn local_mul_many(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         _: &mut Self::State,
     ) -> Vec<P::ScalarField> {
-        arithmetic::local_mul_vec(a, b)
+        arithmetic::local_mul_many(a, b)
     }
 
-    fn io_round_mul_vec<N: Network>(
+    fn io_round_mul_many<N: Network>(
         a: Vec<P::ScalarField>,
         net: &N,
         state: &mut Self::State,
@@ -70,35 +70,35 @@ impl<P: Pairing> CircomPlonkProver<P> for ShamirPlonkDriver {
         net.degree_reduce_many(state, a)
     }
 
-    fn mul_vec<N: Network>(
+    fn mul_many<N: Network>(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         net: &N,
         state: &mut Self::State,
     ) -> eyre::Result<Vec<Self::ArithmeticShare>> {
-        arithmetic::mul_vec(a, b, net, state)
+        arithmetic::mul_many(a, b, net, state)
     }
 
-    fn mul_vecs<N: Network>(
+    fn mul_many_pairs<N: Network>(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         c: &[Self::ArithmeticShare],
         net: &N,
         state: &mut Self::State,
     ) -> eyre::Result<Vec<Self::ArithmeticShare>> {
-        let tmp = arithmetic::mul_vec(a, b, net, state)?;
-        arithmetic::mul_vec(&tmp, c, net, state)
+        let tmp = arithmetic::mul_many(a, b, net, state)?;
+        arithmetic::mul_many(&tmp, c, net, state)
     }
 
-    fn add_mul_vec<N: Network>(
+    fn add_mul_many<N: Network>(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         c: &[Self::ArithmeticShare],
         net: &N,
         state: &mut Self::State,
     ) -> eyre::Result<Vec<Self::ArithmeticShare>> {
-        let mut result = arithmetic::mul_vec(b, c, net, state)?;
-        arithmetic::add_vec_assign(&mut result, a);
+        let mut result = arithmetic::mul_many(b, c, net, state)?;
+        arithmetic::add_many_assign(&mut result, a);
         Ok(result)
     }
 
@@ -193,8 +193,8 @@ impl<P: Pairing> CircomPlonkProver<P> for ShamirPlonkDriver {
         net: &N,
         state: &mut Self::State,
     ) -> eyre::Result<Vec<Self::ArithmeticShare>> {
-        let arr = arithmetic::mul_vec(arr1, arr2, net, state)?;
-        let arr = arithmetic::mul_vec(&arr, arr3, net, state)?;
+        let arr = arithmetic::mul_many(arr1, arr2, net, state)?;
+        let arr = arithmetic::mul_many(&arr, arr3, net, state)?;
         // Do the multiplications of inp[i] * inp[i-1] in constant rounds
         let len = arr.len();
 
@@ -204,9 +204,9 @@ impl<P: Pairing> CircomPlonkProver<P> for ShamirPlonkDriver {
         }
         let r_inv = arithmetic::inv_vec(&r, net, state)?;
         let r_inv0 = vec![r_inv[0]; len];
-        let mut unblind = arithmetic::mul_vec(&r_inv0, &r[1..], net, state)?;
+        let mut unblind = arithmetic::mul_many(&r_inv0, &r[1..], net, state)?;
 
-        let mul = arithmetic::mul_vec(&r[..len], &arr, net, state)?;
+        let mul = arithmetic::mul_many(&r[..len], &arr, net, state)?;
         let mut open = arithmetic::mul_open_vec(&mul, &r_inv[1..], net, state)?;
 
         for i in 1..open.len() {

--- a/co-circom/co-plonk/src/round2.rs
+++ b/co-circom/co-plonk/src/round2.rs
@@ -167,7 +167,7 @@ impl<'a, P: Pairing, T: CircomPlonkProver<P>, N: Network + 'static> Round2<'a, P
         let num = num?;
         let den = den?;
 
-        let mut buffer_z = T::mul_vec(&num, &den, &nets[0], state)?;
+        let mut buffer_z = T::mul_many(&num, &den, &nets[0], state)?;
         buffer_z.rotate_right(1); // Required by SNARKJs/Plonk
         batched_mul_span.exit();
 

--- a/co-circom/co-plonk/src/round3.rs
+++ b/co-circom/co-plonk/src/round3.rs
@@ -29,14 +29,14 @@ macro_rules! mul4vec {
         let mut state7 = $state.fork($len)?;
 
         let (a_b, a_bp, ap_b, ap_bp, c_d, c_dp, cp_d, cp_dp) = mpc_net::join8(
-            || T::mul_vec($a, $b, &$nets[0], &mut state0),
-            || T::mul_vec($a, $bp, &$nets[1], &mut state1),
-            || T::mul_vec($ap, $b, &$nets[2], &mut state2),
-            || T::mul_vec($ap, $bp, &$nets[3], &mut state3),
-            || T::mul_vec($c, $d, &$nets[4], &mut state4),
-            || T::mul_vec($c, $dp, &$nets[5], &mut state5),
-            || T::mul_vec($cp, $d, &$nets[6], &mut state6),
-            || T::mul_vec($cp, $dp, &$nets[7], &mut state7),
+            || T::mul_many($a, $b, &$nets[0], &mut state0),
+            || T::mul_many($a, $bp, &$nets[1], &mut state1),
+            || T::mul_many($ap, $b, &$nets[2], &mut state2),
+            || T::mul_many($ap, $bp, &$nets[3], &mut state3),
+            || T::mul_many($c, $d, &$nets[4], &mut state4),
+            || T::mul_many($c, $dp, &$nets[5], &mut state5),
+            || T::mul_many($cp, $d, &$nets[6], &mut state6),
+            || T::mul_many($cp, $dp, &$nets[7], &mut state7),
         );
         let a_b = a_b?;
         let a_bp = a_bp?;
@@ -54,31 +54,31 @@ macro_rules! mul4vec {
         let mut state4 = $state.fork($len)?;
 
         let (r, a0, a1, a2, a3) = mpc_net::join5(
-            || T::mul_vec(&a_b, &c_d, &$nets[0], &mut state0),
+            || T::mul_many(&a_b, &c_d, &$nets[0], &mut state0),
             || {
-                let mut a0 = T::mul_vec(&ap_b, &c_d, &$nets[1], &mut state1)?;
-                a0 = T::add_mul_vec(&a0, &a_bp, &c_d, &$nets[1], &mut state1)?;
-                a0 = T::add_mul_vec(&a0, &a_b, &cp_d, &$nets[1], &mut state1)?;
-                a0 = T::add_mul_vec(&a0, &a_b, &c_dp, &$nets[1], &mut state1)?;
+                let mut a0 = T::mul_many(&ap_b, &c_d, &$nets[1], &mut state1)?;
+                a0 = T::add_mul_many(&a0, &a_bp, &c_d, &$nets[1], &mut state1)?;
+                a0 = T::add_mul_many(&a0, &a_b, &cp_d, &$nets[1], &mut state1)?;
+                a0 = T::add_mul_many(&a0, &a_b, &c_dp, &$nets[1], &mut state1)?;
                 eyre::Ok(a0)
             },
             || {
-                let mut a1 = T::mul_vec(&ap_bp, &c_d, &$nets[2], &mut state2)?;
-                a1 = T::add_mul_vec(&a1, &ap_b, &cp_d, &$nets[2], &mut state2)?;
-                a1 = T::add_mul_vec(&a1, &ap_b, &c_dp, &$nets[2], &mut state2)?;
-                a1 = T::add_mul_vec(&a1, &a_bp, &cp_d, &$nets[2], &mut state2)?;
-                a1 = T::add_mul_vec(&a1, &a_bp, &c_dp, &$nets[2], &mut state2)?;
-                a1 = T::add_mul_vec(&a1, &a_b, &cp_dp, &$nets[2], &mut state2)?;
+                let mut a1 = T::mul_many(&ap_bp, &c_d, &$nets[2], &mut state2)?;
+                a1 = T::add_mul_many(&a1, &ap_b, &cp_d, &$nets[2], &mut state2)?;
+                a1 = T::add_mul_many(&a1, &ap_b, &c_dp, &$nets[2], &mut state2)?;
+                a1 = T::add_mul_many(&a1, &a_bp, &cp_d, &$nets[2], &mut state2)?;
+                a1 = T::add_mul_many(&a1, &a_bp, &c_dp, &$nets[2], &mut state2)?;
+                a1 = T::add_mul_many(&a1, &a_b, &cp_dp, &$nets[2], &mut state2)?;
                 eyre::Ok(a1)
             },
             || {
-                let mut a2 = T::mul_vec(&a_bp, &cp_dp, &$nets[3], &mut state3)?;
-                a2 = T::add_mul_vec(&a2, &ap_b, &cp_dp, &$nets[3], &mut state3)?;
-                a2 = T::add_mul_vec(&a2, &ap_bp, &c_dp, &$nets[3], &mut state3)?;
-                a2 = T::add_mul_vec(&a2, &ap_bp, &cp_d, &$nets[3], &mut state3)?;
+                let mut a2 = T::mul_many(&a_bp, &cp_dp, &$nets[3], &mut state3)?;
+                a2 = T::add_mul_many(&a2, &ap_b, &cp_dp, &$nets[3], &mut state3)?;
+                a2 = T::add_mul_many(&a2, &ap_bp, &c_dp, &$nets[3], &mut state3)?;
+                a2 = T::add_mul_many(&a2, &ap_bp, &cp_d, &$nets[3], &mut state3)?;
                 eyre::Ok(a2)
             },
-            || T::mul_vec(&ap_bp, &cp_dp, &$nets[4], &mut state4),
+            || T::mul_many(&ap_bp, &cp_dp, &$nets[4], &mut state4),
         );
 
         eyre::Ok([r?, a0?, a1?, a2?, a3?])
@@ -282,16 +282,16 @@ impl<'a, P: Pairing, T: CircomPlonkProver<P>, N: Network + 'static> Round3<'a, P
         let mut state3 = state.fork(len)?;
         let (a_b, a_bp, ap_b, ap_bp) = mpc_net::join4(
             || {
-                T::mul_vec(
+                T::mul_many(
                     &polys.poly_eval_a.eval,
                     &polys.poly_eval_b.eval,
                     &nets[0],
                     &mut state0,
                 )
             },
-            || T::mul_vec(&polys.poly_eval_a.eval, &bp, &nets[1], &mut state1),
-            || T::mul_vec(&polys.poly_eval_b.eval, &ap, &nets[2], &mut state2),
-            || T::mul_vec(&ap, &bp, &nets[3], &mut state3),
+            || T::mul_many(&polys.poly_eval_a.eval, &bp, &nets[1], &mut state1),
+            || T::mul_many(&polys.poly_eval_b.eval, &ap, &nets[2], &mut state2),
+            || T::mul_many(&ap, &bp, &nets[3], &mut state3),
         );
         let a_b = a_b?;
         let a_bp = a_bp?;

--- a/co-noir/co-acvm/src/mpc/rep3.rs
+++ b/co-noir/co-acvm/src/mpc/rep3.rs
@@ -1451,7 +1451,7 @@ impl<'a, F: PrimeField, N: Network> NoirWitnessExtensionProtocol<F> for Rep3Acvm
                 // Set x,y to 0 of infinity is one.
                 // TODO is this even necesary?
                 let mul = arithmetic::sub_public_by_shared(ark_bn254::Fr::one(), i, self.id);
-                let res = arithmetic::mul_vec(&[x, y], &[mul, mul], self.net0, &mut self.state0)?;
+                let res = arithmetic::mul_many(&[x, y], &[mul, mul], self.net0, &mut self.state0)?;
 
                 let out_x = downcast::<_, Self::ArithmeticShare>(&res[0])
                     .expect("We checked types")
@@ -1512,7 +1512,7 @@ impl<'a, F: PrimeField, N: Network> NoirWitnessExtensionProtocol<F> for Rep3Acvm
                 // Set x,y to 0 of infinity is one.
                 // TODO is this even necesary?
                 let mul = arithmetic::sub_public_by_shared(F::one(), i, self.id);
-                let res = arithmetic::mul_vec(&[x, y], &[mul, mul], self.net0, &mut self.state0)?;
+                let res = arithmetic::mul_many(&[x, y], &[mul, mul], self.net0, &mut self.state0)?;
 
                 (res[0].into(), res[1].into(), i.into())
             }
@@ -1918,7 +1918,7 @@ impl<'a, F: PrimeField, N: Network> NoirWitnessExtensionProtocol<F> for Rep3Acvm
         // Set x,y to 0 of infinity is one.
         // TODO is this even necesary?
         let mul = arithmetic::sub_public_by_shared(F::one(), i, self.id);
-        let res = arithmetic::mul_vec(&[x, y], &[mul, mul], self.net0, &mut self.state0)?;
+        let res = arithmetic::mul_many(&[x, y], &[mul, mul], self.net0, &mut self.state0)?;
 
         Ok((res[0].into(), res[1].into(), i.into()))
     }

--- a/co-noir/co-ultrahonk/src/co_decider/relations/ultra_arithmetic_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/ultra_arithmetic_relation.rs
@@ -112,7 +112,7 @@ impl UltraArithmeticRelation {
         let neg_half = -P::ScalarField::from(2u64).inverse().unwrap();
         let three = P::ScalarField::from(3_u64);
 
-        let mul = T::local_mul_vec(w_l, w_r, state);
+        let mul = T::local_mul_many(w_l, w_r, state);
         let id = state.id();
         let tmp_l = (w_l, q_l)
             .into_par_iter()

--- a/co-noir/common/src/mpc/mod.rs
+++ b/co-noir/common/src/mpc/mod.rs
@@ -211,7 +211,7 @@ pub trait NoirUltraHonkProver<P: Pairing>: Send + Sized {
         }
     }
 
-    fn local_mul_vec(
+    fn local_mul_many(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         state: &mut Self::State,

--- a/co-noir/common/src/mpc/plain.rs
+++ b/co-noir/common/src/mpc/plain.rs
@@ -89,7 +89,7 @@ impl<P: Pairing> NoirUltraHonkProver<P> for PlainUltraHonkDriver {
         <Self as NoirUltraHonkProver<P>>::mul_with_public(public, shared)
     }
 
-    fn local_mul_vec(
+    fn local_mul_many(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         _state: &mut Self::State,

--- a/co-noir/common/src/mpc/rep3.rs
+++ b/co-noir/common/src/mpc/rep3.rs
@@ -28,7 +28,7 @@ impl<P: Pairing> NoirUltraHonkProver<P> for Rep3UltraHonkDriver {
     }
 
     fn sub_assign_many(a: &mut [Self::ArithmeticShare], b: &[Self::ArithmeticShare]) {
-        arithmetic::sub_vec_assign(a, b);
+        arithmetic::sub_many_assign(a, b);
     }
 
     fn add(a: Self::ArithmeticShare, b: Self::ArithmeticShare) -> Self::ArithmeticShare {
@@ -79,12 +79,12 @@ impl<P: Pairing> NoirUltraHonkProver<P> for Rep3UltraHonkDriver {
         public * shared.a
     }
 
-    fn local_mul_vec(
+    fn local_mul_many(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         state: &mut Self::State,
     ) -> Vec<P::ScalarField> {
-        arithmetic::local_mul_vec(a, b, state)
+        arithmetic::local_mul_many(a, b, state)
     }
 
     fn reshare<N: Network>(
@@ -101,7 +101,7 @@ impl<P: Pairing> NoirUltraHonkProver<P> for Rep3UltraHonkDriver {
         net: &N,
         state: &mut Self::State,
     ) -> eyre::Result<Vec<Self::ArithmeticShare>> {
-        arithmetic::mul_vec(a, b, net, state)
+        arithmetic::mul_many(a, b, net, state)
     }
 
     fn add_with_public(

--- a/co-noir/common/src/mpc/shamir.rs
+++ b/co-noir/common/src/mpc/shamir.rs
@@ -29,7 +29,7 @@ impl<P: Pairing> NoirUltraHonkProver<P> for ShamirUltraHonkDriver {
     }
 
     fn sub_assign_many(a: &mut [Self::ArithmeticShare], b: &[Self::ArithmeticShare]) {
-        arithmetic::sub_vec_assign(a, b);
+        arithmetic::sub_many_assign(a, b);
     }
 
     fn add(a: Self::ArithmeticShare, b: Self::ArithmeticShare) -> Self::ArithmeticShare {
@@ -78,12 +78,12 @@ impl<P: Pairing> NoirUltraHonkProver<P> for ShamirUltraHonkDriver {
         public * shared.inner()
     }
 
-    fn local_mul_vec(
+    fn local_mul_many(
         a: &[Self::ArithmeticShare],
         b: &[Self::ArithmeticShare],
         _: &mut Self::State,
     ) -> Vec<P::ScalarField> {
-        arithmetic::local_mul_vec(a, b)
+        arithmetic::local_mul_many(a, b)
     }
 
     fn reshare<N: Network>(
@@ -100,7 +100,7 @@ impl<P: Pairing> NoirUltraHonkProver<P> for ShamirUltraHonkDriver {
         net: &N,
         state: &mut Self::State,
     ) -> eyre::Result<Vec<Self::ArithmeticShare>> {
-        arithmetic::mul_vec(a, b, net, state)
+        arithmetic::mul_many(a, b, net, state)
     }
 
     fn add_with_public(

--- a/mpc-core/src/gadgets/poseidon2/rep3.rs
+++ b/mpc-core/src/gadgets/poseidon2/rep3.rs
@@ -23,8 +23,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         for _ in 0..num_sbox {
             r.push(arithmetic::rand(state));
         }
-        let r2 = arithmetic::mul_vec(&r, &r, net, state)?;
-        let r4 = arithmetic::mul_vec(&r2, &r2, net, state)?;
+        let r2 = arithmetic::mul_many(&r, &r, net, state)?;
+        let r4 = arithmetic::mul_many(&r2, &r2, net, state)?;
 
         let mut lhs = Vec::with_capacity(num_sbox * 2);
         let mut rhs = Vec::with_capacity(num_sbox * 2);
@@ -37,7 +37,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             rhs.push(r4);
         }
 
-        let mut r3 = arithmetic::mul_vec(&lhs, &rhs, net, state)?;
+        let mut r3 = arithmetic::mul_many(&lhs, &rhs, net, state)?;
         let r5 = r3.split_off(num_sbox);
 
         Ok(Poseidon2Precomputations {
@@ -434,10 +434,10 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
     ) -> eyre::Result<[F; T]> {
         assert_eq!(D, 5);
         // Square
-        let sq: Vec<Rep3PrimeFieldShare<F>> = arithmetic::mul_vec(input, input, net, state)?;
+        let sq: Vec<Rep3PrimeFieldShare<F>> = arithmetic::mul_many(input, input, net, state)?;
 
         // Quad
-        let qu = arithmetic::mul_vec(&sq, &sq, net, state)?;
+        let qu = arithmetic::mul_many(&sq, &sq, net, state)?;
 
         // Quint
         let res = array::from_fn(|i| qu[i] * input[i]);

--- a/mpc-core/src/gadgets/poseidon2/shamir.rs
+++ b/mpc-core/src/gadgets/poseidon2/shamir.rs
@@ -45,8 +45,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         for _ in 0..num_sbox {
             r.push(state.rand(net)?);
         }
-        let r2 = arithmetic::mul_vec(&r, &r, net, state)?;
-        let r4 = arithmetic::mul_vec(&r2, &r2, net, state)?;
+        let r2 = arithmetic::mul_many(&r, &r, net, state)?;
+        let r4 = arithmetic::mul_many(&r2, &r2, net, state)?;
 
         let mut lhs = Vec::with_capacity(num_sbox * 2);
         let mut rhs = Vec::with_capacity(num_sbox * 2);
@@ -59,7 +59,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             rhs.push(r4);
         }
 
-        let mut r3 = arithmetic::mul_vec(&lhs, &rhs, net, state)?;
+        let mut r3 = arithmetic::mul_many(&lhs, &rhs, net, state)?;
         let r5 = r3.split_off(num_sbox);
 
         Ok(Poseidon2Precomputations {

--- a/mpc-core/src/protocols/rep3/arithmetic.rs
+++ b/mpc-core/src/protocols/rep3/arithmetic.rs
@@ -59,7 +59,7 @@ pub fn add_assign_public<F: PrimeField>(shared: &mut FieldShare<F>, public: F, i
 }
 
 /// Performs element-wise addition of two vectors of shared values in place.
-pub fn add_vec_assign<F: PrimeField>(lhs: &mut [FieldShare<F>], rhs: &[FieldShare<F>]) {
+pub fn add_many_assign<F: PrimeField>(lhs: &mut [FieldShare<F>], rhs: &[FieldShare<F>]) {
     for (a, b) in izip!(lhs.iter_mut(), rhs.iter()) {
         *a += b;
     }
@@ -76,7 +76,7 @@ pub fn sub_assign<F: PrimeField>(shared: &mut FieldShare<F>, b: FieldShare<F>) {
 }
 
 /// Performs element-wise subtraction of two vectors of shared values in place.
-pub fn sub_vec_assign<F: PrimeField>(lhs: &mut [FieldShare<F>], rhs: &[FieldShare<F>]) {
+pub fn sub_many_assign<F: PrimeField>(lhs: &mut [FieldShare<F>], rhs: &[FieldShare<F>]) {
     for (a, b) in izip!(lhs.iter_mut(), rhs.iter()) {
         *a -= *b;
     }
@@ -130,7 +130,7 @@ pub fn mul_assign_public<F: PrimeField>(shared: &mut FieldShare<F>, public: F) {
 /// # Security
 /// If you want to perform additional non-linear operations on the result of this function,
 /// you *MUST* call [`reshare_vec`] first. Only then, a reshare is performed.
-pub fn local_mul_vec<F: PrimeField>(
+pub fn local_mul_many<F: PrimeField>(
     lhs: &[FieldShare<F>],
     rhs: &[FieldShare<F>],
     state: &mut Rep3State,
@@ -153,7 +153,7 @@ pub fn reshare_vec<F: PrimeField, N: Network>(
 ) -> eyre::Result<Vec<FieldShare<F>>> {
     let local_b = net.reshare_many(&local_a)?;
     if local_b.len() != local_a.len() {
-        eyre::bail!("During execution of mul_vec in MPC: Invalid number of elements received",);
+        eyre::bail!("During execution of mul_many in MPC: Invalid number of elements received",);
     }
     Ok(izip!(local_a, local_b)
         .map(|(a, b)| FieldShare::new(a, b))
@@ -162,8 +162,8 @@ pub fn reshare_vec<F: PrimeField, N: Network>(
 
 /// Performs element-wise multiplication of two vectors of shared values.
 ///
-/// Use this function for small vecs. For large vecs see [`local_mul_vec`] and [`reshare_vec`]
-pub fn mul_vec<F: PrimeField, N: Network>(
+/// Use this function for small vecs. For large vecs see [`local_mul_many`] and [`reshare_vec`]
+pub fn mul_many<F: PrimeField, N: Network>(
     lhs: &[FieldShare<F>],
     rhs: &[FieldShare<F>],
     net: &N,
@@ -377,7 +377,7 @@ pub fn sqrt<F: PrimeField, N: Network>(
     // parallel mul of rr with a and r_squ with r_inv
     let lhs = vec![rr, r_squ];
     let rhs = vec![share, r_inv];
-    let mul = mul_vec(&lhs, &rhs, net, state)?;
+            let mul = mul_many(&lhs, &rhs, net, state)?;
 
     // Open mul
     let c = net.reshare_many(&mul.iter().map(|s| s.b.to_owned()).collect_vec())?;

--- a/mpc-core/src/protocols/rep3_ring/arithmetic.rs
+++ b/mpc-core/src/protocols/rep3_ring/arithmetic.rs
@@ -60,7 +60,7 @@ pub fn add_assign_public<T: IntRing2k>(
 }
 
 /// Performs element-wise addition of two vectors of shared values in place.
-pub fn add_vec_assign<T: IntRing2k>(lhs: &mut [RingShare<T>], rhs: &[RingShare<T>]) {
+pub fn add_many_assign<T: IntRing2k>(lhs: &mut [RingShare<T>], rhs: &[RingShare<T>]) {
     for (a, b) in izip!(lhs.iter_mut(), rhs.iter()) {
         *a += b;
     }
@@ -77,7 +77,7 @@ pub fn sub_assign<T: IntRing2k>(shared: &mut RingShare<T>, b: RingShare<T>) {
 }
 
 /// Performs element-wise subtraction of two vectors of shared values in place.
-pub fn sub_vec_assign<T: IntRing2k>(lhs: &mut [RingShare<T>], rhs: &[RingShare<T>]) {
+pub fn sub_many_assign<T: IntRing2k>(lhs: &mut [RingShare<T>], rhs: &[RingShare<T>]) {
     for (a, b) in izip!(lhs.iter_mut(), rhs.iter()) {
         *a -= *b;
     }
@@ -134,7 +134,7 @@ pub fn mul_assign_public<T: IntRing2k>(shared: &mut RingShare<T>, public: RingEl
 /// # Security
 /// If you want to perform additional non-linear operations on the result of this function,
 /// you *MUST* call [`reshare_vec`] first. Only then, a reshare is performed.
-pub fn local_mul_vec<T: IntRing2k>(
+pub fn local_mul_many<T: IntRing2k>(
     lhs: &[RingShare<T>],
     rhs: &[RingShare<T>],
     state: &mut Rep3State,
@@ -172,8 +172,8 @@ pub fn reshare_vec<T: IntRing2k, N: Network>(
 
 /// Performs element-wise multiplication of two vectors of shared values.
 ///
-/// Use this function for small vecs. For large vecs see [`local_mul_vec`] and [`reshare_vec`]
-pub fn mul_vec<T: IntRing2k, N: Network>(
+/// Use this function for small vecs. For large vecs see [`local_mul_many`] and [`reshare_vec`]
+pub fn mul_many<T: IntRing2k, N: Network>(
     lhs: &[RingShare<T>],
     rhs: &[RingShare<T>],
     net: &N,
@@ -182,10 +182,10 @@ pub fn mul_vec<T: IntRing2k, N: Network>(
 where
     Standard: Distribution<T>,
 {
-    // do not use local_mul_vec here!!! We are , this means we
-    // run on a tokio runtime. local_mul_vec uses rayon and starves the
+    // do not use local_mul_many here!!! We are , this means we
+    // run on a tokio runtime. local_mul_many uses rayon and starves the
     // runtime. This method is for small multiplications of vecs.
-    // If you want a larger one use local_mul_vec and then reshare_vec.
+    // If you want a larger one use local_mul_many and then reshare_vec.
     debug_assert_eq!(lhs.len(), rhs.len());
     let local_a = izip!(lhs.iter(), rhs.iter())
         .map(|(lhs, rhs)| lhs * rhs + state.rngs.rand.masking_element::<RingElement<T>>())

--- a/mpc-core/src/protocols/rep3_ring/gadgets/sort.rs
+++ b/mpc-core/src/protocols/rep3_ring/gadgets/sort.rs
@@ -301,8 +301,8 @@ fn gen_bit_perm<N: Network>(
     }
 
     // Private inputs
-    let mul1 = arithmetic::local_mul_vec(&priv_f0, &s0[..priv_len], state);
-    let mul2 = arithmetic::local_mul_vec(&priv_f1, &s1[..priv_len], state);
+            let mul1 = arithmetic::local_mul_many(&priv_f0, &s0[..priv_len], state);
+        let mul2 = arithmetic::local_mul_many(&priv_f1, &s1[..priv_len], state);
     let perm_a = mul1.into_iter().zip(mul2).map(|(a, b)| a + b).collect();
     let mut perm = arithmetic::reshare_vec(perm_a, net)?;
 

--- a/mpc-core/src/protocols/shamir/arithmetic.rs
+++ b/mpc-core/src/protocols/shamir/arithmetic.rs
@@ -35,7 +35,7 @@ pub fn sub_assign<F: PrimeField>(a: &mut ShamirShare<F>, b: ShamirShare<F>) {
 }
 
 /// Performs element-wise subtraction of two slices of shares and stores the result in `lhs`.
-pub fn sub_vec_assign<F: PrimeField>(lhs: &mut [ShamirShare<F>], rhs: &[ShamirShare<F>]) {
+pub fn sub_many_assign<F: PrimeField>(lhs: &mut [ShamirShare<F>], rhs: &[ShamirShare<F>]) {
     for (a, b) in izip!(lhs.iter_mut(), rhs.iter()) {
         *a -= *b;
     }
@@ -52,7 +52,7 @@ pub fn add_assign_public<F: PrimeField>(shared: &mut ShamirShare<F>, public: F) 
 }
 
 /// Performs element-wise addition of two slices of shares and stores the result in `lhs`.
-pub fn add_vec_assign<F: PrimeField>(lhs: &mut [ShamirShare<F>], rhs: &[ShamirShare<F>]) {
+pub fn add_many_assign<F: PrimeField>(lhs: &mut [ShamirShare<F>], rhs: &[ShamirShare<F>]) {
     for (a, b) in izip!(lhs.iter_mut(), rhs.iter()) {
         *a += b;
     }
@@ -70,7 +70,7 @@ pub fn mul<F: PrimeField, N: Network>(
 }
 
 /// Performs multiplication between two shares. *DOES NOT REDUCE DEGREE*
-pub fn local_mul_vec<F: PrimeField>(a: &[ShamirShare<F>], b: &[ShamirShare<F>]) -> Vec<F> {
+pub fn local_mul_many<F: PrimeField>(a: &[ShamirShare<F>], b: &[ShamirShare<F>]) -> Vec<F> {
     a.par_iter()
         .zip_eq(b.par_iter())
         .with_min_len(1024)
@@ -79,14 +79,14 @@ pub fn local_mul_vec<F: PrimeField>(a: &[ShamirShare<F>], b: &[ShamirShare<F>]) 
 }
 
 /// Performs element-wise multiplication of two slices of shares.
-pub fn mul_vec<F: PrimeField, N: Network>(
+pub fn mul_many<F: PrimeField, N: Network>(
     a: &[ShamirShare<F>],
     b: &[ShamirShare<F>],
     net: &N,
     state: &mut ShamirState<F>,
 ) -> eyre::Result<Vec<ShamirShare<F>>> {
-    //do not use local_mul_vec as it uses rayon and this method runs on
-    //the tokio runtime. This method is for smaller vecs, local_mul_vec and then
+    //do not use local_mul_many as it uses rayon and this method runs on
+    //the tokio runtime. This method is for smaller vecs, local_mul_many and then
     //degree_reduce for larger vecs.
     let mul = a
         .iter()

--- a/tests/tests/mpc/rep3.rs
+++ b/tests/tests/mpc/rep3.rs
@@ -353,7 +353,7 @@ mod field_share {
         ) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
-                let mul = arithmetic::mul_vec(&x, &y, &net, &mut state).unwrap();
+                let mul = arithmetic::mul_many(&x, &y, &net, &mut state).unwrap();
                 tx.send(mul)
             });
         }
@@ -365,7 +365,7 @@ mod field_share {
     }
 
     #[test]
-    fn rep3_mul_vec() {
+    fn rep3_mul_many() {
         let nets = LocalNetwork::new_3_parties();
         let mut rng = thread_rng();
         let x = (0..1)
@@ -393,8 +393,8 @@ mod field_share {
         ) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
-                let mul = arithmetic::mul_vec(&x, &y, &net, &mut state).unwrap();
-                let mul = arithmetic::mul_vec(&mul, &y, &net, &mut state).unwrap();
+                let mul = arithmetic::mul_many(&x, &y, &net, &mut state).unwrap();
+                let mul = arithmetic::mul_many(&mul, &y, &net, &mut state).unwrap();
                 tx.send(mul)
             });
         }

--- a/tests/tests/mpc/rep3_ring.rs
+++ b/tests/tests/mpc/rep3_ring.rs
@@ -310,7 +310,7 @@ mod ring_share {
         apply_to_all!(rep3_mul2_then_add_t, [Bit, u8, u16, u32, u64, u128]);
     }
 
-    fn rep3_mul_vec_t<T: IntRing2k>()
+    fn rep3_mul_many_t<T: IntRing2k>()
     where
         Standard: Distribution<T>,
     {
@@ -341,8 +341,8 @@ mod ring_share {
         ) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
-                let mul = arithmetic::mul_vec(&x, &y, &net, &mut state).unwrap();
-                let mul = arithmetic::mul_vec(&mul, &y, &net, &mut state).unwrap();
+                let mul = arithmetic::mul_many(&x, &y, &net, &mut state).unwrap();
+                let mul = arithmetic::mul_many(&mul, &y, &net, &mut state).unwrap();
                 tx.send(mul)
             });
         }
@@ -354,8 +354,8 @@ mod ring_share {
     }
 
     #[test]
-    fn rep3_mul_vec() {
-        apply_to_all!(rep3_mul_vec_t, [Bit, u8, u16, u32, u64, u128]);
+    fn rep3_mul_many() {
+        apply_to_all!(rep3_mul_many_t, [Bit, u8, u16, u32, u64, u128]);
     }
 
     fn rep3_neg_t<T: IntRing2k>()

--- a/tests/tests/mpc/shamir.rs
+++ b/tests/tests/mpc/shamir.rs
@@ -132,7 +132,7 @@ mod field_share {
         shamir_mul2_then_add_inner(10, 4);
     }
 
-    fn shamir_mul_vec_bn_inner(num_parties: usize, threshold: usize) {
+    fn shamir_mul_many_bn_inner(num_parties: usize, threshold: usize) {
         let nets = LocalNetwork::new(num_parties);
         let mut rng = thread_rng();
         let x = [
@@ -206,7 +206,7 @@ mod field_share {
                 let mut state = ShamirPreprocessing::new(num_parties, threshold, x.len(), &net)
                     .unwrap()
                     .into();
-                let mul = arithmetic::mul_vec(&x, &y, &net, &mut state).unwrap();
+                let mul = arithmetic::mul_many(&x, &y, &net, &mut state).unwrap();
                 tx.send(mul)
             });
         }
@@ -224,12 +224,12 @@ mod field_share {
     }
 
     #[test]
-    fn shamir_mul_vec_bn() {
-        shamir_mul_vec_bn_inner(3, 1);
-        shamir_mul_vec_bn_inner(10, 4);
+    fn shamir_mul_many_bn() {
+        shamir_mul_many_bn_inner(3, 1);
+        shamir_mul_many_bn_inner(10, 4);
     }
 
-    fn shamir_mul_vec_inner(num_parties: usize, threshold: usize) {
+    fn shamir_mul_many_inner(num_parties: usize, threshold: usize) {
         let nets = LocalNetwork::new(num_parties);
         let mut rng = thread_rng();
         let x = (0..1)
@@ -260,8 +260,8 @@ mod field_share {
                 let mut state = ShamirPreprocessing::new(num_parties, threshold, x.len() * 2, &net)
                     .unwrap()
                     .into();
-                let mul = arithmetic::mul_vec(&x, &y, &net, &mut state).unwrap();
-                let mul = arithmetic::mul_vec(&mul, &y, &net, &mut state).unwrap();
+                let mul = arithmetic::mul_many(&x, &y, &net, &mut state).unwrap();
+                let mul = arithmetic::mul_many(&mul, &y, &net, &mut state).unwrap();
                 tx.send(mul)
             });
         }
@@ -279,9 +279,9 @@ mod field_share {
     }
 
     #[test]
-    fn shamir_mul_vec() {
-        shamir_mul_vec_inner(3, 1);
-        shamir_mul_vec_inner(10, 4);
+    fn shamir_mul_many() {
+        shamir_mul_many_inner(3, 1);
+        shamir_mul_many_inner(10, 4);
     }
 
     fn shamir_neg_inner(num_parties: usize, threshold: usize) {


### PR DESCRIPTION
- Standardized all batched MPC operations to use `_many` suffix
- Renamed core functions: mul_vec→mul_many, local_mul_vec→local_mul_many, etc.
- Updated trait definitions and all implementations across the codebase
- Updated all function calls and test cases
- Ensures consistent API naming across rep3, shamir, and plain protocols

Changes affect:
- Core arithmetic operations (mpc-core)
- MPC trait definitions (co-noir/common) 
- Specialized implementations (co-circom, co-groth16, co-plonk)
- All test cases and benchmarks

Closes #351