### PR TITLE
feat: add y2b_many and b2y_many

### DIFF
--- a/mpc-core/src/protocols/rep3/rngs.rs
+++ b/mpc-core/src/protocols/rep3/rngs.rs
@@ -245,7 +245,7 @@ impl Rep3Rand {
     }
 
     /// Generate a random shared permutation
-    pub(crate) fn random_perm<T: Clone>(&mut self, input: Vec<T>) -> (Vec<T>, Vec<T>) {
+    pub fn random_perm<T: Clone>(&mut self, input: Vec<T>) -> (Vec<T>, Vec<T>) {
         let mut a = input.to_owned();
         let mut b = input;
         a.shuffle(&mut self.rng1);

--- a/mpc-core/src/protocols/rep3_ring/conversion.rs
+++ b/mpc-core/src/protocols/rep3_ring/conversion.rs
@@ -870,6 +870,36 @@ pub fn b2y<T: IntRing2k, N: Network>(
     Ok(converted)
 }
 
+/// Transforms the replicated shared value x from a binary sharing to a yao sharing. I.e., x = x_1 xor x_2 xor x_3 gets transformed into wires, such that the garbler have keys (k_0, delta) for each bit of x, while the evaluator has k_x = k_0 xor delta * x.
+pub fn b2y_many<T: IntRing2k, N: Network>(
+    x: &[Rep3RingShare<T>],
+    delta: Option<WireMod2>,
+    net: &N,
+    state: &mut Rep3State,
+) -> eyre::Result<BinaryBundle<WireMod2>> {
+    let [x01, x2] = yao::joint_input_binary_xored_many(x, delta, net, state)?;
+
+    let converted = match state.id {
+        PartyID::ID0 => {
+            // There is no code difference between Rep3Evaluator and StreamingRep3Evaluator
+            let mut evaluator = Rep3Evaluator::new(net);
+            // evaluator.receive_circuit()?; // No network used here
+            let res = GarbledCircuits::xor_many(&mut evaluator, &x01, &x2);
+            GCUtils::garbled_circuits_error(res)?
+        }
+        PartyID::ID1 | PartyID::ID2 => {
+            // There is no code difference between Rep3Garbler and StreamingRep3Garbler
+            let delta = delta.ok_or(eyre::eyre!("No delta provided"))?;
+            let mut garbler = Rep3Garbler::new_with_delta(net, state, delta);
+            let res = GarbledCircuits::xor_many(&mut garbler, &x01, &x2);
+            GCUtils::garbled_circuits_error(res)?
+            // garbler.send_circuit()?; // No network used here
+        }
+    };
+
+    Ok(converted)
+}
+
 /// Transforms the shared value x from a yao sharing to a binary sharing. I.e., the sharing such that the garbler have keys (k_0, delta) for each bit of x, while the evaluator has k_x = k_0 xor delta * x gets transformed into x = x_1 xor x_2 xor x_3.
 pub fn y2b<T: IntRing2k, N: Network>(
     x: BinaryBundle<WireMod2>,
@@ -898,6 +928,55 @@ where
             let px = collapsed;
             let r_xor_x_xor_px = net.recv_from(PartyID::ID0)?;
             Rep3RingShare::new_ring(r_xor_x_xor_px, px)
+        }
+    };
+
+    Ok(converted)
+}
+
+/// Transforms the shared value x from a yao sharing to a binary sharing. I.e., the sharing such that the garbler have keys (k_0, delta) for each bit of x, while the evaluator has k_x = k_0 xor delta * x gets transformed into x = x_1 xor x_2 xor x_3.
+pub fn y2b_many<T: IntRing2k, N: Network>(
+    x: BinaryBundle<WireMod2>,
+    net: &N,
+    state: &mut Rep3State,
+) -> eyre::Result<Vec<Rep3RingShare<T>>>
+where
+    Standard: Distribution<T>,
+{
+    let bits = T::K;
+    let vec = x.extract();
+    if !vec.size().is_multiple_of(bits) {
+        eyre::bail!("Invalid input length");
+    }
+    let num_elements = vec.size() / bits;
+    let mut collapsed = Vec::with_capacity(num_elements);
+    for chunk in vec.wires().chunks(bits) {
+        let bundle = BinaryBundle::new(chunk.to_vec());
+        collapsed.push(GCUtils::collapse_bundle_to_lsb_bits_as_ring(bundle)?);
+    }
+
+    let mut converted = Vec::with_capacity(num_elements);
+    match state.id {
+        PartyID::ID0 => {
+            for x_xor_px in collapsed.iter_mut() {
+                let r = state.rngs.rand.random_element_rng1::<RingElement<T>>();
+                let r_xor_x_xor_px = *x_xor_px ^ r;
+                converted.push(Rep3RingShare::new_ring(r, r_xor_x_xor_px));
+                *x_xor_px = r_xor_x_xor_px;
+            }
+            net.send_to(PartyID::ID2, collapsed)?;
+        }
+        PartyID::ID1 => {
+            for px in collapsed {
+                let r = state.rngs.rand.random_element_rng2::<RingElement<T>>();
+                converted.push(Rep3RingShare::new_ring(px, r));
+            }
+        }
+        PartyID::ID2 => {
+            let r_xor_x_xor_px: Vec<RingElement<T>> = net.recv_from(PartyID::ID0)?;
+            for (r_xor_x_xor_px, px) in r_xor_x_xor_px.into_iter().zip(collapsed) {
+                converted.push(Rep3RingShare::new_ring(r_xor_x_xor_px, px));
+            }
         }
     };
 

--- a/mpc-core/src/protocols/rep3_ring/yao.rs
+++ b/mpc-core/src/protocols/rep3_ring/yao.rs
@@ -284,6 +284,79 @@ pub fn joint_input_binary_xored<T: IntRing2k, N: Network>(
     Ok([x01, x2])
 }
 
+/// Transforms an binary shared input x = (x_1, x_2, x_3) into two yao shares x_1^Y, (x_2 xor x_3)^Y. The used delta is an input to the function to allow for the same delta to be used for multiple conversions.
+pub fn joint_input_binary_xored_many<T: IntRing2k, N: Network>(
+    x: &[Rep3RingShare<T>],
+    delta: Option<WireMod2>,
+    net: &N,
+    state: &mut Rep3State,
+) -> eyre::Result<[BinaryBundle<WireMod2>; 2]> {
+    let n_inputs = x.len();
+    let bitlen = T::K;
+    let bits = n_inputs * bitlen;
+
+    let (x01, x2) = match state.id {
+        PartyID::ID0 => {
+            // Receive x01
+            let x01 = GCUtils::receive_bundle_from(bits, net, PartyID::ID1)?;
+
+            // Receive x2
+            let x2 = GCUtils::receive_bundle_from(bits, net, PartyID::ID2)?;
+            (x01, x2)
+        }
+        PartyID::ID1 => {
+            let delta = delta.ok_or(eyre::eyre!("No delta provided"))?;
+
+            let mut garbler_bundle = Vec::with_capacity(bits);
+            let mut evaluator_bundle = Vec::with_capacity(bits);
+
+            // Input x01
+            for x in x.iter() {
+                let xor = x.a ^ x.b;
+                let bits = GCUtils::ring_to_bits_as_u16(xor);
+                let (garbler, evaluator) =
+                    GCUtils::encode_bits_as_wires(bits, &mut state.rng, delta);
+                garbler_bundle.extend(garbler);
+                evaluator_bundle.extend(evaluator);
+            }
+            let x01 = GCUtils::wires_to_gcinput(garbler_bundle, evaluator_bundle, delta);
+
+            // Send x01 to the other parties
+            GCUtils::send_inputs(&x01, net, PartyID::ID2)?;
+            let x01 = x01.garbler_wires;
+
+            // Receive x2
+            let x2 = GCUtils::receive_bundle_from(bits, net, PartyID::ID2)?;
+            (x01, x2)
+        }
+        PartyID::ID2 => {
+            let delta = delta.ok_or(eyre::eyre!("No delta provided"))?;
+            let mut garbler_bundle = Vec::with_capacity(bits);
+            let mut evaluator_bundle = Vec::with_capacity(bits);
+
+            // Input x2
+            for x in x.iter() {
+                let bits = GCUtils::ring_to_bits_as_u16(x.a);
+                let (garbler, evaluator) =
+                    GCUtils::encode_bits_as_wires(bits, &mut state.rng, delta);
+                garbler_bundle.extend(garbler);
+                evaluator_bundle.extend(evaluator);
+            }
+            let x2 = GCUtils::wires_to_gcinput(garbler_bundle, evaluator_bundle, delta);
+
+            // Send x2 to the other parties
+            GCUtils::send_inputs(&x2, net, PartyID::ID1)?;
+            let x2 = x2.garbler_wires;
+
+            // Receive x01
+            let x01 = GCUtils::receive_bundle_from(bits, net, PartyID::ID1)?;
+            (x01, x2)
+        }
+    };
+
+    Ok([x01, x2])
+}
+
 /// A cast of a vector of Rep3RingShare to a vector of Rep3PrimeFieldShare
 pub fn ring_to_field_many<T: IntRing2k, F: PrimeField, N: Network>(
     inputs: &[Rep3RingShare<T>],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new batched conversion paths between replicated binary shares and Yao wires, plus a new multi-element resharing routine, which touches MPC protocol logic and network message shapes. Main risk is subtle correctness/interoperability issues across parties or mismatched bit lengths in these conversions.
> 
> **Overview**
> Adds batched conversions for replicated ring shares between **binary** and **Yao** representations: new `b2y_many` (binary→Yao for slices) and `y2b_many` (Yao→binary returning `Vec<Rep3RingShare<_>>`).
> 
> Extends Yao input handling with `joint_input_binary_xored_many`, which encodes/ships concatenated wire bundles for multiple elements and is used by the new conversion entry points.
> 
> Makes `Rep3Rand::random_perm` public to allow shared-permutation generation outside the module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 404ff8eabcd5bd7c25657c18f8486ca31a06ab34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->