### PR TITLE
chore(relations): derive scaling_factors length from gating selectors

### DIFF
--- a/co-noir/co-ultrahonk/src/co_decider/relations/delta_range_constraint_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/delta_range_constraint_relation.rs
@@ -321,7 +321,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>, L: MPCProverF
             univariate_accumulator,
             input,
             &RelationParameters::default(),
-            &vec![*scaling_factor; input.precomputed.q_elliptic().len()],
+            &vec![*scaling_factor; input.precomputed.q_delta_range().len()],
         )
     }
 

--- a/co-noir/co-ultrahonk/src/co_decider/relations/ecc_op_queue_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/ecc_op_queue_relation.rs
@@ -348,7 +348,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>, L: MPCProverF
             univariate_accumulator,
             input,
             &RelationParameters::default(),
-            &vec![*scaling_factor; input.precomputed.q_elliptic().len()],
+            &vec![*scaling_factor; input.precomputed.lagrange_ecc_op().len()],
         )
     }
 


### PR DESCRIPTION
- DeltaRangeConstraintRelation: use q_delta_range().len() instead of q_elliptic().len().
- EccOpQueueRelation: use lagrange_ecc_op().len() instead of q_elliptic().len().


These changes remove copy-paste mistakes and ensure scaling vectors match the actual gating selector of each relation. While prior code worked due to .cycle().take(...), it was semantically incorrect and risky for future maintenance or refactors.