### PR TITLE
ci: harden workflows with minimal GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   cargo-deny:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,10 @@ on:
     branches:
       - main
 name: release-please
+
+permissions:
+  contents: read
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -10,4 +14,4 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}  
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   release:
@@ -11,6 +11,8 @@ on:
 jobs:
   upload-assets-co-circom:
     if: startsWith(github.event.release.tag_name, 'co-circom-v')
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:
@@ -57,6 +59,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   upload-assets-co-noir:
     if: startsWith(github.event.release.tag_name, 'co-noir-v')
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -14,6 +14,9 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: FULL
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -15,6 +15,9 @@ env:
   RUST_BACKTRACE: FULL
   RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Set explicit, least-privilege `permissions:` blocks on every workflow
so the GITHUB_TOKEN can no longer be used for actions outside what each
job needs. This reduces blast radius if a third-party action or build
step is compromised.

- audit.yml: tighten broad `read-all` to `contents: read`
- release.yml: default to `contents: read`, grant `contents: write`
  only on the upload-asset jobs that need it
- release-please.yml: add top-level `contents: read` (writes go through
  the dedicated RELEASE_PLEASE_TOKEN PAT)
- rust_lint.yml, rust_test.yml: add top-level `contents: read`

rolling.yml already had `contents: read` and is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only changes that tighten GitHub Actions `GITHUB_TOKEN` permissions; main risk is workflows failing if a job implicitly relied on broader token scopes.
> 
> **Overview**
> Hardens GitHub Actions workflows by setting explicit, least-privilege `permissions` blocks across CI.
> 
> `audit.yml`, `rust_lint.yml`, `rust_test.yml`, and `release-please.yml` now default to `contents: read`, and `release.yml` defaults to `contents: read` while granting `contents: write` only to the release asset upload jobs that need it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d1185085a719fe2b014154e0bf7236fe6f3841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->