### PR TITLE
fix: incorrect extra multiply in pow_public for field and ring backends

### DIFF
--- a/mpc-core/src/protocols/rep3/arithmetic.rs
+++ b/mpc-core/src/protocols/rep3/arithmetic.rs
@@ -424,7 +424,7 @@ pub fn pow_public<F: PrimeField, N: Network>(
         shared = mul(shared, shared, net, state)?;
         public >>= 1;
     }
-    mul(res, shared, net, state)
+    Ok(res)
 }
 
 /// Returns 1 if lhs < rhs and 0 otherwise. Checks if one shared value is less than another shared value. The result is a shared value that has value 1 if the first shared value is less than the second shared value and 0 otherwise.

--- a/mpc-core/src/protocols/rep3_ring/arithmetic.rs
+++ b/mpc-core/src/protocols/rep3_ring/arithmetic.rs
@@ -344,7 +344,7 @@ where
         shared = mul(shared, shared, net, state)?;
         public >>= 1;
     }
-    mul(res, shared, net, state)
+    Ok(res)
 }
 
 /// Returns 1 if lhs < rhs and 0 otherwise. Checks if one shared value is less than another shared value. The result is a shared value that has value 1 if the first shared value is less than the second shared value and 0 otherwise.


### PR DESCRIPTION
The square-and-multiply implementation in pow_public performed an extra multiplication after the main loop, returning res * base instead of res. This caused incorrect results (e.g., exponent 1 produced base^3). The issue existed in both field (PrimeField) and ring backends.

Why necessary:
- Ensures exponentiation correctness for shared^public across backends.
- Aligns with the standard square-and-multiply algorithm.
- Prevents silent arithmetic errors in MPC computations and dependent VM operations.