### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly updates for each Dependabot ecosystem mapped from the detected languages on the default branch.

Detected languages: Just,Rust,Shell

- Weekly updates for `github-actions`
- Weekly updates for `cargo`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that just throttles Dependabot PR frequency for `github-actions` and `cargo` updates.
> 
> **Overview**
> Adds a Dependabot `cooldown` of 3 days to the existing weekly update configuration for `github-actions` and `cargo`, reducing how frequently successive update PRs can be opened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae38633e1ed07c9251453bebdcdd78f59ebb8b36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->