### PR TITLE
chore: remove unused ConfigError from plaindriver

### DIFF
--- a/co-noir/co-noir/src/bin/plaindriver.rs
+++ b/co-noir/co-noir/src/bin/plaindriver.rs
@@ -24,11 +24,6 @@ use std::{
     process::ExitCode,
 };
 
-/// Error type for config parsing and merging
-#[derive(thiserror::Error, Debug)]
-#[error(transparent)]
-pub struct ConfigError(#[from] figment::error::Error);
-
 /// An enum representing the transcript hasher to use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ValueEnum)]
 #[clap(rename_all = "lower")]


### PR DESCRIPTION
The ConfigError wrapper around figment::error::Error was never referenced. Config::parse returns Result<Self, Box<figment::error::Error>>, and call sites handle errors directly via color_eyre::Context. Other binaries use the same boxed-figment pattern without a custom error type. Therefore, ConfigError was dead code and has been removed.