### PR TITLE
fix: correct typos in mpc-net and mpc-core

### DIFF
--- a/mpc-core/src/gadgets/mod.rs
+++ b/mpc-core/src/gadgets/mod.rs
@@ -9,7 +9,7 @@ use ark_ff::PrimeField;
 use num_bigint::{BigUint, ParseBigIntError};
 use num_traits::Num;
 
-/// Reads a field elemnent from a hexadecimal string. Therebey, the format can or can not include the 0x prefix, i.e., "0x2" and "2" give the same result.
+/// Reads a field element from a hexadecimal string. Thereby, the format can or can not include the 0x prefix, i.e., "0x2" and "2" give the same result.
 pub fn field_from_hex_string<F: PrimeField>(str: &str) -> Result<F, ParseBigIntError> {
     let tmp = match str.strip_prefix("0x") {
         Some(t) => BigUint::from_str_radix(t, 16),

--- a/mpc-core/src/protocols/shamir.rs
+++ b/mpc-core/src/protocols/shamir.rs
@@ -1,6 +1,6 @@
 //! # Shamir
 //!
-//! This module implements the shamir share and combine opertions and shamir preprocessing
+//! This module implements the shamir share and combine operations and shamir preprocessing
 
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;

--- a/mpc-net/src/lib.rs
+++ b/mpc-net/src/lib.rs
@@ -18,7 +18,7 @@ pub mod tls;
 /// The default connection timeout
 pub const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
 /// The default max frame length for sending messages
-pub const DEFAULT_MAX_FRAME_LENTH: usize = 64 * 1024 * 1024; // 64MB
+pub const DEFAULT_MAX_FRAME_LENGTH: usize = 64 * 1024 * 1024; // 64MB
 
 /// A MPC network that can be used to send and receive data to and from other parties
 ///

--- a/mpc-net/src/quic.rs
+++ b/mpc-net/src/quic.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENTH, Network, config::Address,
+    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENGTH, Network, config::Address,
 };
 use bytes::Bytes;
 use eyre::{Context as _, ContextCompat};
@@ -183,7 +183,7 @@ struct QuicConnectionHandler {
 impl QuicConnectionHandler {
     pub fn new(config: NetworkConfig, rt: Runtime) -> eyre::Result<Self> {
         let id = config.my_id;
-        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENTH);
+        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENGTH);
         let (connections, endpoints) = rt.block_on(Self::init(config))?;
         Ok(Self {
             id,

--- a/mpc-net/src/tcp.rs
+++ b/mpc-net/src/tcp.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use crate::{
-    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENTH, Network, config::Address,
+    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENGTH, Network, config::Address,
 };
 use byteorder::{BigEndian, ReadBytesExt as _, WriteBytesExt as _};
 use crossbeam_channel::Receiver;
@@ -106,7 +106,7 @@ impl TcpNetwork {
             .map(|party| party.dns_name)
             .collect::<Vec<_>>();
         let timeout = config.timeout.unwrap_or(DEFAULT_CONNECTION_TIMEOUT);
-        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENTH);
+        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENGTH);
 
         let domain = match bind_addr {
             SocketAddr::V4(_) => Domain::IPV4,

--- a/mpc-net/src/tls.rs
+++ b/mpc-net/src/tls.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use crate::{
-    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENTH, Network, config::Address,
+    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENGTH, Network, config::Address,
 };
 use byteorder::{BigEndian, ReadBytesExt as _, WriteBytesExt as _};
 use crossbeam_channel::Receiver;
@@ -245,7 +245,7 @@ impl TlsNetwork {
             .map(|party| party.cert)
             .collect::<Vec<_>>();
         let timeout = config.timeout.unwrap_or(DEFAULT_CONNECTION_TIMEOUT);
-        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENTH);
+        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENGTH);
 
         let mut root_store = RootCertStore::empty();
         for cert in &certs {


### PR DESCRIPTION
Fix typos in `mpc-net` and `mpc-core`:

- Rename `DEFAULT_MAX_FRAME_LENTH` → `DEFAULT_MAX_FRAME_LENGTH` and update all references in tcp, tls, and quic modules
- Fix "elemnent" → "element" and "Therebey" → "Thereby" in `mpc-core/src/gadgets/mod.rs`
- Fix "opertions" → "operations" in `mpc-core/src/protocols/shamir.rs`