### PR TITLE
fix(co-acvm): reject nonzero empty assert-zero residuals

### DIFF
--- a/co-noir/co-acvm/src/solver/assert_zero_solver.rs
+++ b/co-noir/co-acvm/src/solver/assert_zero_solver.rs
@@ -145,6 +145,9 @@ where
             if let Some(residual) = T::get_public(&simplified.q_c) {
                 ensure_zero_residual(residual)
             } else if let Some(residual) = T::get_shared(&simplified.q_c) {
+                // Opening is intentional here: valid executions reveal zero, while invalid
+                // executions abort after revealing the failing residual value.
+                // Backends that require private failure values should replace this with a zero-test.
                 let opened = self.driver.open_many(&[residual])?;
                 ensure_single_opened_zero_residual(opened)
             } else if T::is_public_zero(&simplified.q_c) {

--- a/co-noir/co-acvm/src/solver/assert_zero_solver.rs
+++ b/co-noir/co-acvm/src/solver/assert_zero_solver.rs
@@ -186,8 +186,46 @@ where
 #[cfg(test)]
 mod tests {
     use super::{ensure_single_opened_zero_residual, ensure_zero_residual};
+    use crate::mpc::{NoirWitnessExtensionProtocol, plain::PlainAcvmSolver};
+    use crate::pss_store::PssStore;
+    use crate::solver::CoSolver;
+    use acir::{
+        acir_field::GenericFieldElement,
+        native_types::{Expression, Witness, WitnessMap},
+    };
     use ark_bn254::Fr;
     use ark_ff::{One, Zero};
+    use co_brillig::CoBrilligVM;
+    use intmap::IntMap;
+    use noirc_abi::Abi;
+
+    fn field(value: Fr) -> GenericFieldElement<Fr> {
+        GenericFieldElement::from_repr(value)
+    }
+
+    fn expression(q_c: Fr) -> Expression<GenericFieldElement<Fr>> {
+        Expression {
+            mul_terms: vec![],
+            linear_combinations: vec![],
+            q_c: field(q_c),
+        }
+    }
+
+    fn solver_with_witness(witness: WitnessMap<Fr>) -> CoSolver<PlainAcvmSolver<Fr>, Fr> {
+        let mut driver = PlainAcvmSolver::<Fr>::default();
+        let brillig = CoBrilligVM::init(driver.init_brillig_driver().unwrap(), vec![]);
+        CoSolver {
+            driver,
+            brillig,
+            abi: Abi::default(),
+            functions: vec![],
+            value_store: PssStore::new(),
+            witness_map: vec![witness],
+            function_index: 0,
+            memory_access: IntMap::new(),
+            pedantic_solving: true,
+        }
+    }
 
     #[test]
     fn public_zero_residual_succeeds() {
@@ -219,5 +257,44 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("open_many returned 0 values for one shared residual"));
+    }
+
+    #[test]
+    fn solve_assert_zero_accepts_simplified_public_zero_residual() {
+        let mut solver = solver_with_witness(WitnessMap::default());
+
+        assert!(solver.solve_assert_zero(&expression(Fr::zero())).is_ok());
+    }
+
+    #[test]
+    fn solve_assert_zero_rejects_simplified_public_nonzero_residual() {
+        let mut solver = solver_with_witness(WitnessMap::default());
+
+        let err = solver
+            .solve_assert_zero(&expression(Fr::one()))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("UnsatisfiedConstraint"));
+    }
+
+    #[test]
+    fn solve_assert_zero_checks_residual_after_known_witness_simplification() {
+        let witness_id = Witness(1);
+        let mut witness = WitnessMap::default();
+        witness.insert(witness_id, Fr::from(5u64));
+        let mut solver = solver_with_witness(witness);
+        let mut expr = expression(-Fr::from(5u64));
+        expr.linear_combinations
+            .push((field(Fr::one()), witness_id));
+
+        assert!(solver.solve_assert_zero(&expr).is_ok());
+
+        let mut bad_expr = expression(-Fr::from(4u64));
+        bad_expr
+            .linear_combinations
+            .push((field(Fr::one()), witness_id));
+        let err = solver.solve_assert_zero(&bad_expr).unwrap_err().to_string();
+        assert!(err.contains("UnsatisfiedConstraint"));
     }
 }

--- a/co-noir/co-acvm/src/solver/assert_zero_solver.rs
+++ b/co-noir/co-acvm/src/solver/assert_zero_solver.rs
@@ -1,6 +1,6 @@
 use crate::mpc::NoirWitnessExtensionProtocol;
 use acir::{AcirField, acir_field::GenericFieldElement, native_types::Expression};
-use ark_ff::PrimeField;
+use ark_ff::{PrimeField, Zero};
 
 use crate::solver::solver_utils;
 
@@ -122,9 +122,27 @@ where
         // also if we are here and have more than one linear combination, we
         // cannot solve the expression
         if simplified.linear_combinations.is_empty() {
-            // we are done
-            tracing::trace!("nothing to do for us");
-            Ok(())
+            if let Some(residual) = T::get_public(&simplified.q_c) {
+                if residual.is_zero() {
+                    tracing::trace!("nothing to do for us");
+                    Ok(())
+                } else {
+                    Err(eyre::eyre!("UnsatisfiedConstraint"))?
+                }
+            } else if let Some(residual) = T::get_shared(&simplified.q_c) {
+                let opened = self.driver.open_many(&[residual])?;
+                if opened[0].is_zero() {
+                    tracing::trace!("nothing to do for us");
+                    Ok(())
+                } else {
+                    Err(eyre::eyre!("UnsatisfiedConstraint"))?
+                }
+            } else if T::is_public_zero(&simplified.q_c) {
+                tracing::trace!("nothing to do for us");
+                Ok(())
+            } else {
+                Err(eyre::eyre!("UnsatisfiedConstraint"))?
+            }
         } else if simplified.linear_combinations.len() == 1 {
             //we can solve it!
             tracing::trace!("solving equation...");

--- a/co-noir/co-acvm/src/solver/assert_zero_solver.rs
+++ b/co-noir/co-acvm/src/solver/assert_zero_solver.rs
@@ -6,6 +6,26 @@ use crate::solver::solver_utils;
 
 use super::{CoAcvmResult, CoSolver};
 
+fn ensure_zero_residual<F: PrimeField>(residual: F) -> CoAcvmResult<()> {
+    if residual.is_zero() {
+        tracing::trace!("nothing to do for us");
+        Ok(())
+    } else {
+        Err(eyre::eyre!("UnsatisfiedConstraint"))?
+    }
+}
+
+fn ensure_single_opened_zero_residual<F: PrimeField>(opened: Vec<F>) -> CoAcvmResult<()> {
+    if opened.len() != 1 {
+        Err(eyre::eyre!(
+            "open_many returned {} values for one shared residual",
+            opened.len()
+        ))?
+    }
+
+    ensure_zero_residual(opened[0])
+}
+
 impl<T, F> CoSolver<T, F>
 where
     T: NoirWitnessExtensionProtocol<F>,
@@ -123,20 +143,10 @@ where
         // cannot solve the expression
         if simplified.linear_combinations.is_empty() {
             if let Some(residual) = T::get_public(&simplified.q_c) {
-                if residual.is_zero() {
-                    tracing::trace!("nothing to do for us");
-                    Ok(())
-                } else {
-                    Err(eyre::eyre!("UnsatisfiedConstraint"))?
-                }
+                ensure_zero_residual(residual)
             } else if let Some(residual) = T::get_shared(&simplified.q_c) {
                 let opened = self.driver.open_many(&[residual])?;
-                if opened[0].is_zero() {
-                    tracing::trace!("nothing to do for us");
-                    Ok(())
-                } else {
-                    Err(eyre::eyre!("UnsatisfiedConstraint"))?
-                }
+                ensure_single_opened_zero_residual(opened)
             } else if T::is_public_zero(&simplified.q_c) {
                 tracing::trace!("nothing to do for us");
                 Ok(())
@@ -170,5 +180,44 @@ where
             .ok_or(eyre::eyre!(
                 "cannot evaluate expression to const - has unknown"
             ))?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_single_opened_zero_residual, ensure_zero_residual};
+    use ark_bn254::Fr;
+    use ark_ff::{One, Zero};
+
+    #[test]
+    fn public_zero_residual_succeeds() {
+        assert!(ensure_zero_residual(Fr::zero()).is_ok());
+    }
+
+    #[test]
+    fn public_nonzero_residual_errors() {
+        let err = ensure_zero_residual(Fr::one()).unwrap_err().to_string();
+        assert!(err.contains("UnsatisfiedConstraint"));
+    }
+
+    #[test]
+    fn shared_zero_residual_succeeds_after_opening() {
+        assert!(ensure_single_opened_zero_residual(vec![Fr::zero()]).is_ok());
+    }
+
+    #[test]
+    fn shared_nonzero_residual_errors_after_opening() {
+        let err = ensure_single_opened_zero_residual(vec![Fr::one()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("UnsatisfiedConstraint"));
+    }
+
+    #[test]
+    fn opened_shared_residual_must_preserve_input_length() {
+        let err = ensure_single_opened_zero_residual::<Fr>(Vec::new())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("open_many returned 0 values for one shared residual"));
     }
 }


### PR DESCRIPTION
Fixes #550

## Summary

`solve_assert_zero` now checks fully reduced expressions instead of accepting every empty linear combination.

Public zero residuals still succeed. Shared residuals are opened and checked, so valid private constraints that reduce to zero remain accepted, while nonzero public or shared residuals return `UnsatisfiedConstraint`.

## Testing

- `git diff --check`
- Targeted source review of public/shared residual handling

No local compile or test run; verification should run in CI.
