### PR TITLE
Remove redundant slice in CRS G1 transcript reader

### DIFF
--- a/co-noir/co-builder/src/crs/parse.rs
+++ b/co-noir/co-builder/src/crs/parse.rs
@@ -129,7 +129,6 @@ impl<P: HonkCurve<TranscriptFieldType>> FileProcessor<P> for NewFileStructure<P>
         }
         // We must pass the size actually read to the second call, not the desired
         // g1_buffer_size as the file may have been smaller than this.
-        let monomials = &mut monomials[0..];
         Self::read_elements_from_buffer(monomials, &mut buffer);
         Ok(())
     }


### PR DESCRIPTION
Drop an unnecessary &mut monomials[0..] in read_transcript_g1.  The slice was a no-op and its removal simplifies the code without altering behavior. Verified no analogous patterns in the codebase.