### PR TITLE
Fix typos in comments and logging messages

### DIFF
--- a/co-noir/co-noir/src/bin/co-noir.rs
+++ b/co-noir/co-noir/src/bin/co-noir.rs
@@ -1745,7 +1745,7 @@ fn run_generate_vk(config: CreateVKConfig) -> color_eyre::Result<ExitCode> {
         recursive,
     )?;
     let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
-    tracing::info!("Verfication key generation took {} ms", duration_ms);
+    tracing::info!("Verification key generation took {} ms", duration_ms);
 
     let mut out_file =
         BufWriter::new(std::fs::File::create(&vk_path).context("while creating output file")?);

--- a/co-noir/ultrahonk/src/decider/relations/ultra_arithmetic_relation.rs
+++ b/co-noir/ultrahonk/src/decider/relations/ultra_arithmetic_relation.rs
@@ -81,7 +81,7 @@ impl<F: PrimeField, L: PlainProverFlavour> Relation<F, L> for UltraArithmeticRel
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
-     * @details This relation encapsulates several idenitities, toggled by the value of q_arith in [0, 1, 2, 3, ...].
+     * @details This relation encapsulates several identities, toggled by the value of q_arith in [0, 1, 2, 3, ...].
      * The following description is reproduced from the Plonk analog 'plookup_arithmetic_widget':
      * The whole formula is:
      *

--- a/co-noir/ultrahonk/src/decider/small_subgroup_ipa.rs
+++ b/co-noir/ultrahonk/src/decider/small_subgroup_ipa.rs
@@ -225,7 +225,7 @@ impl<P: HonkCurve<TranscriptFieldType>> SmallSubgroupIPAProver<P> {
                 shifted_grand_sum.coefficients[idx] - self.grand_sum_polynomial.coefficients[idx];
         }
 
-        // Mutiply - F(X) * G(X) + A(gX) - A(X) by X-g:
+        // Multiply - F(X) * G(X) + A(gX) - A(X) by X-g:
         // 1. Multiply by X
         for idx in (1..self.grand_sum_identity_polynomial.coefficients.len()).rev() {
             self.grand_sum_identity_polynomial.coefficients[idx] =


### PR DESCRIPTION

Minor typo fixes across three files: correct spelling in logging, documentation, and comments.

