### PR TITLE
chore: clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4161,9 +4161,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/co-circom/co-plonk/src/mpc/plain.rs
+++ b/co-circom/co-plonk/src/mpc/plain.rs
@@ -236,7 +236,7 @@ impl<P: Pairing> CircomPlonkProver<P> for PlainPlonkDriver {
             open[i] = open[i] * open[i - 1];
         }
 
-        for (unblind, open) in unblind.iter_mut().zip(open.into_iter()) {
+        for (unblind, open) in unblind.iter_mut().zip(open) {
             *unblind *= open;
         }
         if inv { inv_vec(&unblind) } else { Ok(unblind) }

--- a/co-circom/co-plonk/src/mpc/rep3.rs
+++ b/co-circom/co-plonk/src/mpc/rep3.rs
@@ -207,7 +207,7 @@ impl<P: Pairing> CircomPlonkProver<P> for Rep3PlonkDriver {
             open[i] = open[i] * open[i - 1];
         }
 
-        for (unblind, open) in unblind.iter_mut().zip(open.into_iter()) {
+        for (unblind, open) in unblind.iter_mut().zip(open) {
             *unblind = arithmetic::mul_public(*unblind, open);
         }
         if inv {

--- a/co-circom/co-plonk/src/mpc/shamir.rs
+++ b/co-circom/co-plonk/src/mpc/shamir.rs
@@ -213,7 +213,7 @@ impl<P: Pairing> CircomPlonkProver<P> for ShamirPlonkDriver {
             open[i] = open[i] * open[i - 1];
         }
 
-        for (unblind, open) in unblind.iter_mut().zip(open.into_iter()) {
+        for (unblind, open) in unblind.iter_mut().zip(open) {
             *unblind = arithmetic::mul_public(*unblind, open);
         }
         if inv {

--- a/co-circom/co-plonk/src/round5.rs
+++ b/co-circom/co-plonk/src/round5.rs
@@ -170,10 +170,7 @@ where
 
         let mut poly_r_shared = vec![T::ArithmeticShare::default(); len];
 
-        for (inout, add) in poly_r_shared
-            .iter_mut()
-            .zip(polys.z.poly.clone().into_iter())
-        {
+        for (inout, add) in poly_r_shared.iter_mut().zip(polys.z.poly.clone()) {
             *inout = T::mul_with_public(add, e24);
         }
 
@@ -183,14 +180,14 @@ where
 
         let mut tmp_poly = vec![T::ArithmeticShare::default(); len];
         let xin2 = xin.square();
-        for (inout, add) in tmp_poly.iter_mut().zip(polys.t3.clone().into_iter()) {
+        for (inout, add) in tmp_poly.iter_mut().zip(polys.t3.clone()) {
             *inout = T::mul_with_public(add, xin2);
         }
-        for (inout, add) in tmp_poly.iter_mut().zip(polys.t2.clone().into_iter()) {
+        for (inout, add) in tmp_poly.iter_mut().zip(polys.t2.clone()) {
             let tmp = T::mul_with_public(add, xin);
             *inout = T::add(*inout, tmp);
         }
-        for (inout, add) in tmp_poly.iter_mut().zip(polys.t1.clone().into_iter()) {
+        for (inout, add) in tmp_poly.iter_mut().zip(polys.t1.clone()) {
             *inout = T::add(*inout, add);
         }
         for inout in tmp_poly.iter_mut() {
@@ -226,17 +223,17 @@ where
             *inout = *add;
         }
         // A
-        for (inout, add) in res.iter_mut().zip(polys.a.poly.clone().into_iter()) {
+        for (inout, add) in res.iter_mut().zip(polys.a.poly.clone()) {
             let tmp = T::mul_with_public(add, challenges.v[0]);
             *inout = T::add(tmp, *inout);
         }
         // B
-        for (inout, add) in res.iter_mut().zip(polys.b.poly.clone().into_iter()) {
+        for (inout, add) in res.iter_mut().zip(polys.b.poly.clone()) {
             let tmp = T::mul_with_public(add, challenges.v[1]);
             *inout = T::add(tmp, *inout);
         }
         // C
-        for (inout, add) in res.iter_mut().zip(polys.c.poly.clone().into_iter()) {
+        for (inout, add) in res.iter_mut().zip(polys.c.poly.clone()) {
             let tmp = T::mul_with_public(add, challenges.v[2]);
             *inout = T::add(tmp, *inout);
         }

--- a/co-noir/co-acvm/src/mpc/plain.rs
+++ b/co-noir/co-acvm/src/mpc/plain.rs
@@ -501,7 +501,7 @@ impl<F: PrimeField> NoirWitnessExtensionProtocol<F> for PlainAcvmSolver<F> {
             })
             .collect();
 
-        indexed_values.sort_by(|a, b| a.0.cmp(&b.0));
+        indexed_values.sort_by_key(|a| a.0);
 
         let mut results = Vec::with_capacity(inputs.len());
 

--- a/co-noir/co-acvm/src/solver/blackbox_solver.rs
+++ b/co-noir/co-acvm/src/solver/blackbox_solver.rs
@@ -89,10 +89,8 @@ where
         };
 
         match (T::get_public(&old_value), T::get_public(&value_to_insert)) {
-            (Some(old_value), Some(value_to_insert)) => {
-                if old_value != value_to_insert {
-                    Err(eyre::eyre!("UnsatisfiedConstraint"))?;
-                }
+            (Some(old_value), Some(value_to_insert)) if old_value != value_to_insert => {
+                Err(eyre::eyre!("UnsatisfiedConstraint"))?;
             }
             _ => { // We cannot have this sanitiy check
             }
@@ -230,7 +228,7 @@ where
         let state = driver.poseidon2_permutation(state, &poseidon2)?;
 
         // Write witness assignments
-        for (output_witness, value) in outputs.iter().zip(state.into_iter()) {
+        for (output_witness, value) in outputs.iter().zip(state) {
             Self::insert_value(output_witness, value, initial_witness)?;
         }
         Ok(())
@@ -244,7 +242,7 @@ where
         let message_input = Self::get_hash_input(initial_witness, inputs)?;
         let digest = T::blake3_hash(driver, message_input, 8)?; // This is now hardcoded to 8 in Noir
 
-        for (output_witness, value) in outputs.iter().zip(digest.into_iter()) {
+        for (output_witness, value) in outputs.iter().zip(digest) {
             Self::insert_value(output_witness, value, initial_witness)?;
         }
 
@@ -338,7 +336,7 @@ where
 
         let state = T::sha256_compression(driver, &state, &message)?;
 
-        for (output_witness, value) in outputs.iter().zip(state.into_iter()) {
+        for (output_witness, value) in outputs.iter().zip(state) {
             Self::insert_value(output_witness, value, initial_witness)?;
         }
 
@@ -354,7 +352,7 @@ where
         let message_input = Self::get_hash_input(initial_witness, inputs)?;
         let digest = T::blake2s_hash(driver, message_input, 8)?; // This is now hardcoded to 8 in Noir
 
-        for (output_witness, value) in outputs.iter().zip(digest.into_iter()) {
+        for (output_witness, value) in outputs.iter().zip(digest) {
             Self::insert_value(output_witness, value, initial_witness)?;
         }
 
@@ -403,7 +401,7 @@ where
         let ciphertext = T::aes128_encrypt(driver, &scalars, ivs, keys)?;
 
         // Write witness assignments
-        for (output_witness, value) in outputs.iter().zip(ciphertext.into_iter()) {
+        for (output_witness, value) in outputs.iter().zip(ciphertext) {
             Self::insert_value(output_witness, value, initial_witness)?;
         }
         Ok(())

--- a/co-noir/co-builder/src/ultra_builder.rs
+++ b/co-noir/co-builder/src/ultra_builder.rs
@@ -1063,9 +1063,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>>
             *rangecount += 1; // we need to add 1 extra addition gates for every distinct range list
         }
         // update rangecount to include the ram range checks the composer will eventually be creating
-        for (ram_range_sizes, ram_range_exist) in ram_range_sizes
-            .into_iter()
-            .zip(ram_range_exists.into_iter())
+        for (ram_range_sizes, ram_range_exist) in ram_range_sizes.into_iter().zip(ram_range_exists)
         {
             if !ram_range_exist {
                 *rangecount += ram_range_sizes;
@@ -2347,7 +2345,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>>
             .collect();
 
         // here we sort two times, since the ordering should be according to this: self.index < other.index || (self.index == other.index && self.timestamp < other.timestamp), hence we first sort along timestamp (which is public), then along index
-        indexed_to_sort3.sort_by(|a, b| a.1.cmp(&b.1));
+        indexed_to_sort3.sort_by_key(|a| a.1);
 
         let mut key = Vec::with_capacity(indexed_to_sort3.len());
         let mut to_sort1 = Vec::with_capacity(indexed_to_sort3.len());

--- a/deny.toml
+++ b/deny.toml
@@ -26,8 +26,8 @@ ignore = [
     { id = "RUSTSEC-2024-0388", reason = "ignore drivative unmaintained, dependency of circom" },
     { id = "RUSTSEC-2024-0436", reason = "ignore paste unmaintained" },
     { id = "RUSTSEC-2025-0055", reason = "ignore vulnerability in tracing-subscriber < 0.3.20, used by ark-relation in examples but as normal dependency" },
-    { id = "RUSTSEC-2025-0057", reason = "ignore fxhash unmaintained, dependency of acvm" },
     { id = "RUSTSEC-2025-0141", reason = "ignore bincode unmaintained" },
+    { id = "RUSTSEC-2026-0097", reason = "ignore rand vuln with custom loggers" },
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/mpc-core/src/gadgets/poseidon2/poseidon2_circom_accelerator.rs
+++ b/mpc-core/src/gadgets/poseidon2/poseidon2_circom_accelerator.rs
@@ -242,9 +242,9 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
 
         for (sq, qu) in squares_1
             .into_iter()
-            .zip(quads_1.into_iter())
-            .chain(squares_3.into_iter().zip(quads_3.into_iter()))
-            .chain(squares_2.into_iter().zip(quads_2.into_iter()))
+            .zip(quads_1)
+            .chain(squares_3.into_iter().zip(quads_3))
+            .chain(squares_2.into_iter().zip(quads_2))
         {
             if let Some(idx) = wtns_indices_iter.next() {
                 trace[idx as usize] = sq;
@@ -1072,9 +1072,9 @@ impl<F: PrimeField, const T: usize> CircomTracePlainHasher<F, T> for Poseidon2<F
 
         for (sq, qu) in squares_1
             .into_iter()
-            .zip(quads_1.into_iter())
-            .chain(squares_3.into_iter().zip(quads_3.into_iter()))
-            .chain(squares_2.into_iter().zip(quads_2.into_iter()))
+            .zip(quads_1)
+            .chain(squares_3.into_iter().zip(quads_3))
+            .chain(squares_2.into_iter().zip(quads_2))
         {
             if let Some(idx) = wtns_indices_iter.next() {
                 trace[idx as usize] = sq;

--- a/mpc-core/src/protocols/rep3_ring/gadgets/lut_curve.rs
+++ b/mpc-core/src/protocols/rep3_ring/gadgets/lut_curve.rs
@@ -32,7 +32,7 @@ where
         conversion::bit_inject_from_bits_to_field_many::<C::ScalarField, _>(&e, net, state)?;
 
     let mut t = Rep3PointShare::default();
-    for (l, e) in lut.iter().zip(injected.into_iter()) {
+    for (l, e) in lut.iter().zip(injected) {
         let mul = pointshare::scalar_mul_public_point(l, e);
         t += &mul;
     }
@@ -96,7 +96,7 @@ where
 
     // Start the result with a random mask (for potential resharing later)
     let mut t = state.rngs.rand.masking_ec_element::<C>();
-    for (l, e) in lut.iter().zip(injected.into_iter()) {
+    for (l, e) in lut.iter().zip(injected) {
         let mul = e * l;
         t += &mul;
     }

--- a/mpc-core/src/protocols/rep3_ring/gadgets/lut_field.rs
+++ b/mpc-core/src/protocols/rep3_ring/gadgets/lut_field.rs
@@ -231,7 +231,7 @@ where
 
     // Start the result with a random mask (for potential resharing later)
     let mut t = state.rngs.rand.masking_field_element::<F>();
-    for (l, e) in lut.iter().zip(injected.into_iter()) {
+    for (l, e) in lut.iter().zip(injected) {
         let mul = &e * l;
         t += mul;
     }

--- a/mpc-core/src/protocols/rep3_ring/lut_field.rs
+++ b/mpc-core/src/protocols/rep3_ring/lut_field.rs
@@ -121,7 +121,7 @@ impl<F: PrimeField> Rep3FieldLookupTable<F> {
         let mut result = Vec::with_capacity(luts.len());
 
         // TODO parallelize this at some point
-        for (bin_a, bin_b) in bins_a.into_iter().zip(bins_b.into_iter()) {
+        for (bin_a, bin_b) in bins_a.into_iter().zip(bins_b) {
             let bin = Rep3BigUintShare::new(bin_a, bin_b);
             let res = rep3::conversion::b2a_selector(&bin, net0, state0)?;
             result.push(res);

--- a/tests/tests/mpc/bridges.rs
+++ b/tests/tests/mpc/bridges.rs
@@ -20,11 +20,7 @@ mod translate_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             thread::spawn(move || {
                 let preprocessing = ShamirPreprocessing::new(3, 1, 1, &net).unwrap();
                 let mut shamir = ShamirState::from(preprocessing);
@@ -54,11 +50,7 @@ mod translate_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             thread::spawn(move || {
                 let preprecessing = ShamirPreprocessing::new(3, 1, x.len(), &net).unwrap();
                 let mut shamir = ShamirState::from(preprecessing);
@@ -86,11 +78,7 @@ mod translate_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             thread::spawn(move || {
                 let preprecessing = ShamirPreprocessing::new(3, 1, 1, &net).unwrap();
                 let mut shamir = ShamirState::from(preprecessing);

--- a/tests/tests/mpc/rep3.rs
+++ b/tests/tests/mpc/rep3.rs
@@ -438,11 +438,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(arithmetic::inv(x, &net, &mut state).unwrap())
@@ -493,11 +489,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::bit_inject(&x, &net, &mut state).unwrap())
@@ -540,7 +532,7 @@ mod field_share {
         for ((net, tx), x) in nets
             .into_iter()
             .zip([tx1, tx2, tx3])
-            .zip([x0_shares, x1_shares, x2_shares].into_iter())
+            .zip([x0_shares, x1_shares, x2_shares])
         {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
@@ -651,11 +643,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2b(x, &net, &mut state).unwrap())
@@ -681,11 +669,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2y2b(x, &net, &mut state).unwrap())
@@ -711,11 +695,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2y2b_streaming(x, &net, &mut state).unwrap())
@@ -756,7 +736,7 @@ mod field_share {
         for ((net, tx), x) in nets
             .into_iter()
             .zip([tx1, tx2, tx3])
-            .zip([x0_shares, x1_shares, x2_shares].into_iter())
+            .zip([x0_shares, x1_shares, x2_shares])
         {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
@@ -781,11 +761,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2b(x, &net, &mut state).unwrap())
@@ -812,11 +788,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2y2b(x, &net, &mut state).unwrap())
@@ -843,11 +815,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2y2b_streaming(x, &net, &mut state).unwrap())
@@ -889,7 +857,7 @@ mod field_share {
         for ((net, tx), x) in nets
             .into_iter()
             .zip([tx1, tx2, tx3])
-            .zip([x0_shares, x1_shares, x2_shares].into_iter())
+            .zip([x0_shares, x1_shares, x2_shares])
         {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
@@ -914,11 +882,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::b2a(&x, &net, &mut state).unwrap())
@@ -941,11 +905,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::b2y2a(&x, &net, &mut state).unwrap())
@@ -968,11 +928,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::b2y2a_streaming(&x, &net, &mut state).unwrap())
@@ -1349,11 +1305,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 let id = state.id;
@@ -1396,11 +1348,7 @@ mod field_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 let id = state.id;
@@ -1702,7 +1650,7 @@ mod field_share {
         let y_shares = rep3::share_field_elements(&y, &mut rng);
 
         let mut should_result = Vec::new();
-        for (x, y) in x.into_iter().zip(y.into_iter()) {
+        for (x, y) in x.into_iter().zip(y) {
             let mut x: BigUint = x.into();
             let mut y: BigUint = y.into();
             let mut xs = Vec::with_capacity(NUM_DECOMPS);
@@ -1984,7 +1932,7 @@ mod field_share {
         let y_shares = rep3::share_field_elements(&y, &mut rng);
 
         let mut should_result = Vec::new();
-        for (x, y) in x.into_iter().zip(y.into_iter()) {
+        for (x, y) in x.into_iter().zip(y) {
             let mut x: BigUint = x.into();
             let mut y: BigUint = y.into();
             let mut xs = Vec::with_capacity(NUM_DECOMPS);
@@ -2105,7 +2053,7 @@ mod field_share {
             x &= &mask;
             shortened.push((i, ark_bn254::Fr::from(x)));
         }
-        shortened.sort_by(|a, b| a.1.cmp(&b.1));
+        shortened.sort_by_key(|a| a.1);
         let mut should_result = Vec::with_capacity(VEC_SIZE);
         for (i, _) in shortened.into_iter() {
             should_result.push(x[i]);
@@ -2372,7 +2320,7 @@ mod field_share {
         let y_shares = rep3::share_field_elements(&keys_b, &mut rng);
 
         let mut should_result = Vec::new();
-        for (x, y) in keys_a.into_iter().zip(keys_b.into_iter()) {
+        for (x, y) in keys_a.into_iter().zip(keys_b) {
             let mut x: BigUint = x.into();
             let mut y: BigUint = y.into();
             let mut xs = Vec::with_capacity(slice_sizes.len());
@@ -2505,7 +2453,7 @@ mod field_share {
         let y_shares = rep3::share_field_elements(&keys_b, &mut rng);
 
         let mut should_result = Vec::new();
-        for (x, y) in keys_a.into_iter().zip(keys_b.into_iter()) {
+        for (x, y) in keys_a.into_iter().zip(keys_b) {
             let mut x: BigUint = x.into();
             let mut y: BigUint = y.into();
             let mut xs = Vec::with_capacity(slice_sizes.len());
@@ -2619,7 +2567,7 @@ mod field_share {
         let y_shares = rep3::share_field_elements(&keys_b, &mut rng);
 
         let mut should_result = Vec::new();
-        for (x, y) in keys_a.into_iter().zip(keys_b.into_iter()) {
+        for (x, y) in keys_a.into_iter().zip(keys_b) {
             let mut x: BigUint = x.into();
             let mut y: BigUint = y.into();
             let mut xs = Vec::with_capacity(slice_sizes.len());
@@ -3152,7 +3100,7 @@ mod field_share {
         let y_shares = rep3::share_field_elements(&y, &mut rng);
 
         let mut should_result = Vec::with_capacity(VEC_SIZE);
-        for (x, y) in x.into_iter().zip(y.into_iter()) {
+        for (x, y) in x.into_iter().zip(y) {
             let x: BigUint = x.into();
             let y: BigUint = y.into();
 
@@ -3241,7 +3189,7 @@ mod field_share {
         let y_shares = rep3::share_field_elements(&y, &mut rng);
 
         let mut should_result = Vec::with_capacity(VEC_SIZE);
-        for (x, y) in x.iter().cloned().zip(y.into_iter()) {
+        for (x, y) in x.iter().cloned().zip(y) {
             let x: BigUint = x.into();
             let y: BigUint = y.into();
 

--- a/tests/tests/mpc/rep3_ring.rs
+++ b/tests/tests/mpc/rep3_ring.rs
@@ -410,11 +410,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::bit_inject(&x, &net, &mut state).unwrap())
@@ -464,7 +460,7 @@ mod ring_share {
         for ((net, tx), x) in nets
             .into_iter()
             .zip([tx1, tx2, tx3])
-            .zip([x0_shares, x1_shares, x2_shares].into_iter())
+            .zip([x0_shares, x1_shares, x2_shares])
         {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
@@ -553,11 +549,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2b(x, &net, &mut state).unwrap())
@@ -587,11 +579,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2y2b(x, &net, &mut state).unwrap())
@@ -621,11 +609,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2y2b_streaming(x, &net, &mut state).unwrap())
@@ -658,11 +642,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2b(x, &net, &mut state).unwrap())
@@ -692,11 +672,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2y2b(x, &net, &mut state).unwrap())
@@ -726,11 +702,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::a2y2b_streaming(x, &net, &mut state).unwrap())
@@ -760,11 +732,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::b2a(&x, &net, &mut state).unwrap())
@@ -794,11 +762,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::b2y2a(&x, &net, &mut state).unwrap())
@@ -828,11 +792,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 tx.send(conversion::b2y2a_streaming(&x, &net, &mut state).unwrap())
@@ -1191,11 +1151,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 let id = state.id;
@@ -1245,11 +1201,7 @@ mod ring_share {
         let (tx1, rx1) = mpsc::channel();
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
-        for ((net, tx), x) in nets
-            .into_iter()
-            .zip([tx1, tx2, tx3])
-            .zip(x_shares.into_iter())
-        {
+        for ((net, tx), x) in nets.into_iter().zip([tx1, tx2, tx3]).zip(x_shares) {
             std::thread::spawn(move || {
                 let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 let id = state.id;
@@ -1749,7 +1701,7 @@ mod ring_share {
         let x_shares = rep3_ring::share_ring_elements(&x, &mut rng);
         let y_shares = rep3_ring::share_ring_elements(&y, &mut rng);
         let mut should_result: Vec<RingElement<T>> = Vec::with_capacity(VEC_SIZE);
-        for (x, y) in x.into_iter().zip(y.into_iter()) {
+        for (x, y) in x.into_iter().zip(y) {
             should_result.push(RingElement(T::cast_from_biguint(
                 &(x.0.cast_to_biguint() / y.0.cast_to_biguint()),
             )));
@@ -2042,7 +1994,7 @@ mod ring_share {
             .collect_vec();
         let y_shares = rep3_ring::share_ring_elements(&y, &mut rng);
         let mut should_result: Vec<RingElement<T>> = Vec::with_capacity(VEC_SIZE);
-        for (x, y) in x.iter().zip(y.into_iter()) {
+        for (x, y) in x.iter().zip(y) {
             should_result.push(RingElement(T::cast_from_biguint(
                 &(x.0.cast_to_biguint() / y.0.cast_to_biguint()),
             )));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly mechanical refactors to iteration/sorting plus a minor dependency lockfile bump; behavior should be unchanged aside from relying on stable sort-key ordering semantics.
> 
> **Overview**
> Primarily addresses new Clippy warnings by simplifying iterator usage (removing unnecessary `into_iter()` calls in `zip`/`chain` loops) and replacing a few `sort_by(|a,b| a.cmp(b))` comparisons with `sort_by_key` across MPC/Plonk/Noir code and tests.
> 
> Separately bumps `rustls-webpki` in `Cargo.lock` and updates `deny.toml` advisory ignores (drops `RUSTSEC-2025-0057`, adds `RUSTSEC-2026-0097`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3800514df3a31393b7b54c0761e499f855195e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->