### PR TITLE
build(deps): update rand to fix CVEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -572,7 +572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -582,7 +582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
 ]
 
@@ -1109,7 +1109,7 @@ dependencies = [
  "noirc_artifacts",
  "num-bigint 0.4.6",
  "paste",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde",
  "sha2",
@@ -1132,7 +1132,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "paste",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tracing",
 ]
 
@@ -1157,7 +1157,7 @@ dependencies = [
  "noir-types",
  "num-bigint 0.4.6",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde_json",
  "tracing",
@@ -1184,7 +1184,7 @@ dependencies = [
  "mpc-core",
  "mpc-net",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls",
  "serde",
  "serde_json",
@@ -1204,7 +1204,7 @@ dependencies = [
  "mpc-core",
  "num-bigint 0.4.6",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "taceo-circom-types",
@@ -1229,7 +1229,7 @@ dependencies = [
  "mpc-core",
  "mpc-net",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde_json",
  "taceo-circom-types",
@@ -1258,7 +1258,7 @@ dependencies = [
  "noir-types",
  "noirc_abi",
  "noirc_artifacts",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls",
  "serde",
  "serde_json",
@@ -1286,7 +1286,7 @@ dependencies = [
  "noir-types",
  "num-bigint 0.4.6",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "ruint",
  "serde",
@@ -1302,7 +1302,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "eyre",
  "mpc-core",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -1322,7 +1322,7 @@ dependencies = [
  "mpc-core",
  "mpc-net",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde_json",
  "sha3",
@@ -1347,7 +1347,7 @@ dependencies = [
  "mpc-net",
  "noir-types",
  "num-bigint 0.4.6",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "sha3",
  "tracing",
@@ -1961,7 +1961,7 @@ dependencies = [
  "fancy-garbling-base-conversion",
  "itertools 0.13.0",
  "ocelot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "scuttlebutt",
  "subtle",
@@ -1984,7 +1984,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.3",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -2091,7 +2091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2838,7 +2838,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "paste",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rayon",
  "ruint",
@@ -3120,7 +3120,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "smallvec",
 ]
@@ -3223,7 +3223,7 @@ dependencies = [
  "curve25519-dalek",
  "generic-array 1.2.0",
  "keyed_arena",
- "rand 0.8.5",
+ "rand 0.8.6",
  "scuttlebutt",
  "subtle",
  "vectoreyes",
@@ -3623,7 +3623,7 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
@@ -3670,7 +3670,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3720,9 +3720,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3731,9 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3990,8 +3990,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -4281,7 +4281,7 @@ dependencies = [
  "curve25519-dalek",
  "generic-array 1.2.0",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "serde",
@@ -4646,7 +4646,7 @@ version = "0.6.0"
 source = "git+https://github.com/GaloisInc/swanky?rev=5ff648457218b74da9d8323b7ca47166ff5be4b3#5ff648457218b74da9d8323b7ca47166ff5be4b3"
 dependencies = [
  "bytemuck",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "vectoreyes",
 ]
@@ -4669,7 +4669,7 @@ dependencies = [
  "crypto-bigint",
  "generic-array 1.2.0",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "subtle",
  "swanky-serialization",
 ]
@@ -4682,7 +4682,7 @@ dependencies = [
  "bytemuck",
  "crypto-bigint",
  "generic-array 1.2.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "subtle",
  "swanky-field",
  "swanky-serialization",
@@ -4697,7 +4697,7 @@ dependencies = [
  "bytemuck",
  "crypto-bigint",
  "generic-array 1.2.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "subtle",
  "swanky-field",
  "swanky-serialization",
@@ -4717,7 +4717,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "num_cpus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2",
@@ -4882,7 +4882,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "paste",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "sha2",
  "sha3",
@@ -5277,7 +5277,7 @@ dependencies = [
  "mpc-core",
  "noir-types",
  "num-bigint 0.4.6",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "tracing",
 ]
@@ -5367,7 +5367,7 @@ dependencies = [
  "proc-macro2",
  "quick-xml",
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "subtle",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Although this is a lockfile-only patch update, `rand` is widely used in cryptographic/proving code, so subtle behavior or dependency-resolution changes could affect test determinism or protocol randomness.
> 
> **Overview**
> Refreshes `Cargo.lock` to upgrade `rand` from `0.8.5` to `0.8.6` (and `rand` `0.9.2` to `0.9.4` where pulled in), updating all transitive references to the newer patched versions to address reported CVEs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b098d321352718bfce886ab36579c48b0dc2c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->