### PR TITLE
chore: fix typos across the codebase

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,21 @@
+[files]
+extend-exclude = [
+    "test_vectors/",
+    "**/CHANGELOG.md",
+    "co-circom/co-circom/examples/**/test_vectors/",
+    "co-circom/co-circom/examples/lib/",
+]
+
+[default.extend-words]
+# Jens Groth / Groth16 — named after the cryptographer, not a typo for "growth"
+Groth = "Groth"
+groth = "groth"
+
+# MiMC hash function — not the word "mimic"
+MiMC = "MiMC"
+Mimc = "Mimc"
+mimc = "mimc"
+
+# "OT" = Oblivious Transfer (MPC primitive)
+OT = "OT"
+Ot = "Ot"

--- a/co-circom/circom-mpc-vm/src/mpc_vm.rs
+++ b/co-circom/circom-mpc-vm/src/mpc_vm.rs
@@ -935,7 +935,7 @@ impl<F: PrimeField, C: VmCircomWitnessExtension<F>> WitnessExtension<F, C> {
         self.ctx.mpc_accelerator.register_function(name, fun);
     }
 
-    /// Registers a new accelerator for the MPC-VM replacing a compnent with the provided function call.
+    /// Registers a new accelerator for the MPC-VM replacing a component with the provided function call.
     pub fn register_accelerator_component(
         &mut self,
         name: String,

--- a/co-circom/co-circom/src/bin/co-circom.rs
+++ b/co-circom/co-circom/src/bin/co-circom.rs
@@ -300,7 +300,7 @@ pub struct GenerateWitnessConfig {
     pub network: NetworkConfig,
 }
 
-/// Cli arguments for `transalte_witness`
+/// Cli arguments for `translate_witness`
 #[derive(Debug, Serialize, Args)]
 pub struct TranslateWitnessCli {
     /// The path to the config file
@@ -329,7 +329,7 @@ pub struct TranslateWitnessCli {
     pub out: Option<PathBuf>,
 }
 
-/// Config for `transalte_witness`
+/// Config for `translate_witness`
 #[derive(Debug, Deserialize)]
 pub struct TranslateWitnessConfig {
     /// The path to the witness share file

--- a/co-circom/co-circom/src/bin/poseidon2_bench.rs
+++ b/co-circom/co-circom/src/bin/poseidon2_bench.rs
@@ -72,7 +72,7 @@ pub struct Cli {
     #[arg(short, long, default_value_t = 10)]
     pub batch_size: usize,
 
-    /// The number of leafs in the Merkle tree tree benchmarks
+    /// The number of leaves in the Merkle tree tree benchmarks
     #[arg(short, long, default_value_t = 1024)]
     pub merkle_size: usize,
 
@@ -90,7 +90,7 @@ pub struct Config {
     pub threshold: usize,
     /// The batch size for the number of poseidon elements in parallel in packed implementation
     pub batch_size: usize,
-    /// The number of leafs in the Merkle tree benchmarks
+    /// The number of leaves in the Merkle tree benchmarks
     pub merkle_size: usize,
     /// Statesize for the hash function
     pub statesize: usize,

--- a/co-circom/co-groth16/src/mpc/shamir.rs
+++ b/co-circom/co-groth16/src/mpc/shamir.rs
@@ -9,7 +9,7 @@ use mpc_core::{
 use mpc_net::Network;
 use rayon::prelude::*;
 
-/// A Groth16 dirver unsing shamir secret sharing
+/// A Groth16 driver using shamir secret sharing
 pub struct ShamirGroth16Driver;
 
 impl<P: Pairing> CircomGroth16Prover<P> for ShamirGroth16Driver {

--- a/co-circom/co-plonk/src/round3.rs
+++ b/co-circom/co-plonk/src/round3.rs
@@ -474,7 +474,7 @@ impl<'a, P: Pairing, T: CircomPlonkProver<P>, N: Network + 'static> Round3<'a, P
             let a_rhs = &coefficients_t[i];
             let a = T::sub(*a_lhs, *a_rhs);
             coefficients_t[i] = a;
-            // Snarkjs is checking whether the poly was divisble by Zh, but we cannot do this here
+            // Snarkjs is checking whether the poly was divisible by Zh, but we cannot do this here
         });
 
         let coefficients_tz = T::ifft(&tz_vec, &domains.extended_domain);

--- a/co-noir/co-acvm/src/mpc/shamir.rs
+++ b/co-noir/co-acvm/src/mpc/shamir.rs
@@ -192,7 +192,7 @@ impl<'a, F: PrimeField, N: Network> NoirWitnessExtensionProtocol<F> for ShamirAc
     }
 
     fn shared_zeros(&mut self, len: usize) -> eyre::Result<Vec<Self::AcvmType>> {
-        // TODO: This is not the best implementaiton for shared zeros
+        // TODO: This is not the best implementation for shared zeros
         let trivial_zeros = vec![F::zero(); len];
         let res = self
             .net

--- a/co-noir/co-acvm/src/solver/assert_zero_solver.rs
+++ b/co-noir/co-acvm/src/solver/assert_zero_solver.rs
@@ -31,7 +31,7 @@ where
                         self.witness().get(lhs).cloned(),
                         self.witness().get(rhs).cloned(),
                     ) {
-                        // we could batch this multiplication but our currently planed network design
+                        // we could batch this multiplication but our currently planned network design
                         // should solve this without batching
                         (Some(lhs), Some(rhs)) => {
                             tracing::trace!("solving mul term...");

--- a/co-noir/co-brillig/src/brillig_vm.rs
+++ b/co-noir/co-brillig/src/brillig_vm.rs
@@ -34,7 +34,7 @@ where
 /// The result of a single run of the coBrillig-VM.
 ///
 /// **Note:** If the coBrillig-VM encountered a branch on shared
-/// values, it will return sucess if one of the paths did not encounter
+/// values, it will return success if one of the paths did not encounter
 /// a trap. In such a case, as we do not know what the correct execution
 /// path would have been, we return a success result with random noise.
 /// The constructed proof will then not verify.
@@ -43,7 +43,7 @@ where
     T: BrilligDriver<F>,
     F: PrimeField + Clone,
 {
-    /// Indicates that the run of the Brillig-VM was a sucess. Holds
+    /// Indicates that the run of the Brillig-VM was a success. Holds
     /// the computed values
     Success(BrilligSuccess<T::BrilligType>),
     /// Indicates that the run failed. At the moment, this only happens
@@ -51,7 +51,7 @@ where
     Failed,
 }
 
-/// The values produces by the coBrillig-VM on a successfull run.
+/// The values produces by the coBrillig-VM on a successful run.
 pub struct BrilligSuccess<T> {
     /// The return value of the function executed by the coBrillig-VM. Those values
     /// are the same (secret-shared) values produced by the ordinary Brillig-VM.
@@ -424,10 +424,10 @@ where
         } else {
             0
         };
-        let persitent_shared_state = std::mem::take(&mut self.persistent_shared_state);
+        let persistent_shared_state = std::mem::take(&mut self.persistent_shared_state);
         Ok(CoBrilligResult::Success(BrilligSuccess {
             unconstrained_witnesses: self.take_result(offset, size),
-            generated_pss: persitent_shared_state,
+            generated_pss: persistent_shared_state,
         }))
     }
 

--- a/co-noir/co-brillig/src/mpc/plain.rs
+++ b/co-noir/co-brillig/src/mpc/plain.rs
@@ -140,7 +140,7 @@ impl<F: PrimeField> BrilligDriver<F> for PlainBrilligDriver<F> {
                     Ok(char::from(u8::try_from(int).expect("u8 fits into char")))
                 } else {
                     Err(eyre::eyre!(
-                        "Must be {} bits for charcters, but is {}",
+                        "Must be {} bits for characters, but is {}",
                         CHAR_BIT_SIZE,
                         bit_size
                     ))

--- a/co-noir/co-brillig/src/taceo_std_lib.rs
+++ b/co-noir/co-brillig/src/taceo_std_lib.rs
@@ -27,7 +27,7 @@ where
                 "Invalid signature for TACEO store. We expect two inputs, a name and the data"
             );
         }
-        let identifer = if let ValueOrArray::HeapArray(heap_array) = inputs[0].to_owned() {
+        let identifier = if let ValueOrArray::HeapArray(heap_array) = inputs[0].to_owned() {
             let mem = self.memory.read_heap_array(heap_array)?;
             mem.into_iter()
                 .map(|c| T::try_into_char(c))
@@ -42,15 +42,15 @@ where
             self.memory.read_heap_array(heap_array)?
         } else {
             eyre::bail!(
-                "Invalid signature for TACEO store. Second paramter must be array of field elements."
+                "Invalid signature for TACEO store. Second parameter must be array of field elements."
             );
         };
         if self
             .persistent_shared_state
-            .insert(identifer.clone(), serialized)
+            .insert(identifier.clone(), serialized)
             .is_some()
         {
-            eyre::bail!("duplicate entry for shared state id: {identifer}");
+            eyre::bail!("duplicate entry for shared state id: {identifier}");
         }
 
         Ok(())

--- a/co-noir/co-builder/src/acir_format.rs
+++ b/co-noir/co-builder/src/acir_format.rs
@@ -179,7 +179,7 @@ impl<F: PrimeField> AcirFormat<F> {
                 acir::circuit::Opcode::MemoryOp { block_id, op } => {
                     let block = block_id_to_block_constraint.get_mut(&block_id.0);
                     if block.is_none() {
-                        panic!("unitialized MemoryOp");
+                        panic!("uninitialized MemoryOp");
                     }
                     let block = block.unwrap();
                     Self::handle_memory_op(op, &mut af, &mut block.0);
@@ -264,7 +264,7 @@ impl<F: PrimeField> AcirFormat<F> {
                 return;
             }
             // Even if the number of linear terms is less than 3, we might not be able to fit it into a width-3 arithmetic
-            // gate. This is the case if the linear terms are all disctinct witness from the multiplication term. In that
+            // gate. This is the case if the linear terms are all distinct witness from the multiplication term. In that
             // case, the serialize_arithmetic_gate() function will return a poly_triple with all 0's, and we use a width-4
             // gate instead. We could probably always use a width-4 gate in fact.
             if pt == PolyTriple::default() {
@@ -657,7 +657,7 @@ impl<F: PrimeField> AcirFormat<F> {
             // Updates both af.minimal_range and af.index_range with u_bit_range when it is lower.
             // By doing so, we keep these invariants:
             // - minimal_range contains the smallest possible range for a witness
-            // - index_range constains the smallest range for a witness implied by any array operation
+            // - index_range contains the smallest range for a witness implied by any array operation
             if af.minimal_range.contains_key(&index_witness) {
                 if af.minimal_range[&index_witness] > bit_range {
                     af.minimal_range.insert(index_witness, bit_range);

--- a/co-noir/co-builder/src/honk_verifier/oink_recursive_verifier.rs
+++ b/co-noir/co-builder/src/honk_verifier/oink_recursive_verifier.rs
@@ -180,7 +180,7 @@ impl OinkRecursiveVerifier {
         // at the end of the loop, add and subtract β to each term respectively to
         // set the expected value for the start of iteration i+1.
         // Note: The public inputs may be offset from the 0th index of the wires, for example due to the inclusion of an
-        // initial zero row or Goblin-stlye ECC op gates. Accordingly, the indices i in the above formulas are given by i =
+        // initial zero row or Goblin-style ECC op gates. Accordingly, the indices i in the above formulas are given by i =
         // [0, m-1] + offset, i.e. i = offset, 1 + offset, …, m - 1 + offset.
 
         let mut numerator = one.clone();

--- a/co-noir/co-builder/src/honk_verifier/padding_indicator_array.rs
+++ b/co-noir/co-builder/src/honk_verifier/padding_indicator_array.rs
@@ -12,7 +12,7 @@ use co_noir_common::types::ZeroKnowledge;
 /**
  * @brief For a small integer N = `virtual_log_n` and a given witness x = `log_n`, compute in-circuit an
  * `indicator_padding_array` of size \f$ N \f$, such that
- * \f{align}{ \text{indicator_padding_array}[i] = \text{"} i < x \text{"}. \f}. To achieve the strict ineqaulity, we
+ * \f{align}{ \text{indicator_padding_array}[i] = \text{"} i < x \text{"}. \f}. To achieve the strict inequality, we
  * evaluate all Lagranges at (x-1) and compute step functions. More concretely
  *
  * 1) Constrain x to be in the range \f$ [1, \ldots, N] \f$ by asserting

--- a/co-noir/co-builder/src/honk_verifier/shplemini.rs
+++ b/co-noir/co-builder/src/honk_verifier/shplemini.rs
@@ -342,7 +342,7 @@ impl ShpleminiVerifier {
      * This method uses `padding_indicator_array`, whose i-th entry is FF{1} if i < log_n and 0 otherwise.
      * We use these entries to either assign `eval_pos_prev` the value `eval_pos` computed in the current iteration of
      * the loop, or to propagate the batched evaluation of the multilinear polynomials to the next iteration. This
-     * ensures the correctnes of the computation of the required positive evaluations.
+     * ensures the correctness of the computation of the required positive evaluations.
      *
      * To ensure that dummy evaluations cannot be used to tamper with the final batch_mul result, we multiply dummy
      * positive evaluations by the entries of `padding_indicator_array`.
@@ -458,7 +458,7 @@ impl ShpleminiVerifier {
      *    \frac{\nu^{2 \cdot d} } {z - r^{2^{d-1}}} + \frac{\nu^{2 \cdot d + 1}}{z + r^{2^{d-1}}}
      *    \f}
      *    and multiplies them against the entries of `padding_indicator_array`. The commitments \f$ [A_1]_1, \ldots,
-     *    [A_{d-1}]_1 \f$ are multiplied by these scalars in the final `batch_mul` perfomed by KZG or IPA. Since
+     *    [A_{d-1}]_1 \f$ are multiplied by these scalars in the final `batch_mul` performed by KZG or IPA. Since
      *    `padding_indicator_array[i]` = 1 for i < log_n, and 0 otherwise, it ensures that the contributions from "dummy"
      *    rounds do not affect the final `batch mul`.
      *

--- a/co-noir/co-builder/src/types/big_field.rs
+++ b/co-noir/co-builder/src/types/big_field.rs
@@ -258,7 +258,7 @@ impl<F: PrimeField> BigField<F> {
             true,
         );
 
-        // AZTEC TODO(https://github.com/AztecProtocol/barretenberg/issues/879): dummy necessary for preceeding big add
+        // AZTEC TODO(https://github.com/AztecProtocol/barretenberg/issues/879): dummy necessary for preceding big add
         // gate
 
         GenericUltraCircuitBuilder::<P, T>::create_unconstrained_gate(
@@ -293,7 +293,7 @@ impl<F: PrimeField> BigField<F> {
             },
         );
 
-        // if maximum_bitlength is set, this supercedes can_overflow
+        // if maximum_bitlength is set, this supersedes can_overflow
         if maximum_bitlength > 0 {
             num_last_limb_bits = maximum_bitlength - (NUM_LIMB_BITS * 3);
             let max_limb_value = (BigUint::one() << num_last_limb_bits) - BigUint::one();
@@ -1994,7 +1994,7 @@ impl<F: PrimeField> BigField<F> {
         // | a2 | b2 | r3 | hi_0 |
         // | a1 | b1 | r2 | hi_1 |
         //
-        // Example constaint: lo_0 = (a1 * b0 + a0 * b1) * 2^b   + (a0 * b0)   - r0
+        // Example constraint: lo_0 = (a1 * b0 + a0 * b1) * 2^b   + (a0 * b0)   - r0
         //                 ==>  w4 = (w1 * w'2 + w'1 * w2) * 2^b + (w'1 * w'2) - w3
         //
         // If a, b both are witnesses, this special gate performs 3 field multiplications per gate.
@@ -2439,7 +2439,7 @@ impl<F: PrimeField> BigField<F> {
     // i.e. we evaluate:
     // result * divisor + (\sum{mul_left[i] * mul_right[i]) + ...to_add) = 0
     //
-    // It is critical that ALL the terms on the LHS are positive to eliminate the possiblity of underflows
+    // It is critical that ALL the terms on the LHS are positive to eliminate the possibility of underflows
     // when calling `evaluate_multiple_multiply_add`
     //
     // only requires one quotient and remainder + overflow limbs
@@ -2997,7 +2997,7 @@ impl<F: PrimeField> BigField<F> {
         // | a2 | b2 | r3 | hi_0 |
         // | a1 | b1 | r2 | hi_1 |
         //
-        // Example constaint: lo_0 = (a1 * b0 + a0 * b1) * 2^b   + (a0 * b0)   - r0
+        // Example constraint: lo_0 = (a1 * b0 + a0 * b1) * 2^b   + (a0 * b0)   - r0
         //                 ==>  w4 = (w1 * w'2 + w'1 * w2) * 2^b + (w'1 * w'2) - w3
         //
         // If a, b both are witnesses, this special gate performs 3 field multiplications per gate.

--- a/co-noir/co-builder/src/types/big_group/big_group.rs
+++ b/co-noir/co-builder/src/types/big_group/big_group.rs
@@ -415,12 +415,12 @@ impl<F: PrimeField, T: NoirWitnessExtensionProtocol<F>> BigGroup<F, T> {
             Self::precomputed_offset_generators::<P>(num_rounds)?;
 
         // Initialize accumulator with initial offset generator + first NAF column
-        let mut inital_entry: ChainAddAccumulator<F> =
+        let mut initial_entry: ChainAddAccumulator<F> =
             point_table.get_chain_initial_entry(builder, driver)?;
 
         let tmp = Self::chain_add(
             &mut offset_generator_start,
-            &mut inital_entry,
+            &mut initial_entry,
             builder,
             driver,
         )?;

--- a/co-noir/co-builder/src/types/big_group/big_group_edgecase_handling.rs
+++ b/co-noir/co-builder/src/types/big_group/big_group_edgecase_handling.rs
@@ -76,7 +76,7 @@ pub(crate) fn mask_points<
 
 /**
  * @brief Replace all pairs (∞, scalar) by the pair (one, 0) where one is a fixed generator of the curve
- * @details This is a step in enabling our our multiscalar multiplication algorithms to hande points at infinity.
+ * @details This is a step in enabling our multiscalar multiplication algorithms to handle points at infinity.
  */
 // TACEO TODO: Batch FieldCT ops
 #[allow(clippy::type_complexity)]

--- a/co-noir/co-builder/src/types/blake3.rs
+++ b/co-noir/co-builder/src/types/blake3.rs
@@ -172,7 +172,7 @@ impl<F: PrimeField> Blake3Hasher<F> {
          * create unexpected overflow in the state matrix. At the end of the `compress_pre()` function, there might be
          * overflows in the elements of the first and third rows of the state matrix. But this wouldn't be a problem because
          * in the below loop, while reading from the lookup table, we ensure that the overflow is ignored and the result is
-         * contrained to 32 bits.
+         * constrained to 32 bits.
          */
         for i in 0..(BLAKE3_STATE_SIZE >> 1) {
             let lookup = Plookup::get_lookup_accumulators_ct(

--- a/co-noir/co-builder/src/types/blake_util.rs
+++ b/co-noir/co-builder/src/types/blake_util.rs
@@ -50,7 +50,7 @@ impl<F: PrimeField> BlakeUtils<F> {
      * This is the round function used in Blake2s and Blake3s for UltraPlonk.
      * Inputs: - 16-word state
      *         - 16-word msg
-     *         - round numbe
+     *         - round number
      *         - which_blake to choose Blake2 or Blake3 (false -> Blake2)
      */
     pub(crate) fn round_fn_lookup<

--- a/co-noir/co-builder/src/types/field_ct.rs
+++ b/co-noir/co-builder/src/types/field_ct.rs
@@ -282,7 +282,7 @@ impl<F: PrimeField> FieldCT<F> {
             result.multiplicative_constant = other.multiplicative_constant * self.additive_constant;
             result.witness_index = other.witness_index;
         } else {
-            // Both inputs map to circuit varaibles: create a `*` constraint.
+            // Both inputs map to circuit variables: create a `*` constraint.
 
             // /**
             //  * Value of this   = a.v * a.mul + a.add;
@@ -352,7 +352,7 @@ impl<F: PrimeField> FieldCT<F> {
             .map(|(i, (l, r))| l.multiply(r, builder, driver).map(|res| (i, res)))
             .collect::<eyre::Result<Vec<_>>>()?;
 
-        // Both inputs map to circuit varaibles: create a `*` constraint.
+        // Both inputs map to circuit variables: create a `*` constraint.
 
         // /**
         //  * Value of this   = a.v * a.mul + a.add;
@@ -452,7 +452,7 @@ impl<F: PrimeField> FieldCT<F> {
             .map(|(i, (l, r))| l.multiply(r, builder, driver).map(|res| (i, res)))
             .collect::<eyre::Result<Vec<_>>>()?;
 
-        // Both inputs map to circuit varaibles: create a `*` constraint.
+        // Both inputs map to circuit variables: create a `*` constraint.
 
         // /**
         //  * Value of this   = a.v * a.mul + a.add;
@@ -764,7 +764,7 @@ impl<F: PrimeField> FieldCT<F> {
             let result_value = base_value.pow([exponent_value.to_u64().expect("we checked bits")]);
             return Ok(FieldCT::from(result_value));
         }
-        // Use the constant version that perfoms only the necessary multiplications if the exponent is constant
+        // Use the constant version that performs only the necessary multiplications if the exponent is constant
         if exponent_constant {
             let exponent_value: BigUint = T::get_public(&exponent_value)
                 .expect("Constant should be public")
@@ -1710,7 +1710,7 @@ impl<F: PrimeField> FieldCT<F> {
         }
         let num_elements = accumulator.len();
         let num_gates = num_elements / 3;
-        // Last gate is handled separetely
+        // Last gate is handled separately
         let last_gate_idx = num_gates - 1;
 
         let total = FieldCT::from_witness(output, builder);
@@ -3300,7 +3300,7 @@ impl<P: HonkCurve<TranscriptFieldType>, T: NoirWitnessExtensionProtocol<P::Scala
             CycleGroupCT::from_group_element(offset_generators[0].to_owned().into());
 
         // populate the set of points we are going to add into our accumulator, *before* we do any ECC operations
-        // this way we are able to fuse mutliple ecc add / ecc double operations and reduce total gate count.
+        // this way we are able to fuse multiple ecc add / ecc double operations and reduce total gate count.
         // (ecc add/ecc double gates normally cost 2 UltraPlonk gates. However if we chain add->add, add->double,
         // double->add, double->double, they only cost one)
         let mut points_to_add = Vec::with_capacity(num_rounds * num_points);

--- a/co-noir/co-builder/src/types/honk_recursion_constraint.rs
+++ b/co-noir/co-builder/src/types/honk_recursion_constraint.rs
@@ -522,7 +522,7 @@ impl<C: HonkCurve<TranscriptFieldType>, T: NoirWitnessExtensionProtocol<C::Scala
      * @brief Create a mock MegaHonk VK that has the correct structure
      *
      * @param dyadic_size Dyadic size of the circuit for which we generate a vk
-     * @param pub_inputs_offest Indicating whether the circuit has a first zero row
+     * @param pub_inputs_offset Indicating whether the circuit has a first zero row
      * @param inner_public_inputs_size Number of public inputs coming from the ACIR constraints
      */
     fn create_mock_honk_vk(

--- a/co-noir/co-builder/src/types/plookup.rs
+++ b/co-noir/co-builder/src/types/plookup.rs
@@ -1838,7 +1838,7 @@ impl<F: PrimeField> Plookup<F> {
         //  * | 1 | a1                                | b1                               | s1                                |
         //  * +---+-----------------------------------+----------------------------------+-----------------------------------+
         //  *
-        //  * Note that we compute the accumulating sums of the slices so as to avoid using additonal gates for the purpose of
+        //  * Note that we compute the accumulating sums of the slices so as to avoid using additional gates for the purpose of
         //  * reconstructing the original inputs/outputs. I.e. the output value at the 0th index in the above table is the
         //  * actual value we were interested in computing in the first place. Importantly, the structure of the remaining rows
         //  * is such that row_i - r*row_{i+1} produces an entry {a_j, b_j, s_j} that exactly corresponds to an entry in a
@@ -2122,7 +2122,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>> PlookupBasi
         table_index: usize,
     ) -> PlookupBasicTable<P, T> {
         // We do the assertion, since this function is templated, but the general API for these functions contains the id,
-        // too. This helps us ensure that the correct instantion is used for a particular BasicTableId
+        // too. This helps us ensure that the correct instantiation is used for a particular BasicTableId
         assert_eq!(ID, usize::from(id.to_owned()) as u64);
         let base = 1 << 1; // Probably has to be a power of 2
         let mut table = PlookupBasicTable::new();

--- a/co-noir/co-builder/src/types/rom_ram.rs
+++ b/co-noir/co-builder/src/types/rom_ram.rs
@@ -159,8 +159,8 @@ impl<F: PrimeField> RamTable<F> {
         assert!(self.check_indices_initialized());
 
         let index_wire = if index.is_constant() {
-            let nativ_index = T::get_public(&index_value).expect("Constant should be public");
-            FieldCT::from_witness_index(builder.put_constant_variable(nativ_index))
+            let native_index = T::get_public(&index_value).expect("Constant should be public");
+            FieldCT::from_witness_index(builder.put_constant_variable(native_index))
         } else {
             index.to_owned()
         };
@@ -189,8 +189,8 @@ impl<F: PrimeField> RamTable<F> {
         self.initialize_table(builder, driver)?;
 
         let index_wire = if index.is_constant() {
-            let nativ_index = T::get_public(&index_value).expect("Constant should be public");
-            FieldCT::from_witness_index(builder.put_constant_variable(nativ_index))
+            let native_index = T::get_public(&index_value).expect("Constant should be public");
+            FieldCT::from_witness_index(builder.put_constant_variable(native_index))
         } else {
             self.initialize_table(builder, driver)?;
             index.to_owned()

--- a/co-noir/co-builder/src/ultra_builder.rs
+++ b/co-noir/co-builder/src/ultra_builder.rs
@@ -1000,7 +1000,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>>
                 }
             }
             *romcount += rom_array.records.len();
-            *romcount += 1; // we add an addition gate after procesing a rom array
+            *romcount += 1; // we add an addition gate after processing a rom array
         }
 
         // each RAM gate adds +2 extra gates due to the ram reads being copied to a sorted list set,
@@ -1009,7 +1009,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>>
         let mut ram_range_sizes = Vec::with_capacity(self.ram_arrays.len());
         let mut ram_range_exists = Vec::with_capacity(self.ram_arrays.len());
         for ram_array in self.ram_arrays.iter() {
-            // If the LUT is not public, then it is definetly not uninitialized, since it gets initialized with every read/write
+            // If the LUT is not public, then it is definitely not uninitialized, since it gets initialized with every read/write
             if T::is_public_lut(&ram_array.state) {
                 let lut_pub =
                     T::get_public_lut(&ram_array.state).expect("Already checked it is public");
@@ -1020,7 +1020,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>>
                 }
             }
             *ramcount += ram_array.records.len() * Self::NUMBER_OF_GATES_PER_RAM_ACCESS;
-            *ramcount += Self::NUMBER_OF_ARITHMETIC_GATES_PER_RAM_ARRAY; // we add an addition gate after procesing a ram array
+            *ramcount += Self::NUMBER_OF_ARITHMETIC_GATES_PER_RAM_ARRAY; // we add an addition gate after processing a ram array
 
             // there will be 'max_timestamp' number of range checks, need to calculate.
             let max_timestamp = ram_array.access_count - 1;
@@ -1621,7 +1621,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>>
 
         let lut = &self.ram_arrays[ram_id].state;
 
-        // We get the minimum and maximum of the write recors to reduce the size of LUTs required to read the variable
+        // We get the minimum and maximum of the write records to reduce the size of LUTs required to read the variable
         let min_witness = self.ram_arrays[ram_id]
             .records
             .iter()
@@ -1966,7 +1966,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>>
         block.q_poseidon2_internal().push(P::ScalarField::zero());
 
         // TACEO TODO these are uncommented due to mutability issues
-        // Taken care of by the caller uisng the create_unconstrained_gate! macro
+        // Taken care of by the caller using the create_unconstrained_gate! macro
         // self.check_selector_length_consistency();
         // self.num_gates += 1;
     }
@@ -2480,7 +2480,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>>
         // Make sure that every cell has been initialized
         // AZTEC TODO: throw some kind of error here? Circuit should initialize all RAM elements to prevent errors.
         // e.g. if a RAM record is uninitialized but the index of that record is a function of public/private inputs,
-        // different public iputs will produce different circuit constraints.
+        // different public inputs will produce different circuit constraints.
 
         // We need to initialize the RAM if it is uninitialized. Since RAM gets initialized on every read/write, it can only be uninitialized if it is public
         if T::is_public_lut(&self.ram_arrays[ram_id].state) {
@@ -2627,7 +2627,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>>
             Utils::get_msb64((list.target_range + 1).next_power_of_two()) as usize,
         )?;
 
-        // list must be padded to a multipe of 4 and larger than 4 (gate_width)
+        // list must be padded to a multiple of 4 and larger than 4 (gate_width)
         const GATE_WIDTH: usize = NUM_WIRES;
         let mut padding = (GATE_WIDTH - (list.variable_indices.len() % GATE_WIDTH)) % GATE_WIDTH;
         let mut indices = Vec::with_capacity(padding + sorted_list.len());
@@ -2875,7 +2875,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>>
         //  * This is not strictly required iff num_bits <= target_range_bitnum.
         //  * However, this produces an edge-case where a variable is range-constrained but NOT present in an arithmetic gate.
         //  * This in turn produces an unsatisfiable circuit (see `create_new_range_constraint`). We would need to check for
-        //  * and accommodate/reject this edge case to support not adding addition gates here if not reqiured
+        //  * and accommodate/reject this edge case to support not adding addition gates here if not required
         //  * if (num_bits <= target_range_bitnum) {
         //  *     const uint64_t expected_range = (1ULL << num_bits) - 1ULL;
         //  *     create_new_range_constraint(variable_index, expected_range);
@@ -3668,7 +3668,7 @@ impl<P: CurveGroup, T: NoirWitnessExtensionProtocol<P::ScalarField>>
         // | x.p | x.1 | y.1 | z.0 | (a.1  + b.1 - c.1 = 0)
         // | x.2 | y.2 | z.2 | z.1 | (a.2  + b.2 - c.2 = 0)
         // | x.3 | y.3 | z.3 | --- | (a.3  + b.3 - c.3 = 0)
-        // AZTEC TODO(https://github.com/AztecProtocol/barretenberg/issues/896): descrepency between above comment and the actual
+        // AZTEC TODO(https://github.com/AztecProtocol/barretenberg/issues/896): discrepancy between above comment and the actual
         // implementation below.
         let block = &mut self.blocks.arithmetic;
         block.populate_wires(y_p, x_0, y_0, x_p);
@@ -4087,7 +4087,7 @@ impl<P: HonkCurve<TranscriptFieldType>, T: NoirWitnessExtensionProtocol<P::Scala
      * @param varnum number of known witness
      *
      * @note The size of witness_values may be less than varnum. The former is the set of actual witness values known at
-     * the time of acir generation. The latter may be larger and essentially acounts for placeholders for witnesses that
+     * the time of acir generation. The latter may be larger and essentially accounts for placeholders for witnesses that
      * we know will exist but whose values are not known during acir generation. Both are in general less than the total
      * number of variables/witnesses that might be present for a circuit generated from acir, since many gates will
      * depend on the details of the bberg implementation (or more generally on the backend used to process acir).

--- a/co-noir/co-noir-common/src/polynomials/polynomial.rs
+++ b/co-noir/co-noir-common/src/polynomials/polynomial.rs
@@ -216,7 +216,7 @@ impl<F: PrimeField> Polynomial<F> {
             let root_inverse = (-*root).inverse().expect("Root is not zero here");
             // set b₋₁ = 0
             let mut temp = F::zero();
-            // We start multiplying lower coefficient by the inverse and subtracting those from highter coefficients
+            // We start multiplying lower coefficient by the inverse and subtracting those from higher coefficients
             // Since (x - r) should divide the polynomial cleanly, we can guide division with lower coefficients
             for coeff in self.coefficients.iter_mut() {
                 // at the start of the loop, temp = bᵢ₋₁
@@ -285,7 +285,7 @@ impl<F: PrimeField> Polynomial<F> {
         let mut n_l = 1 << (dim - 1);
         let mut tmp = vec![F::zero(); n_l];
 
-        // Note below: i * 2 + 1 + offset might equal virtual_size. This used to subtlely be handled by extra capacity
+        // Note below: i * 2 + 1 + offset might equal virtual_size. This used to subtly be handled by extra capacity
         // padding (and there used to be no assert time checks, which this constant helps with).
         for (i, val) in tmp.iter_mut().enumerate().take(n_l) {
             *val = self.coefficients[i * 2]

--- a/co-noir/co-noir-common/src/polynomials/shared_polynomial.rs
+++ b/co-noir/co-noir-common/src/polynomials/shared_polynomial.rs
@@ -125,7 +125,7 @@ impl<T: NoirUltraHonkProver<P>, P: CurveGroup> SharedPolynomial<T, P> {
             let root_inverse = (-*root).inverse().expect("Root is not zero here");
             // set b₋₁ = 0
             let mut temp = Default::default();
-            // We start multiplying lower coefficient by the inverse and subtracting those from highter coefficients
+            // We start multiplying lower coefficient by the inverse and subtracting those from higher coefficients
             // Since (x - r) should divide the polynomial cleanly, we can guide division with lower coefficients
             for coeff in self.coefficients.iter_mut() {
                 // at the start of the loop, temp = bᵢ₋₁
@@ -169,7 +169,7 @@ impl<T: NoirUltraHonkProver<P>, P: CurveGroup> SharedPolynomial<T, P> {
         let mut n_l = 1 << (dim - 1);
         let mut tmp = vec![T::ArithmeticShare::default(); n_l];
 
-        // Note below: i * 2 + 1 + offset might equal virtual_size. This used to subtlely be handled by extra capacity
+        // Note below: i * 2 + 1 + offset might equal virtual_size. This used to subtly be handled by extra capacity
         // padding (and there used to be no assert time checks, which this constant helps with).
         for (i, val) in tmp.iter_mut().enumerate().take(n_l) {
             let sub = T::sub(self.coefficients[i * 2 + 1], self.coefficients[i * 2]);

--- a/co-noir/co-ultrahonk/src/co_decider/co_decider_prover.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/co_decider_prover.rs
@@ -100,7 +100,7 @@ impl<
     }
 
     /**
-     * @brief Produce a univariate opening claim for the sumcheck multivariate evalutions and a batched univariate claim
+     * @brief Produce a univariate opening claim for the sumcheck multivariate evaluations and a batched univariate claim
      * for the transcript polynomials (for the Translator consistency check). Reduce the two opening claims to a single one
      * via Shplonk and produce an opening proof with the univariate PCS of choice (IPA when operating on Grumpkin).
      *

--- a/co-noir/co-ultrahonk/src/co_decider/co_shplemini/co_shplemini_prover.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/co_shplemini/co_shplemini_prover.rs
@@ -147,7 +147,7 @@ impl<
     //  * f₀, …, fₖ₋₁ = multilinear polynomials,
     //  * g₀, …, gₕ₋₁ = shifted multilinear polynomial,
     //  *  Each gⱼ is the left-shift of some f↺ᵢ, and gⱼ points to the same memory location as fᵢ.
-    //  * v₀, …, vₖ₋₁, v↺₀, …, v↺ₕ₋₁ = multilinear evalutions  s.t. fⱼ(u) = vⱼ, and gⱼ(u) = f↺ⱼ(u) = v↺ⱼ
+    //  * v₀, …, vₖ₋₁, v↺₀, …, v↺ₕ₋₁ = multilinear evaluations  s.t. fⱼ(u) = vⱼ, and gⱼ(u) = f↺ⱼ(u) = v↺ⱼ
     //  *
     //  * We use a challenge ρ to create a random linear combination of all fⱼ,
     //  * and actually define A₀ = F + G↺, where

--- a/co-noir/co-ultrahonk/src/co_decider/co_sumcheck/co_sumcheck_round.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/co_sumcheck/co_sumcheck_round.rs
@@ -263,7 +263,7 @@ impl SumcheckRound {
 
         // we have the round size and then reduce it by power of two steps
         // what can we mt here?
-        // Accumulate the contribution from each sub-relation accross each edge of the hyper-cube
+        // Accumulate the contribution from each sub-relation across each edge of the hyper-cube
         // Construct extended edge containers
 
         //

--- a/co-noir/co-ultrahonk/src/co_decider/co_sumcheck/zk_data.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/co_sumcheck/zk_data.rs
@@ -299,7 +299,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> SharedZKSumch
             );
             let libra_evaluation =
                 T::mul_with_public(self.libra_scaling_factor.inverse().expect("non-zero"), eval);
-            // place the evalution into the vector of Libra evaluations
+            // place the evaluation into the vector of Libra evaluations
             self.libra_evaluations.push(libra_evaluation);
             for univariate in &mut self.libra_univariates {
                 univariate.mul_assign(self.libra_challenge.inverse().expect("non-zero"));

--- a/co-noir/co-ultrahonk/src/co_decider/relations/delta_range_constraint_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/delta_range_constraint_relation.rs
@@ -95,7 +95,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
         entity.precomputed.q_delta_range().is_zero()
     }
 
-    fn add_entites(
+    fn add_entities(
         entity: &super::ProverUnivariates<T, P>,
         batch: &mut super::ProverUnivariatesBatch<T, P>,
     ) {

--- a/co-noir/co-ultrahonk/src/co_decider/relations/elliptic_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/elliptic_relation.rs
@@ -72,7 +72,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
         entity.precomputed.q_elliptic().is_zero()
     }
 
-    fn add_entites(
+    fn add_entities(
         entity: &super::ProverUnivariates<T, P>,
         batch: &mut super::ProverUnivariatesBatch<T, P>,
     ) {

--- a/co-noir/co-ultrahonk/src/co_decider/relations/logderiv_lookup_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/logderiv_lookup_relation.rs
@@ -177,7 +177,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
         false
     }
 
-    fn add_entites(
+    fn add_entities(
         entity: &super::ProverUnivariates<T, P>,
         batch: &mut ProverUnivariatesBatch<T, P>,
     ) {
@@ -245,7 +245,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
      * an inversion when are not supposed to skip over it.
      * we argue that this does not give the prover any advantage, as it would only mean an element from the lookup table
      * is removed. this means that if a proof verifies, we still have that the provers set is a subset of the lookup
-     * table, as the only freedome the prover has is to make the lookup table smaller.
+     * table, as the only freedom the prover has is to make the lookup table smaller.
      * the boolean check is still necessary, as otherwise has_inverse, is a leanier function of read_tags, and the
      * the prover can set it to zero (by picking a non-binary value for read_tags) even when we have a read gate in the
      * row.

--- a/co-noir/co-ultrahonk/src/co_decider/relations/memory_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/memory_relation.rs
@@ -114,7 +114,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
         entity.precomputed.q_memory().is_zero()
     }
 
-    fn add_entites(
+    fn add_entities(
         entity: &super::ProverUnivariates<T, P>,
         batch: &mut ProverUnivariatesBatch<T, P>,
     ) {
@@ -159,7 +159,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
      * N.B.2 The q_c selector is used to store circuit-specific values in the RAM/ROM access gate
      *
      * @param evals transformed to `evals + C(in(X)...)*scaling_factor`
-     * @param in an std::array containing the Totaly extended Univariate edges.
+     * @param in an std::array containing the Totally extended Univariate edges.
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */

--- a/co-noir/co-ultrahonk/src/co_decider/relations/mod.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/mod.rs
@@ -74,14 +74,14 @@ pub(crate) trait Relation<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFiel
         if !Self::can_skip(entity) {
             let scaling_factors = vec![scaling_factor; MAX_PARTIAL_RELATION_LENGTH];
             data.can_skip = false;
-            Self::add_entites(entity, &mut data.all_entities);
+            Self::add_entities(entity, &mut data.all_entities);
             data.scaling_factors.extend(scaling_factors);
         }
     }
 
     fn can_skip(entity: &ProverUnivariates<T, P>) -> bool;
 
-    fn add_entites(entity: &ProverUnivariates<T, P>, batch: &mut ProverUnivariatesBatch<T, P>);
+    fn add_entities(entity: &ProverUnivariates<T, P>, batch: &mut ProverUnivariatesBatch<T, P>);
 
     fn accumulate<N: Network>(
         net: &N,

--- a/co-noir/co-ultrahonk/src/co_decider/relations/non_native_field_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/non_native_field_relation.rs
@@ -64,7 +64,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
         entity.precomputed.q_nnf().is_zero()
     }
 
-    fn add_entites(
+    fn add_entities(
         entity: &super::ProverUnivariates<T, P>,
         batch: &mut ProverUnivariatesBatch<T, P>,
     ) {
@@ -102,7 +102,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
      * | Bigfield Product 3           | 1     | 1   | 0   | 0   | 1   |
      *
      * @param evals transformed to `evals + C(in(X)...)*scaling_factor`
-     * @param in an std::array containing the Totaly extended Univariate edges.
+     * @param in an std::array containing the Totally extended Univariate edges.
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */

--- a/co-noir/co-ultrahonk/src/co_decider/relations/permutation_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/permutation_relation.rs
@@ -159,7 +159,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
         false
     }
 
-    fn add_entites(
+    fn add_entities(
         entity: &super::ProverUnivariates<T, P>,
         batch: &mut ProverUnivariatesBatch<T, P>,
     ) {

--- a/co-noir/co-ultrahonk/src/co_decider/relations/poseidon2_external_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/poseidon2_external_relation.rs
@@ -93,7 +93,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
         entity.precomputed.q_poseidon2_external().is_zero()
     }
 
-    fn add_entites(
+    fn add_entities(
         entity: &super::ProverUnivariates<T, P>,
         batch: &mut ProverUnivariatesBatch<T, P>,
     ) {

--- a/co-noir/co-ultrahonk/src/co_decider/relations/poseidon2_internal_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/poseidon2_internal_relation.rs
@@ -94,7 +94,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
         entity.precomputed.q_poseidon2_internal().is_zero()
     }
 
-    fn add_entites(
+    fn add_entities(
         entity: &super::ProverUnivariates<T, P>,
         batch: &mut ProverUnivariatesBatch<T, P>,
     ) {

--- a/co-noir/co-ultrahonk/src/co_decider/relations/ultra_arithmetic_relation.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/relations/ultra_arithmetic_relation.rs
@@ -248,7 +248,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
         entity.precomputed.q_arith().is_zero()
     }
 
-    fn add_entites(
+    fn add_entities(
         entity: &super::ProverUnivariates<T, P>,
         batch: &mut ProverUnivariatesBatch<T, P>,
     ) {
@@ -271,7 +271,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>> Relation<T, P
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
-     * @details This relation encapsulates several idenitities, toggled by the value of q_arith in [0, 1, 2, 3, ...].
+     * @details This relation encapsulates several identities, toggled by the value of q_arith in [0, 1, 2, 3, ...].
      * The following description is reproduced from the Plonk analog 'plookup_arithmetic_widget':
      * The whole formula is:
      *

--- a/co-noir/co-ultrahonk/src/co_decider/small_subgroup_ipa.rs
+++ b/co-noir/co-ultrahonk/src/co_decider/small_subgroup_ipa.rs
@@ -265,7 +265,7 @@ impl<T: NoirUltraHonkProver<P>, P: HonkCurve<TranscriptFieldType>>
                 T::add(self.grand_sum_identity_polynomial.coefficients[idx], sub);
         }
 
-        // Mutiply - F(X) * G(X) + A(gX) - A(X) by X-g:
+        // Multiply - F(X) * G(X) + A(gX) - A(X) by X-g:
         // 1. Multiply by X
         for idx in (1..self.grand_sum_identity_polynomial.coefficients.len()).rev() {
             self.grand_sum_identity_polynomial.coefficients[idx] =

--- a/co-noir/co-ultrahonk/src/co_oink/co_oink_prover.rs
+++ b/co-noir/co-ultrahonk/src/co_oink/co_oink_prover.rs
@@ -306,7 +306,7 @@ impl<
         // at the end of the loop, add and subtract β to each term respectively to
         // set the expected value for the start of iteration i+1.
         // Note: The public inputs may be offset from the 0th index of the wires, for example due to the inclusion of an
-        // initial zero row or Goblin-stlye ECC op gates. Accordingly, the indices i in the above formulas are given by i =
+        // initial zero row or Goblin-style ECC op gates. Accordingly, the indices i in the above formulas are given by i =
         // [0, m-1] + offset, i.e. i = offset, 1 + offset, …, m - 1 + offset.
 
         let mut num = C::ScalarField::one();
@@ -634,7 +634,7 @@ impl<
 
         self.compute_logderivative_inverses(proving_key)?;
 
-        // We moved the commiting and opening of the lookup inverses to be at the same time as z_perm
+        // We moved the committing and opening of the lookup inverses to be at the same time as z_perm
 
         // Round is done since ultra_honk is no goblin flavor
         Ok(())

--- a/co-noir/ultrahonk/src/decider/decider_prover.rs
+++ b/co-noir/ultrahonk/src/decider/decider_prover.rs
@@ -96,7 +96,7 @@ impl<P: HonkCurve<TranscriptFieldType>, H: TranscriptHasher<TranscriptFieldType>
     }
 
     /**
-     * @brief Produce a univariate opening claim for the sumcheck multivariate evalutions and a batched univariate claim
+     * @brief Produce a univariate opening claim for the sumcheck multivariate evaluations and a batched univariate claim
      * for the transcript polynomials (for the Translator consistency check). Reduce the two opening claims to a single one
      * via Shplonk and produce an opening proof with the univariate PCS of choice (IPA when operating on Grumpkin).
      *

--- a/co-noir/ultrahonk/src/decider/relations/elliptic_relation.rs
+++ b/co-noir/ultrahonk/src/decider/relations/elliptic_relation.rs
@@ -61,7 +61,7 @@ impl EllipticRelation {
     pub(crate) const SKIPPABLE: bool = true;
 
     pub(crate) fn skip<F: PrimeField>(input: &ProverUnivariates<F>) -> bool {
-        // This is the relation implemented manally
+        // This is the relation implemented manually
         if !Self::SKIPPABLE {
             panic!("Cannot skip this relation");
         }

--- a/co-noir/ultrahonk/src/decider/relations/logderiv_lookup_relation.rs
+++ b/co-noir/ultrahonk/src/decider/relations/logderiv_lookup_relation.rs
@@ -256,7 +256,7 @@ impl<F: PrimeField> Relation<F> for LogDerivLookupRelation {
      * an inversion when are not supposed to skip over it.
      * we argue that this does not give the prover any advantage, as it would only mean an element from the lookup table
      * is removed. this means that if a proof verifies, we still have that the provers set is a subset of the lookup
-     * table, as the only freedome the prover has is to make the lookup table smaller.
+     * table, as the only freedom the prover has is to make the lookup table smaller.
      * the boolean check is still necessary, as otherwise has_inverse, is a leanier function of read_tags, and the
      * the prover can set it to zero (by picking a non-binary value for read_tags) even when we have a read gate in the
      * row.

--- a/co-noir/ultrahonk/src/decider/relations/memory_relation.rs
+++ b/co-noir/ultrahonk/src/decider/relations/memory_relation.rs
@@ -138,7 +138,7 @@ impl<F: PrimeField> Relation<F> for MemoryRelation {
      * N.B.2 The q_c selector is used to store circuit-specific values in the RAM/ROM access gate
      *
      * @param evals transformed to `evals + C(in(X)...)*scaling_factor`
-     * @param in an std::array containing the Totaly extended Univariate edges.
+     * @param in an std::array containing the Totally extended Univariate edges.
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */

--- a/co-noir/ultrahonk/src/decider/relations/non_native_field_relation.rs
+++ b/co-noir/ultrahonk/src/decider/relations/non_native_field_relation.rs
@@ -78,7 +78,7 @@ impl<F: PrimeField> Relation<F> for NonNativeFieldRelation {
      * | Bigfield Product 3           | 1     | 1   | 0   | 0   | 1   |
      *
      * @param evals transformed to `evals + C(in(X)...)*scaling_factor`
-     * @param in an std::array containing the Totaly extended Univariate edges.
+     * @param in an std::array containing the Totally extended Univariate edges.
      * @param parameters contains beta, gamma, and public_input_delta, ....
      * @param scaling_factor optional term to scale the evaluation before adding to evals.
      */

--- a/co-noir/ultrahonk/src/decider/relations/ultra_arithmetic_relation.rs
+++ b/co-noir/ultrahonk/src/decider/relations/ultra_arithmetic_relation.rs
@@ -74,7 +74,7 @@ impl<F: PrimeField> Relation<F> for UltraArithmeticRelation {
 
     /**
      * @brief Expression for the Ultra Arithmetic gate.
-     * @details This relation encapsulates several idenitities, toggled by the value of q_arith in [0, 1, 2, 3, ...].
+     * @details This relation encapsulates several identities, toggled by the value of q_arith in [0, 1, 2, 3, ...].
      * The following description is reproduced from the Plonk analog 'plookup_arithmetic_widget':
      * The whole formula is:
      *

--- a/co-noir/ultrahonk/src/decider/shplemini/shplemini_prover.rs
+++ b/co-noir/ultrahonk/src/decider/shplemini/shplemini_prover.rs
@@ -111,7 +111,7 @@ impl<P: HonkCurve<TranscriptFieldType>, H: TranscriptHasher<TranscriptFieldType>
     //  * f₀, …, fₖ₋₁ = multilinear polynomials,
     //  * g₀, …, gₕ₋₁ = shifted multilinear polynomial,
     //  *  Each gⱼ is the left-shift of some f↺ᵢ, and gⱼ points to the same memory location as fᵢ.
-    //  * v₀, …, vₖ₋₁, v↺₀, …, v↺ₕ₋₁ = multilinear evalutions  s.t. fⱼ(u) = vⱼ, and gⱼ(u) = f↺ⱼ(u) = v↺ⱼ
+    //  * v₀, …, vₖ₋₁, v↺₀, …, v↺ₕ₋₁ = multilinear evaluations  s.t. fⱼ(u) = vⱼ, and gⱼ(u) = f↺ⱼ(u) = v↺ⱼ
     //  *
     //  * We use a challenge ρ to create a random linear combination of all fⱼ,
     //  * and actually define A₀ = F + G↺, where

--- a/co-noir/ultrahonk/src/decider/small_subgroup_ipa.rs
+++ b/co-noir/ultrahonk/src/decider/small_subgroup_ipa.rs
@@ -221,7 +221,7 @@ impl<P: HonkCurve<TranscriptFieldType>> SmallSubgroupIPAProver<P> {
                 shifted_grand_sum.coefficients[idx] - self.grand_sum_polynomial.coefficients[idx];
         }
 
-        // Mutiply - F(X) * G(X) + A(gX) - A(X) by X-g:
+        // Multiply - F(X) * G(X) + A(gX) - A(X) by X-g:
         // 1. Multiply by X
         for idx in (1..self.grand_sum_identity_polynomial.coefficients.len()).rev() {
             self.grand_sum_identity_polynomial.coefficients[idx] =

--- a/co-noir/ultrahonk/src/decider/sumcheck/sumcheck_round_prover.rs
+++ b/co-noir/ultrahonk/src/decider/sumcheck/sumcheck_round_prover.rs
@@ -235,7 +235,7 @@ impl SumcheckProverRound {
 
         let mut univariate_accumulators = AllRelationAcc::<P::ScalarField>::default();
 
-        // Accumulate the contribution from each sub-relation accross each edge of the hyper-cube
+        // Accumulate the contribution from each sub-relation across each edge of the hyper-cube
         for edge_idx in (0..self.round_size).step_by(2) {
             Self::extend_edges(&mut extended_edge, polynomials, edge_idx);
             // Compute the \f$ \ell \f$-th edge's univariate contribution,

--- a/co-noir/ultrahonk/src/decider/sumcheck/zk_data.rs
+++ b/co-noir/ultrahonk/src/decider/sumcheck/zk_data.rs
@@ -266,7 +266,7 @@ impl<P: HonkCurve<TranscriptFieldType>> ZKSumcheckData<P> {
             // compute the evaluation of the last Libra univariate at the challenge u_{d-1}
             let libra_evaluation = self.libra_univariates[round_idx].eval_poly(round_challenge)
                 / self.libra_scaling_factor;
-            // place the evalution into the vector of Libra evaluations
+            // place the evaluation into the vector of Libra evaluations
             self.libra_evaluations.push(libra_evaluation);
             for univariate in &mut self.libra_univariates {
                 *univariate *= self.libra_challenge.inverse().expect("non-zero");

--- a/co-noir/ultrahonk/src/oink/oink_prover.rs
+++ b/co-noir/ultrahonk/src/oink/oink_prover.rs
@@ -242,7 +242,7 @@ impl<C: HonkCurve<TranscriptFieldType>, H: TranscriptHasher<TranscriptFieldType>
         // at the end of the loop, add and subtract β to each term respectively to
         // set the expected value for the start of iteration i+1.
         // Note: The public inputs may be offset from the 0th index of the wires, for example due to the inclusion of an
-        // initial zero row or Goblin-stlye ECC op gates. Accordingly, the indices i in the above formulas are given by i =
+        // initial zero row or Goblin-style ECC op gates. Accordingly, the indices i in the above formulas are given by i =
         // [0, m-1] + offset, i.e. i = offset, 1 + offset, …, m - 1 + offset.
 
         let mut num = C::ScalarField::one();

--- a/co-noir/ultrahonk/src/ultra_prover.rs
+++ b/co-noir/ultrahonk/src/ultra_prover.rs
@@ -42,7 +42,7 @@ impl<C: HonkCurve<TranscriptFieldType>, H: TranscriptHasher<TranscriptFieldType>
         let oink_result = oink.prove(&mut proving_key, &mut transcript, verifying_key)?;
 
         let crs = proving_key.crs;
-        let cicruit_size = proving_key.circuit_size;
+        let circuit_size = proving_key.circuit_size;
 
         let mut memory =
             ProverMemory::from_memory_and_polynomials(oink_result, proving_key.polynomials);
@@ -58,7 +58,7 @@ impl<C: HonkCurve<TranscriptFieldType>, H: TranscriptHasher<TranscriptFieldType>
 
         let num_public_inputs = proving_key.num_public_inputs - PAIRING_POINT_ACCUMULATOR_SIZE;
         let decider = Decider::new(memory, has_zk);
-        let proof = decider.prove(cicruit_size, &crs, transcript, virtual_log_n)?;
+        let proof = decider.prove(circuit_size, &crs, transcript, virtual_log_n)?;
         Ok(proof.separate_proof_and_public_inputs(num_public_inputs as usize))
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -218,11 +218,11 @@ wildcards = "warn"
 # * all - Both lowest-version and simplest-path are used
 highlight = "all"
 # The default lint level for `default` features for crates that are members of
-# the workspace that is being checked. This can be overriden by allowing/denying
+# the workspace that is being checked. This can be overridden by allowing/denying
 # `default` on a crate-by-crate basis if desired.
 workspace-default-features = "allow"
 # The default lint level for `default` features for external crates that are not
-# members of the workspace. This can be overriden by allowing/denying `default`
+# members of the workspace. This can be overridden by allowing/denying `default`
 # on a crate-by-crate basis if desired.
 external-default-features = "allow"
 # List of crates that are allowed. Use with care!

--- a/mpc-core/src/gadgets/merkle_tree/plain.rs
+++ b/mpc-core/src/gadgets/merkle_tree/plain.rs
@@ -222,7 +222,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
     }
 
     /// Verify a Merkle path with a given root, leaf, and witness using Poseidon2 in sponge mode.
-    pub fn verifiy_merkle_path_sponge(
+    pub fn verify_merkle_path_sponge(
         &self,
         root: F,
         mut leaf: F,
@@ -256,7 +256,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
     }
 
     /// Verify a Merkle path with a given root, leaf, and witness using Poseidon2 in compression mode.
-    pub fn verifiy_merkle_path_compression(
+    pub fn verify_merkle_path_compression(
         &self,
         root: F,
         mut leaf: F,
@@ -386,7 +386,7 @@ mod test {
 
         let (root, witness) = poseidon2.merkle_tree_compression_with_witness::<ARITY>(input, index);
         assert_eq!(root, expected);
-        let verified = poseidon2.verifiy_merkle_path_compression(root, leaf, witness);
+        let verified = poseidon2.verify_merkle_path_compression(root, leaf, witness);
         assert!(verified);
     }
 
@@ -408,7 +408,7 @@ mod test {
 
         let (root, witness) = poseidon2.merkle_tree_sponge_with_witness::<ARITY>(input, index);
         assert_eq!(root, expected);
-        let verified = poseidon2.verifiy_merkle_path_sponge(root, leaf, witness);
+        let verified = poseidon2.verify_merkle_path_sponge(root, leaf, witness);
         assert!(verified);
     }
 

--- a/mpc-core/src/gadgets/poseidon2/poseidon2_circom_accelerator.rs
+++ b/mpc-core/src/gadgets/poseidon2/poseidon2_circom_accelerator.rs
@@ -94,7 +94,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         (res, input_square, input_quad)
     }
 
-    /// Computes the Poseidon2 permuation using the Rep3 MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation.
+    /// Computes the Poseidon2 permutation using the Rep3 MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation.
     pub fn rep3_permutation_in_place_with_precomputation_intermediate<N: Network>(
         &self,
         state: &mut [Rep3PrimeFieldShare<F>; T],
@@ -283,7 +283,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(trace)
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol. Returns a value needed for the trace when T > 4.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol. Returns a value needed for the trace when T > 4.
     #[expect(clippy::type_complexity)]
     pub fn rep3_external_round_precomp_intermediate<N: Network>(
         &self,
@@ -310,7 +310,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok((squares, quads, sbox_0, matmul_external))
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     #[expect(clippy::type_complexity)]
     pub fn rep3_external_round_precomp_matmul_intermediate<N: Network>(
         &self,
@@ -331,7 +331,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok((squares, quads, res))
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     #[expect(clippy::type_complexity)]
     pub fn rep3_external_round_precomp_intermediate_packed<N: Network, const BATCH_SIZE: usize>(
         &self,
@@ -369,7 +369,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok((squares, quads, sboxes_0, matmul_external))
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     #[expect(clippy::type_complexity)]
     pub fn rep3_external_round_precomp_matmul_intermediate_packed<
         N: Network,
@@ -404,7 +404,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         ))
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     #[expect(clippy::type_complexity)]
     pub fn rep3_external_round_precomp_intermediate_vec<N: Network>(
         &self,
@@ -442,7 +442,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok((squares, quads, sboxes_0, matmul_external))
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     #[expect(clippy::type_complexity)]
     pub fn rep3_external_round_precomp_matmul_intermediate_vec<N: Network>(
         &self,
@@ -596,7 +596,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok((squares, quads))
     }
 
-    /// One internal round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One internal round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     #[expect(clippy::type_complexity)]
     pub fn rep3_internal_round_precomp_intermediate<N: Network>(
         &self,
@@ -626,7 +626,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok((sum, squares, quads))
     }
 
-    /// One internal round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One internal round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     #[expect(clippy::type_complexity)]
     pub fn rep3_internal_round_precomp_intermediate_packed<N: Network>(
         &self,

--- a/mpc-core/src/gadgets/poseidon2/poseidon2_permutation.rs
+++ b/mpc-core/src/gadgets/poseidon2/poseidon2_permutation.rs
@@ -3,7 +3,7 @@ use std::any::TypeId;
 use super::poseidon2_params::Poseidon2Params;
 use ark_ff::PrimeField;
 
-/// A struct represnting the Poseidon2 permutation.
+/// A struct representing the Poseidon2 permutation.
 #[derive(Clone, Debug)]
 pub struct Poseidon2<F: PrimeField, const T: usize, const D: u64> {
     /// The parameter set containing the parameters for the Poseidon2 permutation.
@@ -11,7 +11,7 @@ pub struct Poseidon2<F: PrimeField, const T: usize, const D: u64> {
 }
 
 impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
-    /// Creates a new instance of the Poseidon2 permuation with given parameters
+    /// Creates a new instance of the Poseidon2 permutation with given parameters
     pub fn new(params: &'static Poseidon2Params<F, T, D>) -> Self {
         Self { params }
     }
@@ -161,7 +161,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         }
     }
 
-    /// The round constant additon in the external rounds of the Poseidon2 permutation.
+    /// The round constant addition in the external rounds of the Poseidon2 permutation.
     pub fn add_rc_external(&self, input: &mut [F; T], rc_offset: usize) {
         for (s, rc) in input
             .iter_mut()
@@ -171,19 +171,19 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         }
     }
 
-    /// The round constant additon in the internal rounds of the Poseidon2 permutation.
+    /// The round constant addition in the internal rounds of the Poseidon2 permutation.
     pub fn add_rc_internal(&self, input: &mut [F; T], rc_offset: usize) {
         input[0] += &self.params.round_constants_internal[rc_offset];
     }
 
-    /// One external round of the Poseidon2 permuation.
+    /// One external round of the Poseidon2 permutation.
     pub fn external_round(&self, state: &mut [F; T], r: usize) {
         self.add_rc_external(state, r);
         Self::sbox(state);
         Self::matmul_external(state);
     }
 
-    /// One internal round of the Poseidon2 permuation.
+    /// One internal round of the Poseidon2 permutation.
     pub fn internal_round(&self, state: &mut [F; T], r: usize) {
         self.add_rc_internal(state, r);
         Self::single_sbox(&mut state[0]);

--- a/mpc-core/src/gadgets/poseidon2/rep3.rs
+++ b/mpc-core/src/gadgets/poseidon2/rep3.rs
@@ -444,7 +444,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(res)
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     fn rep3_external_round_precomp_additive<N: Network>(
         &self,
         state: &mut [F; T],
@@ -461,7 +461,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One internal round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One internal round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     fn rep3_internal_round_precomp_additive<N: Network>(
         &self,
         state: &mut [F; T],
@@ -478,7 +478,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     pub fn rep3_external_round_precomp<N: Network>(
         &self,
         state: &mut [Rep3PrimeFieldShare<F>; T],
@@ -493,7 +493,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One internal round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One internal round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     pub fn rep3_internal_round_precomp<N: Network>(
         &self,
         state: &mut [Rep3PrimeFieldShare<F>; T],
@@ -512,7 +512,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     fn rep3_external_round_precomp_packed<N: Network>(
         &self,
         state: &mut [Rep3PrimeFieldShare<F>],
@@ -548,7 +548,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One internal round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
+    /// One internal round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
     fn rep3_internal_round_precomp_packed<N: Network>(
         &self,
         state: &mut [Rep3PrimeFieldShare<F>],
@@ -574,7 +574,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One external round of the Poseidon2 permuation. Implemented for the Rep3 MPC protocol.
+    /// One external round of the Poseidon2 permutation. Implemented for the Rep3 MPC protocol.
     fn rep3_external_round<N: Network>(
         &self,
         state: &mut [F; T],
@@ -591,7 +591,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One internal round of the Poseidon2 permuation. Implemented for the Rep3 MPC protocol.
+    /// One internal round of the Poseidon2 permutation. Implemented for the Rep3 MPC protocol.
     fn rep3_internal_round<N: Network>(
         &self,
         state: &mut [F; T],
@@ -608,7 +608,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// Computes multiple Poseidon2 permuations in parallel using the Rep3 MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation.
+    /// Computes multiple Poseidon2 permutations in parallel using the Rep3 MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation.
     pub fn rep3_permutation_in_place_with_precomputation_packed<N: Network>(
         &self,
         state: &mut [Rep3PrimeFieldShare<F>],
@@ -647,7 +647,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// Computes the Poseidon2 permuation using the Rep3 MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation.
+    /// Computes the Poseidon2 permutation using the Rep3 MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation.
     pub fn rep3_permutation_in_place_with_precomputation<N: Network>(
         &self,
         state: &mut [Rep3PrimeFieldShare<F>; T],
@@ -681,7 +681,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// Computes the Poseidon2 permuation using the Rep3 MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation. Furthermore, the whole state is processed as additive shares, i.e., less CPU at the cost of more network communication.
+    /// Computes the Poseidon2 permutation using the Rep3 MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation. Furthermore, the whole state is processed as additive shares, i.e., less CPU at the cost of more network communication.
     pub fn rep3_permutation_additive_in_place_with_precomputation<N: Network>(
         &self,
         state_: &mut [Rep3PrimeFieldShare<F>; T],
@@ -721,7 +721,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// Computes the Poseidon2 permuation using the Rep3 MPC protocol while overwriting the input.
+    /// Computes the Poseidon2 permutation using the Rep3 MPC protocol while overwriting the input.
     pub fn rep3_permutation_in_place<N: Network>(
         &self,
         state_: &mut [Rep3PrimeFieldShare<F>; T],
@@ -760,7 +760,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// Computes the Poseidon2 permuation using the Rep3 MPC protocol.
+    /// Computes the Poseidon2 permutation using the Rep3 MPC protocol.
     pub fn rep3_permutation<N: Network>(
         &self,
         state: &[Rep3PrimeFieldShare<F>; T],
@@ -772,7 +772,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(state)
     }
 
-    /// Computes the Poseidon2 permuation using the Rep3 MPC protocol. Thereby, a preprocessing technique is used to reduce the depth of the computation.
+    /// Computes the Poseidon2 permutation using the Rep3 MPC protocol. Thereby, a preprocessing technique is used to reduce the depth of the computation.
     pub fn rep3_permutation_with_precomputation<N: Network>(
         &self,
         state: &[Rep3PrimeFieldShare<F>; T],
@@ -785,7 +785,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(state)
     }
 
-    /// Computes multiple Poseidon2 permuations in paralllel using the Rep3 MPC protocol. Thereby, a preprocessing technique is used to reduce the depth of the computation.
+    /// Computes multiple Poseidon2 permutations in parallel using the Rep3 MPC protocol. Thereby, a preprocessing technique is used to reduce the depth of the computation.
     pub fn rep3_permutation_with_precomputation_packed<N: Network>(
         &self,
         state: &[Rep3PrimeFieldShare<F>],
@@ -798,7 +798,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(state)
     }
 
-    /// Computes the Poseidon2 permuation using the Rep3 MPC protocol. Thereby, a preprocessing technique is used to reduce the depth of the computation. Furthermore, the whole state is processed as additive shares, i.e., less CPU at the cost of more network communication.
+    /// Computes the Poseidon2 permutation using the Rep3 MPC protocol. Thereby, a preprocessing technique is used to reduce the depth of the computation. Furthermore, the whole state is processed as additive shares, i.e., less CPU at the cost of more network communication.
     pub fn rep3_permutation_additive_with_precomputation<N: Network>(
         &self,
         state: &[Rep3PrimeFieldShare<F>; T],

--- a/mpc-core/src/gadgets/poseidon2/shamir.rs
+++ b/mpc-core/src/gadgets/poseidon2/shamir.rs
@@ -196,7 +196,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
     #[inline(always)]
     pub fn shamir_external_round_precomp<N: Network>(
         &self,
@@ -210,7 +210,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         self.shamir_external_round_precomp_inner(state, r, precomp, net, shamir_state)
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
     fn shamir_external_round_precomp_inner<N: Network>(
         &self,
         state: &mut [F; T],
@@ -225,7 +225,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One internal round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
+    /// One internal round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
     #[inline(always)]
     pub fn shamir_internal_round_precomp<N: Network>(
         &self,
@@ -239,7 +239,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         self.shamir_internal_round_precomp_inner(state, r, precomp, net, shamir_state)
     }
 
-    /// One internal round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
+    /// One internal round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
     fn shamir_internal_round_precomp_inner<N: Network>(
         &self,
         state: &mut [F; T],
@@ -254,7 +254,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One external round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
+    /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
     fn shamir_external_round_precomp_inner_packed<N: Network>(
         &self,
         state: &mut [F],
@@ -274,7 +274,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One internal round of the Poseidon2 permuation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
+    /// One internal round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Shamir MPC protocol.
     fn shamir_internal_round_precomp_inner_packed<N: Network>(
         &self,
         state: &mut [F],
@@ -294,7 +294,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One external round of the Poseidon2 permuation. Implemented for the Shamir MPC protocol.
+    /// One external round of the Poseidon2 permutation. Implemented for the Shamir MPC protocol.
     fn shamir_external_round<N: Network>(
         &self,
         state: &mut [F; T],
@@ -308,7 +308,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// One internal round of the Poseidon2 permuation. Implemented for the Shamir MPC protocol.
+    /// One internal round of the Poseidon2 permutation. Implemented for the Shamir MPC protocol.
     fn shamir_internal_round<N: Network>(
         &self,
         state: &mut [F; T],
@@ -322,7 +322,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// Computes multiple Poseidon2 permuations in parallel using the Shamir MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation.
+    /// Computes multiple Poseidon2 permutations in parallel using the Shamir MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation.
     pub fn shamir_permutation_in_place_with_precomputation_packed<N: Network>(
         &self,
         state: &mut [ShamirPrimeFieldShare<F>],
@@ -363,7 +363,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// Computes the Poseidon2 permuation using the Shamir MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation.
+    /// Computes the Poseidon2 permutation using the Shamir MPC protocol while overwriting the input. Thereby, a preprocessing technique is used to reduce the depth of the computation.
     pub fn shamir_permutation_in_place_with_precomputation<N: Network>(
         &self,
         state: &mut [ShamirPrimeFieldShare<F>; T],
@@ -398,7 +398,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// Computes the Poseidon2 permuation using the Shamir MPC protocol while overwriting the input.
+    /// Computes the Poseidon2 permutation using the Shamir MPC protocol while overwriting the input.
     pub fn shamir_permutation_in_place<N: Network>(
         &self,
         state: &mut [ShamirPrimeFieldShare<F>; T],
@@ -428,7 +428,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(())
     }
 
-    /// Computes the Poseidon2 permuation using the Shamir MPC protocol.
+    /// Computes the Poseidon2 permutation using the Shamir MPC protocol.
     pub fn shamir_permutation<N: Network>(
         &self,
         state: &[ShamirPrimeFieldShare<F>; T],
@@ -440,7 +440,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(state)
     }
 
-    /// Computes the Poseidon2 permuation using the Shamir MPC protocol. Thereby, a preprocessing technique is used to reduce the depth of the computation.
+    /// Computes the Poseidon2 permutation using the Shamir MPC protocol. Thereby, a preprocessing technique is used to reduce the depth of the computation.
     pub fn shamir_permutation_with_precomputation<N: Network>(
         &self,
         state: &[ShamirPrimeFieldShare<F>; T],
@@ -458,7 +458,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Ok(state)
     }
 
-    /// Computes multiple Poseidon2 permuations in parallel using the Shamir MPC protocol. Thereby, a preprocessing technique is used to reduce the depth of the computation.
+    /// Computes multiple Poseidon2 permutations in parallel using the Shamir MPC protocol. Thereby, a preprocessing technique is used to reduce the depth of the computation.
     pub fn shamir_permutation_with_precomputation_packed<N: Network>(
         &self,
         state: &[ShamirPrimeFieldShare<F>],

--- a/mpc-core/src/protocols/rep3/arithmetic.rs
+++ b/mpc-core/src/protocols/rep3/arithmetic.rs
@@ -784,7 +784,7 @@ pub fn arithmetic_xor_many<F: PrimeField, N: Network>(
     Ok(res)
 }
 
-/// Reshares the shared valuse from two parties to one other
+/// Reshares the shared values from two parties to one other
 /// Assumes seeds are set up correctly already
 pub fn reshare_from_2_to_3_parties<F: PrimeField, N: Network>(
     input: Option<Vec<Rep3PrimeFieldShare<F>>>,

--- a/mpc-core/src/protocols/rep3/arithmetic/ops.rs
+++ b/mpc-core/src/protocols/rep3/arithmetic/ops.rs
@@ -134,7 +134,7 @@ impl<F: PrimeField> ark_ff::Zero for Rep3PrimeFieldShare<F> {
 
     fn is_zero(&self) -> bool {
         panic!(
-            "is_zero is not a meaningful operation for Rep3PrimeFieldShare, use interative zero check instead"
+            "is_zero is not a meaningful operation for Rep3PrimeFieldShare, use interactive zero check instead"
         );
     }
 }

--- a/mpc-core/src/protocols/rep3/binary.rs
+++ b/mpc-core/src/protocols/rep3/binary.rs
@@ -300,8 +300,8 @@ pub fn is_zero<F: PrimeField, N: Network>(
     // negate
     let mut x = x ^ &mask;
 
-    // do ands in a tree
-    // TODO: Make and tree more communication efficient, ATM we send the full element for each level, even though they halve in size
+    // do AND operations in a tree
+    // TODO: Make AND tree more communication efficient, ATM we send the full element for each level, even though they halve in size
     let mut len = bit_len;
     while len > 1 {
         if len % 2 == 1 {
@@ -336,8 +336,8 @@ pub fn is_zero_many<F: PrimeField, N: Network>(
     }
     let mut y = x.clone();
 
-    // do ands in a tree
-    // TODO: Make and tree more communication efficient, ATM we send the full element for each level, even though they halve in size
+    // do AND operations in a tree
+    // TODO: Make AND tree more communication efficient, ATM we send the full element for each level, even though they halve in size
     let mut len = bit_len;
     while len > 1 {
         if len % 2 == 1 {

--- a/mpc-core/src/protocols/rep3/pointshare.rs
+++ b/mpc-core/src/protocols/rep3/pointshare.rs
@@ -216,7 +216,7 @@ pub fn msm_public_points<C: CurveGroup>(
 }
 
 /// Checks whether the shared point is zero/infinity.
-/// The strategy is that we split the point into two random shares (as for point_share_to_fieldshares) and check for equal x-coordinates. This works, since the two random shares, with overwhelming probability, will have different x-coordinates if the underyling value is not zero.
+/// The strategy is that we split the point into two random shares (as for point_share_to_fieldshares) and check for equal x-coordinates. This works, since the two random shares, with overwhelming probability, will have different x-coordinates if the underlying value is not zero.
 /// Returns a replicated boolean share in two separate parts.
 pub fn is_zero<C: CurveGroup, N: Network>(
     x: PointShare<C>,
@@ -234,7 +234,7 @@ where
 }
 
 /// Checks whether the shared point is zero/infinity.
-/// The strategy is that we split the point into two random shares (as for point_share_to_fieldshares) and check for equal x-coordinates. This works, since the two random shares, with overwhelming probability, will have different x-coordinates if the underyling value is not zero.
+/// The strategy is that we split the point into two random shares (as for point_share_to_fieldshares) and check for equal x-coordinates. This works, since the two random shares, with overwhelming probability, will have different x-coordinates if the underlying value is not zero.
 /// Returns a replicated boolean share in two separate parts.
 pub fn is_zero_many<C: CurveGroup, N: Network>(
     x: &[PointShare<C>],

--- a/mpc-core/src/protocols/rep3/pointshare/types.rs
+++ b/mpc-core/src/protocols/rep3/pointshare/types.rs
@@ -11,7 +11,7 @@ pub struct Rep3PointShare<C: CurveGroup> {
 }
 
 impl<C: CurveGroup> Rep3PointShare<C> {
-    /// Contruct a new [`Rep3PointShare`]
+    /// Construct a new [`Rep3PointShare`]
     pub fn new(a: C, b: C) -> Self {
         Self { a, b }
     }

--- a/mpc-core/src/protocols/rep3/poly.rs
+++ b/mpc-core/src/protocols/rep3/poly.rs
@@ -51,7 +51,7 @@ pub fn eval_poly<F: PrimeField>(coeffs: &[FieldShare<F>], point: F) -> FieldShar
 
     // run Horners method on each thread as follows:
     // 1) Split up the coefficients across each thread evenly.
-    // 2) Do polynomial evaluation via horner's method for the thread's coefficeints
+    // 2) Do polynomial evaluation via horner's method for the thread's coefficients
     // 3) Scale the result point^{thread coefficient start index}
     // Then obtain the final polynomial evaluation by summing each threads result.
     coeffs

--- a/mpc-core/src/protocols/rep3/rngs.rs
+++ b/mpc-core/src/protocols/rep3/rngs.rs
@@ -263,7 +263,7 @@ pub struct Rep3RandBitComp {
 }
 
 impl Rep3RandBitComp {
-    /// Contruct a new [`Rep3RandBitComp`] w rngs
+    /// Construct a new [`Rep3RandBitComp`] w rngs
     pub fn new_2keys(rng1: [u8; crate::SEED_SIZE], rng2: [u8; crate::SEED_SIZE]) -> Self {
         Self {
             rng1: RngType::from_seed(rng1),
@@ -272,7 +272,7 @@ impl Rep3RandBitComp {
         }
     }
 
-    /// Contruct a new [`Rep3RandBitComp`] with 3 rngs
+    /// Construct a new [`Rep3RandBitComp`] with 3 rngs
     pub fn new_3keys(
         rng1: [u8; crate::SEED_SIZE],
         rng2: [u8; crate::SEED_SIZE],

--- a/mpc-core/src/protocols/rep3/yao.rs
+++ b/mpc-core/src/protocols/rep3/yao.rs
@@ -69,7 +69,7 @@ impl GCUtils {
 
     /// Garbles an 'and' gate given two input wires and the delta.
     ///
-    /// Outputs a tuple consisting of the two gates (that should be transfered to the evaluator)
+    /// Outputs a tuple consisting of the two gates (that should be transferred to the evaluator)
     /// and the next wire label for the garbler.
     ///
     /// Used internally as a subroutine to implement 'and' gates for `FancyBinary`.

--- a/mpc-core/src/protocols/rep3/yao/bristol_fashion/bristol.rs
+++ b/mpc-core/src/protocols/rep3/yao/bristol_fashion/bristol.rs
@@ -122,7 +122,7 @@ impl BristolFashionCircuit {
                         .or_default()
                         .push(gate);
                 }
-                // EqWires are a bit strange, they should just be removed from the circuit alltogether in the future
+                // EqWires are a bit strange, they should just be removed from the circuit altogether in the future
                 // Atm we add a linear level for them
                 BristolFashionGate::EqWire { inwire, outwire } => {
                     let (and_depth, total_depth) = gate_level
@@ -588,7 +588,7 @@ pub trait BristolFashionEvaluator {
     // TODO: once GATs are stable, see if we can maybe specify the error type here better
 
     /// Produce a `WireValue` equal to a zero/false bit if `input == false`,
-    /// otherwise procude a `WireValue` equal to a one/true bit.
+    /// otherwise produce a `WireValue` equal to a one/true bit.
     fn constant(&mut self, input: bool) -> Result<Self::WireValue, CircuitExecutionError>;
     /// Produce a `WireValue` equal to the inverse of the input `WireValue`
     ///

--- a/mpc-core/src/protocols/rep3/yao/bristol_fashion/mod.rs
+++ b/mpc-core/src/protocols/rep3/yao/bristol_fashion/mod.rs
@@ -7,10 +7,10 @@ pub use bristol::{BristolFashionCircuit, BristolFashionEvaluator, LeveledBristol
 /// Errors that happen during parsing of circuits
 #[derive(Error, Debug)]
 pub enum CircuitBuilderError {
-    /// An IO-Error has occured
+    /// An IO-Error has occurred
     #[error("{0}")]
     IoError(#[from] std::io::Error),
-    /// An Error has occured during parsing
+    /// An Error has occurred during parsing
     #[error("Error during Parsing: {0}")]
     ParseError(String),
     /// The built/parsed circuit is invalid
@@ -21,10 +21,10 @@ pub enum CircuitBuilderError {
 /// Errors that happen during execution of circuits
 #[derive(Error, Debug)]
 pub enum CircuitExecutionError {
-    /// An unspecified Error has occured
+    /// An unspecified Error has occurred
     #[error("{0}")]
     GenericError(Box<dyn std::error::Error>),
-    /// An IO-Error has occured
+    /// An IO-Error has occurred
     #[error("{0}")]
     IoError(#[from] std::io::Error),
     /// The provided input was not the correct format for the circuit

--- a/mpc-core/src/protocols/rep3/yao/garbler.rs
+++ b/mpc-core/src/protocols/rep3/yao/garbler.rs
@@ -210,7 +210,7 @@ impl<'a, N: Network> Rep3Garbler<'a, N> {
 
     /// Garbles an 'and' gate given two input wires and the delta.
     ///
-    /// Outputs a tuple consisting of the two gates (that should be transfered to the evaluator)
+    /// Outputs a tuple consisting of the two gates (that should be transferred to the evaluator)
     /// and the next wire label for the garbler.
     ///
     /// Used internally as a subroutine to implement 'and' gates for `FancyBinary`.

--- a/mpc-core/src/protocols/rep3/yao/streaming_garbler.rs
+++ b/mpc-core/src/protocols/rep3/yao/streaming_garbler.rs
@@ -134,7 +134,7 @@ impl<'a, N: Network> StreamingRep3Garbler<'a, N> {
         }
     }
 
-    /// As ID2, send a hash of the sended data to the evaluator.
+    /// As ID2, send a hash of the sent data to the evaluator.
     pub fn send_hash(&self) -> eyre::Result<()> {
         if self.id == PartyID::ID2 {
             let digest = self.hash.clone().finalize();
@@ -192,7 +192,7 @@ impl<'a, N: Network> StreamingRep3Garbler<'a, N> {
 
     /// Garbles an 'and' gate given two input wires and the delta.
     ///
-    /// Outputs a tuple consisting of the two gates (that should be transfered to the evaluator)
+    /// Outputs a tuple consisting of the two gates (that should be transferred to the evaluator)
     /// and the next wire label for the garbler.
     ///
     /// Used internally as a subroutine to implement 'and' gates for `FancyBinary`.

--- a/mpc-core/src/protocols/rep3_ring/arithmetic/ops.rs
+++ b/mpc-core/src/protocols/rep3_ring/arithmetic/ops.rs
@@ -134,7 +134,7 @@ impl<T: IntRing2k> ark_ff::Zero for Rep3RingShare<T> {
 
     fn is_zero(&self) -> bool {
         panic!(
-            "is_zero is not a meaningful operation for Rep3PrimeFieldShare, use interative zero check instead"
+            "is_zero is not a meaningful operation for Rep3PrimeFieldShare, use interactive zero check instead"
         );
     }
 }

--- a/mpc-core/src/protocols/rep3_ring/binary.rs
+++ b/mpc-core/src/protocols/rep3_ring/binary.rs
@@ -230,8 +230,8 @@ where
     // negate
     let mut x = !x;
 
-    // do ands in a tree
-    // TODO: Make and tree more communication efficient, ATM we send the full element for each level, even though they halve in size
+    // do AND operations in a tree
+    // TODO: Make AND tree more communication efficient, ATM we send the full element for each level, even though they halve in size
     let mut len = T::K;
     debug_assert!(len.is_power_of_two());
     while len > 1 {

--- a/mpc-core/src/protocols/rep3_ring/gadgets/ohv.rs
+++ b/mpc-core/src/protocols/rep3_ring/gadgets/ohv.rs
@@ -15,7 +15,7 @@ use crate::protocols::{
 };
 
 /// Generates a random one-hot-encoded vector of size k bits.
-/// The output is (r, e), where r is a binary sharing of the index of the set bit, wheras e is a vector of size 2^k with all bits zero except at index r.
+/// The output is (r, e), where r is a binary sharing of the index of the set bit, whereas e is a vector of size 2^k with all bits zero except at index r.
 /// The algorithm is a rewrite of Protocol 5 from [https://eprint.iacr.org/2024/1317.pdf](https://eprint.iacr.org/2024/1317.pdf) for rep3.
 pub fn rand_ohv<T: IntRing2k, N: Network>(
     k: usize,
@@ -41,7 +41,7 @@ where
 }
 
 /// Generates a one-hot-encoded vector of size k bits from a given secret shared index which is already decomposed into shared bits.
-/// The output is (r, e), where r is a binary sharing of the index of the set bit, wheras e is a vector of size 2^k with all bits zero except at index r.
+/// The output is (r, e), where r is a binary sharing of the index of the set bit, whereas e is a vector of size 2^k with all bits zero except at index r.
 /// The algorithm is a rewrite of Protocol 5 from [https://eprint.iacr.org/2024/1317.pdf](https://eprint.iacr.org/2024/1317.pdf) for rep3.
 pub fn ohv<T: IntRing2k, N: Network>(
     k: usize,

--- a/mpc-core/src/protocols/rep3_ring/ring/bit.rs
+++ b/mpc-core/src/protocols/rep3_ring/ring/bit.rs
@@ -46,7 +46,7 @@ impl Bit {
         unsafe { &*(vec as *const [bool] as *const [Self]) }
     }
 
-    /// Transfroms a vector of bool into a vector of Bits
+    /// Transforms a vector of bool into a vector of Bits
     // Safe because Bit has repr(transparent)
     pub fn convert_vec_rev(vec: Vec<bool>) -> Vec<Self> {
         let me = ManuallyDrop::new(vec);

--- a/mpc-core/src/protocols/rep3_ring/ring/ring_impl.rs
+++ b/mpc-core/src/protocols/rep3_ring/ring/ring_impl.rs
@@ -1,6 +1,6 @@
 //! RingImpl
 //!
-//! This type is a wrapper for all datatypes implementing the [`IntRing2k`] trait. The purpose is explicitly allowing wrapping arithmetic opearations.
+//! This type is a wrapper for all datatypes implementing the [`IntRing2k`] trait. The purpose is explicitly allowing wrapping arithmetic operations.
 
 use super::int_ring::IntRing2k;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
@@ -18,7 +18,7 @@ use std::{
     },
 };
 
-/// The RingElement type is a wrapper for all datatypes implementing the [`IntRing2k`] trait to explicitly allow wrapping arithmetic opearations.
+/// The RingElement type is a wrapper for all datatypes implementing the [`IntRing2k`] trait to explicitly allow wrapping arithmetic operations.
 #[derive(
     Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, PartialOrd, Eq, Ord, Hash,
 )]
@@ -34,7 +34,7 @@ impl<T: IntRing2k> RingElement<T> {
         unsafe { &*(vec as *const [T] as *const [Self]) }
     }
 
-    /// Transfroms a vector of T into a vector of RingElements
+    /// Transforms a vector of T into a vector of RingElements
     // Safe because RingElement has repr(transparent)
     pub fn convert_vec_rev(vec: Vec<T>) -> Vec<Self> {
         let me = ManuallyDrop::new(vec);

--- a/mpc-core/src/protocols/rep3_ring/yao.rs
+++ b/mpc-core/src/protocols/rep3_ring/yao.rs
@@ -368,7 +368,7 @@ where
 {
     // Special case for Bit
     if TypeId::of::<T>() == TypeId::of::<Bit>() {
-        // SAFTEY: We already checked that the type matches
+        // SAFETY: We already checked that the type matches
         let shares =
             unsafe { &*(inputs as *const [Rep3RingShare<T>] as *const [Rep3RingShare<Bit>]) };
         let biguint_shares = shares
@@ -888,7 +888,7 @@ where
 
     // Special case for Bit
     if TypeId::of::<T>() == TypeId::of::<Bit>() {
-        // SAFTEY: We already checked that the type matches
+        // SAFETY: We already checked that the type matches
         let shares =
             unsafe { &*(inputs as *const [Rep3RingShare<T>] as *const [Rep3RingShare<Bit>]) };
         return conversion::bit_inject_from_bits_many(shares, net, state);
@@ -1324,7 +1324,7 @@ where
     Ok(res)
 }
 
-/// Decomposes a FieldElement into a vector of RingElements of size decompose_bitlen each. In total, ther will be num_decomps_per_field decompositions. The output is stored in the ring specified by T.
+/// Decomposes a FieldElement into a vector of RingElements of size decompose_bitlen each. In total, there will be num_decomps_per_field decompositions. The output is stored in the ring specified by T.
 pub fn decompose_field_to_rings<F: PrimeField, T: IntRing2k, N: Network>(
     input: Rep3PrimeFieldShare<F>,
     net: &N,

--- a/mpc-core/src/protocols/shamir.rs
+++ b/mpc-core/src/protocols/shamir.rs
@@ -1,6 +1,6 @@
 //! # Shamir
 //!
-//! This module implements the shamir share and combine opertions and shamir preprocessing
+//! This module implements the shamir share and combine operations and shamir preprocessing
 
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
@@ -405,7 +405,7 @@ pub fn poly_with_zeros_from_precomputed<F: PrimeField>(secret: &F, precomp: Vec<
     poly
 }
 
-/// Create the poly from secret pont and precomputed values
+/// Create the poly from secret point and precomputed values
 // sets the shares of parties in points to 0
 pub fn poly_with_zeros_from_precomputed_point<F: PrimeField, C>(secret: &C, precomp: &[F]) -> Vec<C>
 where

--- a/mpc-core/src/protocols/shamir/arithmetic/ops.rs
+++ b/mpc-core/src/protocols/shamir/arithmetic/ops.rs
@@ -161,7 +161,7 @@ impl<F: PrimeField> ark_ff::Zero for ShamirPrimeFieldShare<F> {
 
     fn is_zero(&self) -> bool {
         panic!(
-            "is_zero is not a meaningful operation for Rep3PrimeFieldShare, use interative zero check instead"
+            "is_zero is not a meaningful operation for Rep3PrimeFieldShare, use interactive zero check instead"
         );
     }
 }

--- a/mpc-core/src/protocols/shamir/network.rs
+++ b/mpc-core/src/protocols/shamir/network.rs
@@ -54,7 +54,7 @@ pub trait ShamirNetworkExt: Network {
         Ok(res)
     }
 
-    /// Send and reveive data to and from all parties.
+    /// Send and receive data to and from all parties.
     #[inline(always)]
     fn broadcast<F: CanonicalSerialize + CanonicalDeserialize + Clone + Send>(
         &self,
@@ -89,7 +89,7 @@ pub trait ShamirNetworkExt: Network {
         Ok(res)
     }
 
-    /// Send and reveive a vector of data to and from all parties.
+    /// Send and receive a vector of data to and from all parties.
     #[inline(always)]
     fn broadcast_next<F: CanonicalSerialize + CanonicalDeserialize + Clone + Send>(
         &self,

--- a/mpc-core/src/protocols/shamir/pointshare.rs
+++ b/mpc-core/src/protocols/shamir/pointshare.rs
@@ -202,7 +202,7 @@ pub fn open_point_and_field_many<C: CurveGroup, N: Network>(
     Ok((res_points, res_fields))
 }
 
-/// Perfoms MSM between curve points and field shares.
+/// Performs MSM between curve points and field shares.
 pub fn msm_public_points<C: CurveGroup>(
     points: &[C::Affine],
     scalars: &[FieldShare<C::ScalarField>],

--- a/mpc-core/src/protocols/shamir/poly.rs
+++ b/mpc-core/src/protocols/shamir/poly.rs
@@ -51,7 +51,7 @@ pub fn eval_poly<F: PrimeField>(coeffs: &[FieldShare<F>], point: F) -> FieldShar
 
     // run Horners method on each thread as follows:
     // 1) Split up the coefficients across each thread evenly.
-    // 2) Do polynomial evaluation via horner's method for the thread's coefficeints
+    // 2) Do polynomial evaluation via horner's method for the thread's coefficients
     // 3) Scale the result point^{thread coefficient start index}
     // Then obtain the final polynomial evaluation by summing each threads result.
     coeffs

--- a/mpc-net/src/lib.rs
+++ b/mpc-net/src/lib.rs
@@ -20,7 +20,7 @@ pub mod tls;
 /// The default connection timeout
 pub const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
 /// The default max frame length for sending messages
-pub const DEFAULT_MAX_FRAME_LENTH: usize = 64 * 1024 * 1024; // 64MB
+pub const DEFAULT_MAX_FRAME_LENGTH: usize = 64 * 1024 * 1024; // 64MB
 
 /// A MPC network that can be used to send and receive data to and from other parties
 ///

--- a/mpc-net/src/quic.rs
+++ b/mpc-net/src/quic.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENTH, Network, config::Address,
+    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENGTH, Network, config::Address,
 };
 use bytes::Bytes;
 use eyre::{Context as _, ContextCompat};
@@ -183,7 +183,7 @@ struct QuicConnectionHandler {
 impl QuicConnectionHandler {
     pub fn new(config: NetworkConfig, rt: Runtime) -> eyre::Result<Self> {
         let id = config.my_id;
-        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENTH);
+        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENGTH);
         let (connections, endpoints) = rt.block_on(Self::init(config))?;
         Ok(Self {
             id,

--- a/mpc-net/src/tcp.rs
+++ b/mpc-net/src/tcp.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use crate::{
-    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENTH, Network, config::Address,
+    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENGTH, Network, config::Address,
 };
 use byteorder::{BigEndian, ReadBytesExt as _, WriteBytesExt as _};
 use crossbeam_channel::Receiver;
@@ -106,7 +106,7 @@ impl TcpNetwork {
             .map(|party| party.dns_name)
             .collect::<Vec<_>>();
         let timeout = config.timeout.unwrap_or(DEFAULT_CONNECTION_TIMEOUT);
-        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENTH);
+        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENGTH);
 
         let domain = match bind_addr {
             SocketAddr::V4(_) => Domain::IPV4,

--- a/mpc-net/src/tcp_session.rs
+++ b/mpc-net/src/tcp_session.rs
@@ -14,7 +14,7 @@ use tokio::{net::TcpStream, sync::oneshot};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 use tokio_util::sync::{CancellationToken, DropGuard};
 
-use crate::{ConnectionStats, DEFAULT_MAX_FRAME_LENTH, Network};
+use crate::{ConnectionStats, DEFAULT_MAX_FRAME_LENGTH, Network};
 
 /// The default time to idle for incoming connections that were not picked up because, e.g. `init_session` for that session id was never called.
 pub const DEFAULT_TIME_TO_IDLE: Duration = Duration::from_secs(30);
@@ -116,7 +116,7 @@ impl TcpNetworkHandlerBuilder {
             bind_addr,
             parties,
             time_to_idle: DEFAULT_TIME_TO_IDLE,
-            max_frame_length: DEFAULT_MAX_FRAME_LENTH,
+            max_frame_length: DEFAULT_MAX_FRAME_LENGTH,
         }
     }
 
@@ -130,7 +130,7 @@ impl TcpNetworkHandlerBuilder {
 
     /// Set the maximum length of a frame that can be sent or received. This is used to prevent DoS attacks by sending very large frames.
     ///
-    /// Defaults to `DEFAULT_MAX_FRAME_LENTH` (64MB)
+    /// Defaults to `DEFAULT_MAX_FRAME_LENGTH` (64MB)
     pub fn max_frame_length(mut self, max_frame_length: usize) -> Self {
         self.max_frame_length = max_frame_length;
         self

--- a/mpc-net/src/tls.rs
+++ b/mpc-net/src/tls.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use crate::{
-    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENTH, Network, config::Address,
+    ConnectionStats, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MAX_FRAME_LENGTH, Network, config::Address,
 };
 use byteorder::{BigEndian, ReadBytesExt as _, WriteBytesExt as _};
 use crossbeam_channel::Receiver;
@@ -245,7 +245,7 @@ impl TlsNetwork {
             .map(|party| party.cert)
             .collect::<Vec<_>>();
         let timeout = config.timeout.unwrap_or(DEFAULT_CONNECTION_TIMEOUT);
-        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENTH);
+        let max_frame_length = config.max_frame_length.unwrap_or(DEFAULT_MAX_FRAME_LENGTH);
 
         let mut root_store = RootCertStore::empty();
         for cert in &certs {

--- a/tests/tests/mpc/rep3_ring.rs
+++ b/tests/tests/mpc/rep3_ring.rs
@@ -2435,7 +2435,7 @@ mod ring_share {
     }
 
     #[test]
-    fn rep3_write_cuvre_lut_test() {
+    fn rep3_write_curve_lut_test() {
         apply_to_all!(rep3_write_curve_lut_test_t, [u8, u16]);
     }
 }


### PR DESCRIPTION
Introduces a typos-cli (.typos.toml) config that allowlists crypto terminology ("Groth" as in Groth16, "MiMC", "OT" for Oblivious Transfer) and excludes third-party circomlib test vectors and auto-generated CHANGELOGs, then fixes every remaining real typo the tool surfaced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly comment/docstring and identifier spelling fixes; the only notable risk is from a few public-ish symbol renames (e.g., Merkle verify helpers and `DEFAULT_MAX_FRAME_LENGTH`) that could break downstream callers if not updated everywhere.
> 
> **Overview**
> Adds a `typos-cli` configuration (`.typos.toml`) that excludes test vectors/CHANGELOGs and allowlists common crypto terms (e.g., `Groth`, `MiMC`, `OT`).
> 
> Applies widespread typo fixes across the Rust workspace, including a handful of **identifier renames** (e.g., `verifiy_merkle_path_*` → `verify_merkle_path_*`, `DEFAULT_MAX_FRAME_LENTH` → `DEFAULT_MAX_FRAME_LENGTH`, `add_entites` → `add_entities`) plus minor variable/test name spelling corrections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ef33f029f3a8d63d3d7be9eb3ee0d724561898d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->