### PR TITLE
feat: Allow to specify component accelerators for the MPC VM

### DIFF
--- a/co-circom/circom-mpc-vm/src/mpc_vm.rs
+++ b/co-circom/circom-mpc-vm/src/mpc_vm.rs
@@ -926,6 +926,26 @@ impl<F: PrimeField, C: VmCircomWitnessExtension<F>> WitnessExtension<F, C> {
         })
     }
 
+    /// Registers a new accelerator for the MPC-VM replacing a function call with the provided one.
+    pub fn register_accelerator_function(
+        &mut self,
+        name: String,
+        fun: impl Fn(&mut C, &[C::VmType]) -> eyre::Result<Vec<C::VmType>> + Send + 'static,
+    ) {
+        self.ctx.mpc_accelerator.register_function(name, fun);
+    }
+
+    /// Registers a new accelerator for the MPC-VM replacing a compnent with the provided function call.
+    pub fn register_accelerator_component(
+        &mut self,
+        name: String,
+        fun: impl Fn(&mut C, &[C::VmType], usize) -> eyre::Result<ComponentAcceleratorOutput<C::VmType>>
+        + Send
+        + 'static,
+    ) {
+        self.ctx.mpc_accelerator.register_component(name, fun);
+    }
+
     fn set_input_signals(&mut self, mut input_signals: BTreeMap<String, C::VmType>) -> Result<()> {
         for (name, offset, size) in self.main_input_list.iter() {
             if *size == 1 {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds two new public registration methods without changing execution behavior unless callers opt into custom accelerators. Main risk is misuse of the new API leading to incorrect witness computation in downstream code.
> 
> **Overview**
> Adds a public API on `WitnessExtension` to register custom MPC accelerators at runtime.
> 
> Callers can now replace VM `Call` sites via `register_accelerator_function` and replace whole components via `register_accelerator_component`, wiring through to the existing `MpcAccelerator` registry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1243608995de016df4322d85a5bfd020ff2045b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->