### PR TITLE
feat!: move HonkProof and the corresponding field serde to noir-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,6 +1388,7 @@ dependencies = [
  "itertools 0.14.0",
  "mpc-core",
  "mpc-net",
+ "noir-types",
  "num-bigint 0.4.6",
  "num-traits",
  "rand 0.8.5",
@@ -2988,6 +2989,7 @@ dependencies = [
  "eyre",
  "noirc_abi",
  "noirc_artifacts",
+ "num-bigint 0.4.6",
  "serde_json",
  "toml 0.8.23",
 ]

--- a/co-noir/co-builder/src/keys/verification_key.rs
+++ b/co-noir/co-builder/src/keys/verification_key.rs
@@ -1,18 +1,14 @@
 use crate::polynomials::polynomial_flavours::PrecomputedEntitiesFlavour;
 use crate::{
-    HonkProofError, HonkProofResult, TranscriptFieldType,
-    crs::ProverCrs,
-    flavours::ultra_flavour::UltraFlavour,
-    honk_curve::HonkCurve,
-    prover_flavour::ProverFlavour,
-    serialize::{Serialize, SerializeP},
-    ultra_builder::UltraCircuitBuilder,
-    utils::Utils,
+    HonkProofError, HonkProofResult, TranscriptFieldType, crs::ProverCrs,
+    flavours::ultra_flavour::UltraFlavour, honk_curve::HonkCurve, prover_flavour::ProverFlavour,
+    serialize::SerializeP, ultra_builder::UltraCircuitBuilder, utils::Utils,
 };
 use ark_ec::CurveGroup;
 use ark_ec::{AffineRepr, pairing::Pairing};
 use ark_ff::Zero;
 use co_acvm::PlainAcvmSolver;
+use noir_types::SerializeF;
 use serde::{Deserialize, Serialize as SerdeSerialize};
 use std::sync::Arc;
 
@@ -132,11 +128,11 @@ impl<P: HonkCurve<TranscriptFieldType>> VerifyingKeyBarretenberg<P, UltraFlavour
     pub fn to_buffer(&self) -> Vec<u8> {
         let mut buffer = Vec::with_capacity(Self::SER_FULL_SIZE);
 
-        Serialize::<P::ScalarField>::write_u64(&mut buffer, self.circuit_size);
-        Serialize::<P::ScalarField>::write_u64(&mut buffer, self.log_circuit_size);
-        Serialize::<P::ScalarField>::write_u64(&mut buffer, self.num_public_inputs);
-        Serialize::<P::ScalarField>::write_u64(&mut buffer, self.pub_inputs_offset);
-        Serialize::<P::ScalarField>::write_u32(
+        SerializeF::<P::ScalarField>::write_u64(&mut buffer, self.circuit_size);
+        SerializeF::<P::ScalarField>::write_u64(&mut buffer, self.log_circuit_size);
+        SerializeF::<P::ScalarField>::write_u64(&mut buffer, self.num_public_inputs);
+        SerializeF::<P::ScalarField>::write_u64(&mut buffer, self.pub_inputs_offset);
+        SerializeF::<P::ScalarField>::write_u32(
             &mut buffer,
             self.pairing_inputs_public_input_key.start_idx,
         );
@@ -152,10 +148,10 @@ impl<P: HonkCurve<TranscriptFieldType>> VerifyingKeyBarretenberg<P, UltraFlavour
     pub fn to_buffer_keccak(&self) -> Vec<u8> {
         let mut buffer = Vec::with_capacity(Self::SER_COMPRESSED_SIZE);
 
-        Serialize::<P::ScalarField>::write_u64(&mut buffer, self.circuit_size);
-        Serialize::<P::ScalarField>::write_u64(&mut buffer, self.log_circuit_size);
-        Serialize::<P::ScalarField>::write_u64(&mut buffer, self.num_public_inputs);
-        Serialize::<P::ScalarField>::write_u64(&mut buffer, self.pub_inputs_offset);
+        SerializeF::<P::ScalarField>::write_u64(&mut buffer, self.circuit_size);
+        SerializeF::<P::ScalarField>::write_u64(&mut buffer, self.log_circuit_size);
+        SerializeF::<P::ScalarField>::write_u64(&mut buffer, self.num_public_inputs);
+        SerializeF::<P::ScalarField>::write_u64(&mut buffer, self.pub_inputs_offset);
 
         for el in self.commitments.iter() {
             SerializeP::<P>::write_g1_element(&mut buffer, el, true);
@@ -173,13 +169,13 @@ impl<P: HonkCurve<TranscriptFieldType>> VerifyingKeyBarretenberg<P, UltraFlavour
         }
 
         // Read data
-        let circuit_size = Serialize::<P::ScalarField>::read_u64(buf, &mut offset);
-        let log_circuit_size = Serialize::<P::ScalarField>::read_u64(buf, &mut offset);
-        let num_public_inputs = Serialize::<P::ScalarField>::read_u64(buf, &mut offset);
-        let pub_inputs_offset = Serialize::<P::ScalarField>::read_u64(buf, &mut offset);
+        let circuit_size = SerializeF::<P::ScalarField>::read_u64(buf, &mut offset);
+        let log_circuit_size = SerializeF::<P::ScalarField>::read_u64(buf, &mut offset);
+        let num_public_inputs = SerializeF::<P::ScalarField>::read_u64(buf, &mut offset);
+        let pub_inputs_offset = SerializeF::<P::ScalarField>::read_u64(buf, &mut offset);
         let pairing_inputs_public_input_key = if size == Self::SER_FULL_SIZE {
             PublicComponentKey {
-                start_idx: Serialize::<P::ScalarField>::read_u32(buf, &mut offset),
+                start_idx: SerializeF::<P::ScalarField>::read_u32(buf, &mut offset),
             }
         } else {
             Default::default()

--- a/co-noir/co-builder/src/prelude.rs
+++ b/co-noir/co-builder/src/prelude.rs
@@ -17,7 +17,7 @@ pub use crate::polynomials::polynomial_types::{
     Polynomials, PrecomputedEntities, ProverWitnessEntities, ShiftedWitnessEntities,
     WitnessEntities,
 };
-pub use crate::serialize::{Serialize, SerializeP};
+pub use crate::serialize::SerializeP;
 pub use crate::types::aes128::AES128_SBOX;
 pub use crate::types::generators::{derive_generators, offset_generator, offset_generator_scaled};
 pub use crate::types::types::{
@@ -27,3 +27,4 @@ pub use crate::types::types::{
 pub use crate::ultra_builder::{GenericUltraCircuitBuilder, UltraCircuitBuilder};
 pub use crate::utils::Utils;
 pub use co_acvm::PlainAcvmSolver;
+pub use noir_types::SerializeF;

--- a/co-noir/co-builder/src/serialize.rs
+++ b/co-noir/co-builder/src/serialize.rs
@@ -1,11 +1,7 @@
-use crate::{HonkProofError, HonkProofResult, TranscriptFieldType, prelude::HonkCurve};
+use crate::{TranscriptFieldType, prelude::HonkCurve};
 use ark_ec::{AffineRepr, CurveConfig, CurveGroup};
 use ark_ff::{Field, PrimeField};
-use num_bigint::BigUint;
-
-pub struct Serialize<F: Field> {
-    phantom: std::marker::PhantomData<F>,
-}
+use noir_types::SerializeF;
 
 pub struct SerializeC<C: CurveGroup> {
     phantom: std::marker::PhantomData<C>,
@@ -13,131 +9,6 @@ pub struct SerializeC<C: CurveGroup> {
 
 pub struct SerializeP<P: CurveGroup> {
     phantom: std::marker::PhantomData<P>,
-}
-
-impl<F: Field> Serialize<F> {
-    const NUM_64_LIMBS: u32 = <F::BasePrimeField as PrimeField>::MODULUS_BIT_SIZE.div_ceil(64);
-    const FIELDSIZE_BYTES: u32 = Self::NUM_64_LIMBS * 8;
-    const VEC_LEN_BYTES: u32 = 4;
-
-    // TODO maybe change to impl Read?
-    pub fn from_buffer(buf: &[u8], size_included: bool) -> HonkProofResult<Vec<F>> {
-        let size = buf.len();
-        let mut offset = 0;
-
-        // Check sizes
-        let num_elements = if size_included {
-            let num_elements =
-                (size - Self::VEC_LEN_BYTES as usize) / Self::FIELDSIZE_BYTES as usize;
-            if num_elements * Self::FIELDSIZE_BYTES as usize + Self::VEC_LEN_BYTES as usize != size
-            {
-                return Err(HonkProofError::InvalidProofLength);
-            }
-
-            let read_num_elements = Self::read_u32(buf, &mut offset);
-            if read_num_elements != num_elements as u32 {
-                return Err(HonkProofError::InvalidProofLength);
-            }
-            num_elements
-        } else {
-            let num_elements = size / Self::FIELDSIZE_BYTES as usize;
-            if num_elements * Self::FIELDSIZE_BYTES as usize != size {
-                return Err(HonkProofError::InvalidProofLength);
-            }
-            num_elements
-        };
-
-        // Read data
-        let mut res = Vec::with_capacity(num_elements);
-        for _ in 0..num_elements {
-            res.push(Self::read_field_element(buf, &mut offset));
-        }
-        debug_assert_eq!(offset, size);
-        Ok(res)
-    }
-
-    pub(crate) fn field_size() -> usize {
-        Self::FIELDSIZE_BYTES as usize * F::extension_degree() as usize
-    }
-
-    pub fn to_buffer(buf: &[F], include_size: bool) -> Vec<u8> {
-        let total_size = buf.len() as u32 * Self::field_size() as u32
-            + if include_size { Self::VEC_LEN_BYTES } else { 0 };
-
-        let mut res = Vec::with_capacity(total_size as usize);
-        if include_size {
-            Self::write_u32(&mut res, buf.len() as u32);
-        }
-        for el in buf.iter().cloned() {
-            Self::write_field_element(&mut res, el);
-        }
-        debug_assert_eq!(res.len(), total_size as usize);
-        res
-    }
-
-    pub fn read_u32(buf: &[u8], offset: &mut usize) -> u32 {
-        const BYTES: usize = 4;
-        let res = u32::from_be_bytes(buf[*offset..*offset + BYTES].try_into().unwrap());
-        *offset += BYTES;
-        res
-    }
-
-    pub(crate) fn read_u64(buf: &[u8], offset: &mut usize) -> u64 {
-        const BYTES: usize = 8;
-        let res = u64::from_be_bytes(buf[*offset..*offset + BYTES].try_into().unwrap());
-        *offset += BYTES;
-        res
-    }
-
-    pub fn read_biguint(buf: &[u8], num_64_limbs: usize, offset: &mut usize) -> BigUint {
-        let mut bigint = BigUint::default();
-        for _ in 0..num_64_limbs {
-            let data = Self::read_u64(buf, offset);
-            bigint <<= 64;
-            bigint += data;
-        }
-        bigint
-    }
-
-    pub fn write_u32(buf: &mut Vec<u8>, val: u32) {
-        buf.extend(val.to_be_bytes());
-    }
-
-    pub(crate) fn write_u64(buf: &mut Vec<u8>, val: u64) {
-        buf.extend(val.to_be_bytes());
-    }
-
-    pub fn write_field_element(buf: &mut Vec<u8>, el: F) {
-        let prev_len = buf.len();
-        for el in el.to_base_prime_field_elements() {
-            let el = el.into_bigint(); // Gets rid of montgomery form
-
-            for data in el.as_ref().iter().rev().cloned() {
-                Self::write_u64(buf, data);
-            }
-
-            debug_assert_eq!(
-                buf.len() - prev_len,
-                Self::FIELDSIZE_BYTES as usize * F::extension_degree() as usize
-            );
-        }
-    }
-
-    pub fn read_field_element(buf: &[u8], offset: &mut usize) -> F {
-        let mut fields = Vec::with_capacity(F::extension_degree() as usize);
-
-        for _ in 0..F::extension_degree() {
-            let mut bigint: BigUint = Default::default();
-            for _ in 0..Self::NUM_64_LIMBS {
-                let data = Self::read_u64(buf, offset);
-                bigint <<= 64;
-                bigint += data;
-            }
-            fields.push(F::BasePrimeField::from(bigint));
-        }
-
-        F::from_base_prime_field_elems(fields).expect("Should work")
-    }
 }
 
 impl<C: CurveGroup> SerializeC<C> {
@@ -161,11 +32,11 @@ impl<C: CurveGroup> SerializeC<C> {
         } else {
             let (x, y) = el.xy().unwrap_or_default();
             if write_x_first {
-                Serialize::write_field_element(buf, x);
-                Serialize::write_field_element(buf, y);
+                SerializeF::write_field_element(buf, x);
+                SerializeF::write_field_element(buf, y);
             } else {
-                Serialize::write_field_element(buf, y);
-                Serialize::write_field_element(buf, x);
+                SerializeF::write_field_element(buf, y);
+                SerializeF::write_field_element(buf, x);
             }
         }
 
@@ -189,8 +60,8 @@ impl<P: HonkCurve<TranscriptFieldType>> SerializeP<P> {
             *offset += Self::FIELDSIZE_BYTES as usize * 2;
             return P::Affine::zero();
         }
-        let first = Serialize::<P::BaseField>::read_field_element(buf, offset);
-        let second = Serialize::<P::BaseField>::read_field_element(buf, offset);
+        let first = SerializeF::<P::BaseField>::read_field_element(buf, offset);
+        let second = SerializeF::<P::BaseField>::read_field_element(buf, offset);
 
         if read_x_first {
             P::g1_affine_from_xy(first, second)

--- a/co-noir/co-goblin/src/co_merge_prover.rs
+++ b/co-noir/co-goblin/src/co_merge_prover.rs
@@ -10,9 +10,9 @@ use common::shared_polynomial::SharedPolynomial;
 use common::transcript::Transcript;
 use common::transcript::TranscriptHasher;
 
-use common::HonkProof;
 use itertools::{Itertools, izip};
 use mpc_net::Network;
+use ultrahonk::prelude::HonkProof;
 
 use crate::eccvm::co_ecc_op_queue::CoECCOpQueue;
 

--- a/co-noir/co-noir/src/bin/co-noir.rs
+++ b/co-noir/co-noir/src/bin/co-noir.rs
@@ -1,8 +1,8 @@
 use ark_bn254::Bn254;
 use ark_ff::Zero;
 use clap::{Args, Parser, Subcommand, ValueEnum};
-use co_builder::{flavours::ultra_flavour::UltraFlavour, prelude::Serialize as FieldSerialize};
-use co_noir::Bn254G1;
+use co_builder::flavours::ultra_flavour::UltraFlavour;
+use co_noir::{Bn254G1, HonkProof, SerializeF};
 use co_noir_types::{PubPrivate, Rep3SharedInput, Rep3Type};
 use co_ultrahonk::prelude::{
     CrsParser, ProvingKey, Rep3CoUltraHonk, ShamirCoUltraHonk, UltraHonk, VerifyingKey,
@@ -10,7 +10,6 @@ use co_ultrahonk::prelude::{
 };
 use color_eyre::eyre::{self, Context, ContextCompat};
 use common::{
-    HonkProof,
     mpc::{rep3::Rep3UltraHonkDriver, shamir::ShamirUltraHonkDriver},
     transcript::Poseidon2Sponge,
 };
@@ -1488,7 +1487,7 @@ fn run_generate_proof(config: GenerateProofConfig) -> color_eyre::Result<ExitCod
             std::fs::File::create(public_input_filename).context("while creating output file")?,
         );
 
-        let public_inputs_u8 = FieldSerialize::to_buffer(&public_input, false);
+        let public_inputs_u8 = SerializeF::to_buffer(&public_input, false);
         out_file
             .write(public_inputs_u8.as_slice())
             .context("while writing proof to file")?;
@@ -1719,7 +1718,7 @@ fn run_build_and_generate_proof(
             std::fs::File::create(public_input_filename).context("while creating output file")?,
         );
 
-        let public_inputs_u8 = FieldSerialize::to_buffer(&public_input, false);
+        let public_inputs_u8 = SerializeF::to_buffer(&public_input, false);
         out_file
             .write(public_inputs_u8.as_slice())
             .context("while writing public input to file")?;
@@ -1894,7 +1893,7 @@ fn run_verify(config: VerifyConfig) -> color_eyre::Result<ExitCode> {
             .map(|e| ark_bn254::Fr::new(ark_ff::BigInt::from_str(&e).expect("valid field")))
             .collect()
     } else {
-        FieldSerialize::from_buffer(&public_inputs_u8, false)
+        SerializeF::from_buffer(&public_inputs_u8, false)
             .context("while deserializing public_inputs")?
     };
 

--- a/co-noir/co-noir/src/bin/plaindriver.rs
+++ b/co-noir/co-noir/src/bin/plaindriver.rs
@@ -4,8 +4,7 @@ use ark_ff::PrimeField;
 use clap::{Parser, ValueEnum};
 use co_acvm::{PlainAcvmSolver, solver::PlainCoSolver};
 use co_builder::flavours::ultra_flavour::UltraFlavour;
-use co_builder::prelude::Serialize as FieldSerialize;
-use co_noir::{Bn254G1, HonkRecursion};
+use co_noir::{Bn254G1, HonkRecursion, SerializeF};
 use co_ultrahonk::{
     PlainCoBuilder,
     prelude::{CoUltraHonk, CrsParser, ProvingKey, UltraHonk, VerifyingKey, ZeroKnowledge},
@@ -266,7 +265,7 @@ fn main() -> color_eyre::Result<ExitCode> {
     let mut out_file = BufWriter::new(
         std::fs::File::create(&out_path).context("while creating output file for proof")?,
     );
-    let public_inputs_u8 = FieldSerialize::to_buffer(&public_inputs, false);
+    let public_inputs_u8 = SerializeF::to_buffer(&public_inputs, false);
     out_file
         .write(public_inputs_u8.as_slice())
         .context("while writing proof to file")?;

--- a/co-noir/co-noir/src/lib.rs
+++ b/co-noir/co-noir/src/lib.rs
@@ -26,6 +26,10 @@ pub use ark_ec::pairing::Pairing;
 pub use co_acvm::{Rep3AcvmType, ShamirAcvmType};
 pub use co_builder::prelude::constraint_system_from_reader;
 pub use co_builder::prelude::get_constraint_system_from_artifact;
+pub use co_noir_types::merge_input_shares;
+pub use co_noir_types::split_input_rep3;
+pub use co_noir_types::split_witness_rep3;
+pub use co_noir_types::split_witness_shamir;
 pub use co_ultrahonk::{
     Rep3CoBuilder, ShamirCoBuilder,
     prelude::{
@@ -34,17 +38,13 @@ pub use co_ultrahonk::{
         UltraHonk, VerifyingKey, VerifyingKeyBarretenberg,
     },
 };
-pub use common::HonkProof;
 pub use common::transcript::{Poseidon2Sponge, TranscriptHasher};
+pub use noir_types::HonkProof;
+pub use noir_types::SerializeF;
 pub use noir_types::program_artifact_from_reader;
 pub use noir_types::witness_from_reader;
 pub use noirc_artifacts::program::ProgramArtifact;
 pub use sha3::Keccak256;
-
-pub use co_noir_types::merge_input_shares;
-pub use co_noir_types::split_input_rep3;
-pub use co_noir_types::split_witness_rep3;
-pub use co_noir_types::split_witness_shamir;
 
 pub type Bn254G1 = <ark_ec::bn::Bn<ark_bn254::Config> as ark_ec::pairing::Pairing>::G1;
 

--- a/co-noir/co-protogalaxy/src/co_protogalaxy_prover.rs
+++ b/co-noir/co-protogalaxy/src/co_protogalaxy_prover.rs
@@ -15,13 +15,12 @@ use co_ultrahonk::co_decider::types::RelationParameters;
 use co_ultrahonk::co_oink::co_oink_prover::CoOink;
 use common::transcript::Transcript;
 use common::{
-    HonkProof, mpc::NoirUltraHonkProver, shared_polynomial::SharedPolynomial,
-    transcript::TranscriptHasher,
+    mpc::NoirUltraHonkProver, shared_polynomial::SharedPolynomial, transcript::TranscriptHasher,
 };
 use mpc_net::Network;
 use ultrahonk::{
     plain_prover_flavour::UnivariateTrait,
-    prelude::{GateSeparatorPolynomial, Univariate, ZeroKnowledge},
+    prelude::{GateSeparatorPolynomial, HonkProof, Univariate, ZeroKnowledge},
 };
 
 use crate::co_protogalaxy_prover_internal::{

--- a/co-noir/co-protogalaxy/src/tests.rs
+++ b/co-noir/co-protogalaxy/src/tests.rs
@@ -17,7 +17,6 @@ use co_ultrahonk::{
 };
 use co_ultrahonk::{co_decider::univariates::SharedUnivariate, types::AllEntities};
 use common::{
-    HonkProof,
     mpc::{NoirUltraHonkProver, rep3::Rep3UltraHonkDriver},
     shared_polynomial::SharedPolynomial,
 };
@@ -32,7 +31,7 @@ use rand::thread_rng;
 use serde::de::DeserializeOwned;
 
 use ultrahonk::prelude::{
-    GateSeparatorPolynomial, Poseidon2Sponge, Transcript, Univariate, ZeroKnowledge,
+    GateSeparatorPolynomial, HonkProof, Poseidon2Sponge, Transcript, Univariate, ZeroKnowledge,
 };
 
 use crate::{

--- a/co-noir/co-ultrahonk/src/co_decider/co_decider_prover.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/co_decider_prover.rs
@@ -8,9 +8,10 @@ use co_builder::{
     HonkProofResult, TranscriptFieldType,
     prelude::{HonkCurve, ProverCrs, Utils},
 };
+use common::mpc::NoirUltraHonkProver;
 use common::transcript::{Transcript, TranscriptHasher};
-use common::{HonkProof, mpc::NoirUltraHonkProver};
 use mpc_net::Network;
+use noir_types::HonkProof;
 use std::marker::PhantomData;
 use ultrahonk::prelude::ZeroKnowledge;
 pub(crate) struct CoDecider<

--- a/co-noir/co-ultrahonk/src/co_ultra_prover.rs
+++ b/co-noir/co-ultrahonk/src/co_ultra_prover.rs
@@ -11,7 +11,6 @@ use co_builder::{
     prover_flavour::Flavour,
 };
 use co_builder::{TranscriptFieldType, flavours::ultra_flavour::UltraFlavour};
-use common::HonkProof;
 use common::mpc::{
     NoirUltraHonkProver, plain::PlainUltraHonkDriver, rep3::Rep3UltraHonkDriver,
     shamir::ShamirUltraHonkDriver,
@@ -22,6 +21,7 @@ use mpc_core::protocols::{
     shamir::{ShamirPreprocessing, ShamirState},
 };
 use mpc_net::Network;
+use noir_types::HonkProof;
 use std::marker::PhantomData;
 use ultrahonk::prelude::ZeroKnowledge;
 

--- a/co-noir/co-ultrahonk/tests/plaindriver.rs
+++ b/co-noir/co-ultrahonk/tests/plaindriver.rs
@@ -8,9 +8,9 @@ use co_builder::flavours::ultra_flavour::UltraFlavour;
 use co_builder::prelude::constraint_system_from_reader;
 use co_builder::prelude::{CrsParser, HonkRecursion};
 use co_ultrahonk::prelude::{CoUltraHonk, PlainCoBuilder, ProvingKey};
-use common::HonkProof;
 use common::mpc::plain::PlainUltraHonkDriver;
 use common::transcript::{Poseidon2Sponge, TranscriptHasher};
+use noir_types::HonkProof;
 use sha3::Keccak256;
 use ultrahonk::prelude::{UltraHonk, ZeroKnowledge};
 

--- a/co-noir/common/Cargo.toml
+++ b/co-noir/common/Cargo.toml
@@ -14,6 +14,7 @@ readme.workspace = true
 mpc-core = { version = "0.9.0", path = "../../mpc-core" }
 mpc-net = { version = "0.4.0", path = "../../mpc-net" }
 co-builder = { version = "0.4.0", path = "../co-builder" }
+noir-types = { version = "0.1.0", path = "../noir-types" }
 rayon.workspace = true
 ark-serialize.workspace = true
 ark-poly.workspace = true

--- a/co-noir/common/src/keccak_hash.rs
+++ b/co-noir/common/src/keccak_hash.rs
@@ -1,18 +1,18 @@
 use crate::transcript::TranscriptHasher;
 use ark_ff::PrimeField;
-use co_builder::prelude::Serialize;
+use noir_types::SerializeF;
 use sha3::{Digest, Keccak256};
 
 impl<F: PrimeField> TranscriptHasher<F> for Keccak256 {
     fn hash(buffer: Vec<F>) -> F {
         // Losing 2 bits of this is not an issue -> we can just reduce mod p
 
-        let vec = Serialize::to_buffer(&buffer, false);
+        let vec = SerializeF::to_buffer(&buffer, false);
         let mut hasher = Keccak256::default();
         hasher.update(vec);
         let hash_result = hasher.finalize();
 
         let mut offset = 0;
-        Serialize::read_field_element(&hash_result, &mut offset)
+        SerializeF::read_field_element(&hash_result, &mut offset)
     }
 }

--- a/co-noir/common/src/lib.rs
+++ b/co-noir/common/src/lib.rs
@@ -3,10 +3,9 @@ use crate::{
     transcript::{Transcript, TranscriptFieldType, TranscriptHasher},
 };
 use ark_ec::CurveGroup;
-use ark_ff::PrimeField;
 use co_builder::{
     HonkProofResult,
-    prelude::{HonkCurve, ProverCrs, Serialize, Utils},
+    prelude::{HonkCurve, ProverCrs, Utils},
 };
 use mpc_net::Network;
 
@@ -98,40 +97,5 @@ impl CoUtils {
         state: &mut T::State,
     ) -> eyre::Result<()> {
         T::inv_many_in_place_leaking_zeros(poly, net, state)
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HonkProof<F: PrimeField> {
-    proof: Vec<F>,
-}
-
-impl<F: PrimeField> HonkProof<F> {
-    pub fn new(proof: Vec<F>) -> Self {
-        Self { proof }
-    }
-
-    pub fn inner(self) -> Vec<F> {
-        self.proof
-    }
-
-    pub fn to_buffer(&self) -> Vec<u8> {
-        Serialize::to_buffer(&self.proof, false)
-    }
-
-    pub fn from_buffer(buf: &[u8]) -> HonkProofResult<Self> {
-        let res = Serialize::from_buffer(buf, false)?;
-        Ok(Self::new(res))
-    }
-
-    pub fn separate_proof_and_public_inputs(self, num_public_inputs: usize) -> (Self, Vec<F>) {
-        let (public_inputs, proof) = self.proof.split_at(num_public_inputs);
-        (Self::new(proof.to_vec()), public_inputs.to_vec())
-    }
-
-    pub fn insert_public_inputs(self, public_inputs: Vec<F>) -> Self {
-        let mut proof = public_inputs;
-        proof.extend(self.proof.to_owned());
-        Self::new(proof)
     }
 }

--- a/co-noir/common/src/transcript.rs
+++ b/co-noir/common/src/transcript.rs
@@ -1,11 +1,9 @@
-use crate::{
-    HonkProof,
-    sponge_hasher::{FieldHash, FieldSponge},
-};
+use crate::sponge_hasher::{FieldHash, FieldSponge};
 use ark_ec::AffineRepr;
 use ark_ff::{One, PrimeField, Zero};
 use co_builder::{HonkProofError, HonkProofResult, prelude::HonkCurve};
 use mpc_core::gadgets::poseidon2::Poseidon2;
+use noir_types::HonkProof;
 use num_bigint::BigUint;
 use serde::Deserialize;
 use serde::Serialize;

--- a/co-noir/goblin/src/eccvm/eccvm_prover.rs
+++ b/co-noir/goblin/src/eccvm/eccvm_prover.rs
@@ -17,7 +17,6 @@ use co_builder::{
     HonkProofResult, TranscriptFieldType,
     prelude::{HonkCurve, Polynomial, ProverCrs},
 };
-use common::HonkProof;
 use common::shplemini::OpeningPair;
 use common::shplemini::ShpleminiOpeningClaim;
 use common::transcript::Transcript;
@@ -26,6 +25,7 @@ use itertools::izip;
 use std::iter;
 use ultrahonk::NUM_SMALL_IPA_EVALUATIONS;
 use ultrahonk::prelude::AllEntities;
+use ultrahonk::prelude::HonkProof;
 use ultrahonk::prelude::ZeroKnowledge;
 use ultrahonk::{
     Utils as UltraHonkUtils,

--- a/co-noir/goblin/src/merge_prover.rs
+++ b/co-noir/goblin/src/merge_prover.rs
@@ -2,11 +2,11 @@ use ark_ec::AdditiveGroup;
 use ark_ff::Field;
 use co_builder::prelude::{HonkCurve, Polynomial, ProverCrs, Utils};
 use co_builder::{HonkProofResult, TranscriptFieldType};
-use common::HonkProof;
 use common::shplemini::OpeningPair;
 use common::shplemini::ShpleminiOpeningClaim;
 use common::transcript::Transcript;
 use common::transcript::TranscriptHasher;
+use ultrahonk::prelude::HonkProof;
 
 use crate::eccvm::ecc_op_queue::ECCOpQueue;
 

--- a/co-noir/goblin/src/translator/translator_prover.rs
+++ b/co-noir/goblin/src/translator/translator_prover.rs
@@ -8,13 +8,13 @@ use co_builder::polynomials::polynomial_flavours::ShiftedWitnessEntitiesFlavour;
 use co_builder::polynomials::polynomial_flavours::WitnessEntitiesFlavour;
 use co_builder::prelude::Utils;
 use co_builder::prelude::{HonkCurve, Polynomial, Polynomials, ProverCrs};
-use common::HonkProof;
 use common::compute_opening_proof;
 use common::transcript::{Transcript, TranscriptFieldType};
 use itertools::izip;
 use num_bigint::BigUint;
 use std::iter;
 use ultrahonk::Utils as UltraHonkUtils;
+use ultrahonk::prelude::HonkProof;
 use ultrahonk::prelude::ZeroKnowledge;
 use ultrahonk::prelude::{
     AllEntities, Decider, ProvingKey, SmallSubgroupIPAProver, SumcheckOutput, TranscriptHasher,

--- a/co-noir/goblin/tests/plain.rs
+++ b/co-noir/goblin/tests/plain.rs
@@ -5,7 +5,7 @@ use co_builder::TranscriptFieldType;
 use co_builder::flavours::eccvm_flavour::ECCVMFlavour;
 use co_builder::flavours::translator_flavour::TranslatorFlavour;
 use co_builder::prelude::HonkCurve;
-use co_builder::prelude::{CrsParser, Serialize, SerializeP};
+use co_builder::prelude::{CrsParser, SerializeF, SerializeP};
 use common::transcript::Poseidon2Sponge;
 use common::transcript::Transcript;
 use goblin::prelude::ECCOpQueue;
@@ -50,9 +50,10 @@ fn deserialize_ecc_op_queue<P: HonkCurve<TranscriptFieldType>>(path: PathBuf) ->
             };
             offset += 1;
             let base_point = SerializeP::<P>::read_g1_element(buf, &mut offset, false);
-            let z1 = Serialize::<P::ScalarField>::read_biguint(buf, 4, &mut offset);
-            let z2 = Serialize::<P::ScalarField>::read_biguint(buf, 4, &mut offset);
-            let mul_scalar_full = Serialize::<P::ScalarField>::read_field_element(buf, &mut offset);
+            let z1 = SerializeF::<P::ScalarField>::read_biguint(buf, 4, &mut offset);
+            let z2 = SerializeF::<P::ScalarField>::read_biguint(buf, 4, &mut offset);
+            let mul_scalar_full =
+                SerializeF::<P::ScalarField>::read_field_element(buf, &mut offset);
             tmp.push(VMOperation {
                 op_code,
                 base_point,
@@ -78,12 +79,12 @@ fn deserialize_ecc_op_queue<P: HonkCurve<TranscriptFieldType>>(path: PathBuf) ->
                 reset: (op_code & 0b1000) != 0,
             };
             offset += 1;
-            let x_lo = Serialize::<P::ScalarField>::read_field_element(buf, &mut offset);
-            let x_hi = Serialize::<P::ScalarField>::read_field_element(buf, &mut offset);
-            let y_lo = Serialize::<P::ScalarField>::read_field_element(buf, &mut offset);
-            let y_hi = Serialize::<P::ScalarField>::read_field_element(buf, &mut offset);
-            let z_1 = Serialize::<P::ScalarField>::read_field_element(buf, &mut offset);
-            let z_2 = Serialize::<P::ScalarField>::read_field_element(buf, &mut offset);
+            let x_lo = SerializeF::<P::ScalarField>::read_field_element(buf, &mut offset);
+            let x_hi = SerializeF::<P::ScalarField>::read_field_element(buf, &mut offset);
+            let y_lo = SerializeF::<P::ScalarField>::read_field_element(buf, &mut offset);
+            let y_hi = SerializeF::<P::ScalarField>::read_field_element(buf, &mut offset);
+            let z_1 = SerializeF::<P::ScalarField>::read_field_element(buf, &mut offset);
+            let z_2 = SerializeF::<P::ScalarField>::read_field_element(buf, &mut offset);
             let return_is_infinity = buf[offset] != 0;
             offset += 1;
             tmp.push(UltraOp {
@@ -102,11 +103,11 @@ fn deserialize_ecc_op_queue<P: HonkCurve<TranscriptFieldType>>(path: PathBuf) ->
     let ultra_ops_table = UltraEccOpsTable {
         table: ultra_ops_table,
     };
-    let cached_num_muls = Serialize::<P::ScalarField>::read_u32(buf, &mut offset);
-    let cached_active_msm_count = Serialize::<P::ScalarField>::read_u32(buf, &mut offset);
-    let num_transcript_rows = Serialize::<P::ScalarField>::read_u32(buf, &mut offset);
-    let num_precompute_table_rows = Serialize::<P::ScalarField>::read_u32(buf, &mut offset);
-    let num_msm_rows = Serialize::<P::ScalarField>::read_u32(buf, &mut offset);
+    let cached_num_muls = SerializeF::<P::ScalarField>::read_u32(buf, &mut offset);
+    let cached_active_msm_count = SerializeF::<P::ScalarField>::read_u32(buf, &mut offset);
+    let num_transcript_rows = SerializeF::<P::ScalarField>::read_u32(buf, &mut offset);
+    let num_precompute_table_rows = SerializeF::<P::ScalarField>::read_u32(buf, &mut offset);
+    let num_msm_rows = SerializeF::<P::ScalarField>::read_u32(buf, &mut offset);
     let eccvm_row_tracker = EccvmRowTracker {
         cached_num_muls,
         cached_active_msm_count,

--- a/co-noir/noir-types/Cargo.toml
+++ b/co-noir/noir-types/Cargo.toml
@@ -19,5 +19,6 @@ eyre = { workspace = true }
 co-noir-types = { version = "0.1.0", path = "../co-noir-types" }
 serde_json = { workspace = true }
 toml.workspace = true
+num-bigint.workspace = true
 
 [dev-dependencies]

--- a/co-noir/protogalaxy/src/protogalaxy_prover.rs
+++ b/co-noir/protogalaxy/src/protogalaxy_prover.rs
@@ -12,8 +12,7 @@ use co_builder::{
 
 use itertools::{Itertools, izip};
 
-use common::HonkProof;
-use ultrahonk::decider::types::RelationParameters;
+use ultrahonk::{decider::types::RelationParameters, prelude::HonkProof};
 use ultrahonk::{
     oink::oink_prover::Oink,
     plain_prover_flavour::UnivariateTrait,

--- a/co-noir/ultrahonk/src/decider/decider_prover.rs
+++ b/co-noir/ultrahonk/src/decider/decider_prover.rs
@@ -11,8 +11,8 @@ use co_builder::{
     HonkProofResult,
     prelude::{HonkCurve, ProverCrs, ZeroKnowledge},
 };
-use common::HonkProof;
 use common::transcript::{Transcript, TranscriptFieldType, TranscriptHasher};
+use noir_types::HonkProof;
 use rand::SeedableRng;
 use rand_chacha::ChaCha12Rng;
 use std::marker::PhantomData;

--- a/co-noir/ultrahonk/src/prelude.rs
+++ b/co-noir/ultrahonk/src/prelude.rs
@@ -7,7 +7,7 @@ pub use crate::decider::types::{
     ClaimedEvaluations, GateSeparatorPolynomial, ProverUnivariates, RelationParameters,
 };
 pub use crate::decider::univariate::Univariate;
-pub use crate::types::{AllEntities, HonkProof};
+pub use crate::types::AllEntities;
 pub use crate::ultra_prover::UltraHonk;
 pub use co_builder::flavours::ultra_flavour::UltraFlavour;
 pub use co_builder::prelude::PlainAcvmSolver;
@@ -15,3 +15,4 @@ pub use co_builder::prelude::VerifyingKeyBarretenberg;
 pub use co_builder::prelude::{ProvingKey, UltraCircuitBuilder, ZeroKnowledge};
 pub use common::transcript::Poseidon2Sponge;
 pub use common::transcript::{Transcript, TranscriptHasher};
+pub use noir_types::HonkProof;

--- a/co-noir/ultrahonk/src/types.rs
+++ b/co-noir/ultrahonk/src/types.rs
@@ -1,49 +1,9 @@
-use ark_ff::PrimeField;
-use co_builder::{
-    HonkProofResult,
-    polynomials::polynomial_flavours::{
-        PrecomputedEntitiesFlavour, ShiftedWitnessEntitiesFlavour, WitnessEntitiesFlavour,
-    },
-    prelude::Serialize,
+use co_builder::polynomials::polynomial_flavours::{
+    PrecomputedEntitiesFlavour, ShiftedWitnessEntitiesFlavour, WitnessEntitiesFlavour,
 };
 use std::fmt::Debug;
 
 use crate::plain_prover_flavour::PlainProverFlavour;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HonkProof<F: PrimeField> {
-    proof: Vec<F>,
-}
-
-impl<F: PrimeField> HonkProof<F> {
-    pub fn new(proof: Vec<F>) -> Self {
-        Self { proof }
-    }
-
-    pub fn inner(self) -> Vec<F> {
-        self.proof
-    }
-
-    pub fn to_buffer(&self) -> Vec<u8> {
-        Serialize::to_buffer(&self.proof, false)
-    }
-
-    pub fn from_buffer(buf: &[u8]) -> HonkProofResult<Self> {
-        let res = Serialize::from_buffer(buf, false)?;
-        Ok(Self::new(res))
-    }
-
-    pub fn separate_proof_and_public_inputs(self, num_public_inputs: usize) -> (Self, Vec<F>) {
-        let (public_inputs, proof) = self.proof.split_at(num_public_inputs);
-        (Self::new(proof.to_vec()), public_inputs.to_vec())
-    }
-
-    pub fn insert_public_inputs(self, public_inputs: Vec<F>) -> Self {
-        let mut proof = public_inputs;
-        proof.extend(self.proof.to_owned());
-        Self::new(proof)
-    }
-}
 
 pub struct AllEntities<T, L>
 where

--- a/co-noir/ultrahonk/src/ultra_prover.rs
+++ b/co-noir/ultrahonk/src/ultra_prover.rs
@@ -9,8 +9,8 @@ use co_builder::{
     prelude::{HonkCurve, PAIRING_POINT_ACCUMULATOR_SIZE, ProvingKey, ZeroKnowledge},
     prover_flavour::Flavour,
 };
-use common::HonkProof;
 use common::transcript::{Transcript, TranscriptFieldType, TranscriptHasher};
+use noir_types::HonkProof;
 use std::marker::PhantomData;
 
 pub struct UltraHonk<

--- a/co-noir/ultrahonk/src/ultra_verifier.rs
+++ b/co-noir/ultrahonk/src/ultra_verifier.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 use ark_ec::pairing::Pairing;
 use co_builder::prelude::{HonkCurve, VerifyingKey, ZeroKnowledge};
-use common::HonkProof;
 use common::transcript::{Transcript, TranscriptFieldType, TranscriptHasher};
+use noir_types::HonkProof;
 
 pub(crate) type HonkVerifyResult<T> = std::result::Result<T, eyre::Report>;
 

--- a/co-noir/ultrahonk/tests/plain.rs
+++ b/co-noir/ultrahonk/tests/plain.rs
@@ -7,8 +7,8 @@ use co_builder::prelude::CrsParser;
 use co_builder::prelude::HonkRecursion;
 use co_builder::prelude::ZeroKnowledge;
 use co_builder::prelude::constraint_system_from_reader;
-use common::HonkProof;
 use common::transcript::{Poseidon2Sponge, TranscriptHasher};
+use noir_types::HonkProof;
 use sha3::Keccak256;
 use ultrahonk::prelude::{PlainAcvmSolver, UltraCircuitBuilder, UltraHonk};
 

--- a/tests/tests/noir/proof_tests/mega.rs
+++ b/tests/tests/noir/proof_tests/mega.rs
@@ -6,6 +6,7 @@ use co_builder::polynomials::polynomial_flavours::ProverWitnessEntitiesFlavour;
 use co_builder::prover_flavour::ProverFlavour;
 use co_builder::{flavours::mega_flavour::MegaFlavour, TranscriptFieldType};
 use co_noir::Bn254G1;
+use co_noir::HonkProof;
 use co_noir::VerifyingKey;
 pub use co_ultrahonk::prelude::PlainProvingKey;
 use co_ultrahonk::prelude::{
@@ -15,7 +16,6 @@ use common::mpc::plain::PlainUltraHonkDriver;
 use common::mpc::rep3::Rep3UltraHonkDriver;
 use common::transcript::Poseidon2Sponge;
 use common::transcript::TranscriptHasher;
-use common::HonkProof;
 use itertools::izip;
 use mpc_core::protocols::rep3;
 use mpc_net::local::LocalNetwork;


### PR DESCRIPTION
this change allows us to only need the `noir-types` and `co-noir-types` crates in proof-network clients