### PR TITLE
Ff/shamir witext

### DIFF
--- a/co-circom/circom-mpc-vm/src/lib.rs
+++ b/co-circom/circom-mpc-vm/src/lib.rs
@@ -27,3 +27,4 @@ pub mod types;
 pub use accelerator::ComponentAcceleratorOutput;
 pub use mpc::batched_rep3::BatchedRep3VmType;
 pub use mpc::rep3::Rep3VmType;
+pub use mpc::shamir::ShamirVmType;

--- a/co-circom/circom-mpc-vm/src/mpc.rs
+++ b/co-circom/circom-mpc-vm/src/mpc.rs
@@ -8,6 +8,7 @@ pub(crate) mod batched_plain;
 pub(crate) mod batched_rep3;
 pub(crate) mod plain;
 pub(crate) mod rep3;
+pub(crate) mod shamir;
 
 /// This trait represents the operations used during witness extension by the co-circom MPC-VM
 pub trait VmCircomWitnessExtension<F: PrimeField> {

--- a/co-circom/circom-mpc-vm/src/mpc/shamir.rs
+++ b/co-circom/circom-mpc-vm/src/mpc/shamir.rs
@@ -1,0 +1,485 @@
+use super::{VmCircomWitnessExtension, plain::CircomPlainVmWitnessExtension};
+use crate::{mpc::plain::to_usize, mpc_vm::VMConfig};
+use ark_ff::PrimeField;
+use co_circom_types::ShamirInputType;
+use eyre::bail;
+use mpc_core::{
+    MpcState,
+    protocols::shamir::{
+        ShamirPreprocessing, ShamirPrimeFieldShare, ShamirState, arithmetic,
+        network::ShamirNetworkExt,
+    },
+};
+use mpc_net::Network;
+use num_bigint::BigUint;
+
+type ArithmeticShare<F> = ShamirPrimeFieldShare<F>;
+
+/// This type represents a public, arithmetic share, or binary share type used in the co-cricom MPC-VM
+#[derive(Clone)]
+pub enum ShamirVmType<F: PrimeField> {
+    /// The public variant
+    Public(F),
+    /// The arithmetic share variant
+    Arithmetic(ArithmeticShare<F>),
+}
+
+impl<F: PrimeField> From<F> for ShamirVmType<F> {
+    fn from(value: F) -> Self {
+        Self::Public(value)
+    }
+}
+
+impl<F: PrimeField> From<ArithmeticShare<F>> for ShamirVmType<F> {
+    fn from(value: ArithmeticShare<F>) -> Self {
+        Self::Arithmetic(value)
+    }
+}
+
+impl<F: PrimeField> Default for ShamirVmType<F> {
+    fn default() -> Self {
+        Self::Public(F::zero())
+    }
+}
+
+impl<F: PrimeField> From<ShamirInputType<F>> for ShamirVmType<F> {
+    fn from(value: ShamirInputType<F>) -> Self {
+        match value {
+            ShamirInputType::Public(public) => Self::Public(public),
+            ShamirInputType::Shared(shared) => Self::Arithmetic(shared),
+        }
+    }
+}
+
+pub struct CircomShamirVmWitnessExtension<'a, F: PrimeField, N: Network> {
+    net: &'a N,
+    state: ShamirState<F>,
+    plain: CircomPlainVmWitnessExtension<F>,
+}
+
+impl<'a, F: PrimeField, N: Network> CircomShamirVmWitnessExtension<'a, F, N> {
+    pub fn new(
+        net: &'a N,
+        num_parties: usize,
+        threshold: usize,
+        amount: usize,
+    ) -> eyre::Result<Self> {
+        let shamir_preprocessed = ShamirPreprocessing::new(num_parties, threshold, amount, net)?;
+        let state = ShamirState::from(shamir_preprocessed);
+        Ok(Self {
+            net,
+            state,
+            plain: CircomPlainVmWitnessExtension::default(),
+        })
+    }
+}
+
+impl<F: PrimeField, N: Network> VmCircomWitnessExtension<F>
+    for CircomShamirVmWitnessExtension<'_, F, N>
+{
+    type Public = F;
+
+    type ArithmeticShare = ArithmeticShare<F>;
+
+    type VmType = ShamirVmType<F>;
+
+    fn add(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => Ok(self.plain.add(a, b)?.into()),
+            (ShamirVmType::Public(b), ShamirVmType::Arithmetic(a))
+            | (ShamirVmType::Arithmetic(a), ShamirVmType::Public(b)) => {
+                Ok(arithmetic::add_public(a, b).into())
+            }
+            (ShamirVmType::Arithmetic(a), ShamirVmType::Arithmetic(b)) => {
+                Ok(arithmetic::add(a, b).into())
+            }
+        }
+    }
+
+    fn sub(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => Ok(self.plain.sub(a, b)?.into()),
+            (ShamirVmType::Arithmetic(a), ShamirVmType::Public(b)) => {
+                Ok(arithmetic::add_public(a, -b).into())
+            }
+            (ShamirVmType::Public(a), ShamirVmType::Arithmetic(b)) => {
+                Ok(arithmetic::add_public(arithmetic::neg(b), a).into())
+            }
+            (ShamirVmType::Arithmetic(a), ShamirVmType::Arithmetic(b)) => {
+                Ok(arithmetic::sub(a, b).into())
+            }
+        }
+    }
+
+    fn mul(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => Ok(self.plain.mul(a, b)?.into()),
+            (ShamirVmType::Public(b), ShamirVmType::Arithmetic(a))
+            | (ShamirVmType::Arithmetic(a), ShamirVmType::Public(b)) => {
+                Ok(arithmetic::mul_public(a, b).into())
+            }
+            (ShamirVmType::Arithmetic(a), ShamirVmType::Arithmetic(b)) => {
+                Ok(arithmetic::mul(a, b, self.net, &mut self.state)?.into())
+            }
+        }
+    }
+
+    fn div(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => Ok(self.plain.div(a, b)?.into()),
+            (ShamirVmType::Public(a), ShamirVmType::Arithmetic(b)) => {
+                Ok(arithmetic::div_public_by_shared(a, b, self.net, &mut self.state)?.into())
+            }
+            (ShamirVmType::Arithmetic(a), ShamirVmType::Public(b)) => {
+                Ok(arithmetic::div_shared_by_public(a, b)?.into())
+            }
+            (ShamirVmType::Arithmetic(a), ShamirVmType::Arithmetic(b)) => {
+                Ok(arithmetic::div(a, b, self.net, &mut self.state)?.into())
+            }
+        }
+    }
+
+    fn int_div(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => {
+                Ok(self.plain.int_div(a, b)?.into())
+            }
+            _ => unimplemented!("int_div with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn pow(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => Ok(self.plain.pow(a, b)?.into()),
+            _ => unimplemented!("pow with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn modulo(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => {
+                Ok(self.plain.modulo(a, b)?.into())
+            }
+            _ => unimplemented!("modulo with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn sqrt(&mut self, a: Self::VmType) -> eyre::Result<Self::VmType> {
+        match a {
+            ShamirVmType::Public(a) => Ok(self.plain.sqrt(a)?.into()),
+            ShamirVmType::Arithmetic(_) => {
+                unimplemented!("sqrt on shared value not implemented for Shamir")
+            }
+        }
+    }
+
+    fn neg(&mut self, a: Self::VmType) -> eyre::Result<Self::VmType> {
+        match a {
+            ShamirVmType::Public(a) => Ok(self.plain.neg(a)?.into()),
+            ShamirVmType::Arithmetic(a) => Ok(arithmetic::neg(a).into()),
+        }
+    }
+
+    fn lt(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => Ok(self.plain.lt(a, b)?.into()),
+            _ => unimplemented!("lt with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn le(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => Ok(self.plain.le(a, b)?.into()),
+            _ => unimplemented!("le with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn gt(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => Ok(self.plain.gt(a, b)?.into()),
+            _ => unimplemented!("gt with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn ge(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => Ok(self.plain.ge(a, b)?.into()),
+            _ => unimplemented!("ge with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn eq(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => Ok(self.plain.eq(a, b)?.into()),
+            _ => unimplemented!("eq with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn neq(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => Ok(self.plain.neq(a, b)?.into()),
+            _ => unimplemented!("neq with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn shift_r(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => {
+                Ok(self.plain.shift_r(a, b)?.into())
+            }
+            _ => unimplemented!("shift_r with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn shift_l(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => {
+                Ok(self.plain.shift_l(a, b)?.into())
+            }
+            _ => unimplemented!("shift_l with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn bool_not(&mut self, a: Self::VmType) -> eyre::Result<Self::VmType> {
+        match a {
+            ShamirVmType::Public(a) => Ok(self.plain.bool_not(a)?.into()),
+            ShamirVmType::Arithmetic(a) => {
+                let neg_a = arithmetic::neg(a);
+                let not_a = arithmetic::add_public(neg_a, F::one());
+                Ok(not_a.into())
+            }
+        }
+    }
+
+    fn bool_and(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => {
+                Ok(self.plain.bool_and(a, b)?.into())
+            }
+            (a, b) => self.mul(a, b),
+        }
+    }
+
+    fn bool_or(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => {
+                Ok(self.plain.bool_or(a, b)?.into())
+            }
+            (ShamirVmType::Public(b), ShamirVmType::Arithmetic(a))
+            | (ShamirVmType::Arithmetic(a), ShamirVmType::Public(b)) => {
+                let mul = arithmetic::mul_public(a, b);
+                let add = arithmetic::add_public(a, b);
+                let sub = arithmetic::sub(add, mul);
+                Ok(sub.into())
+            }
+            (ShamirVmType::Arithmetic(a), ShamirVmType::Arithmetic(b)) => {
+                let mul = arithmetic::mul(a, b, self.net, &mut self.state)?;
+                let add = arithmetic::add(a, b);
+                let sub = arithmetic::sub(add, mul);
+                Ok(sub.into())
+            }
+        }
+    }
+
+    fn cmux(
+        &mut self,
+        cond: Self::VmType,
+        truthy: Self::VmType,
+        falsy: Self::VmType,
+    ) -> eyre::Result<Self::VmType> {
+        match (cond, truthy, falsy) {
+            (ShamirVmType::Public(cond), truthy, falsy) => {
+                assert!(cond.is_one() || cond.is_zero());
+                if cond.is_one() { Ok(truthy) } else { Ok(falsy) }
+            }
+            (ShamirVmType::Arithmetic(cond), truthy, falsy) => {
+                let b_min_a = self.sub(truthy, falsy.clone())?;
+                let d = self.mul(cond.into(), b_min_a)?;
+                self.add(falsy, d)
+            }
+        }
+    }
+
+    fn bit_xor(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => {
+                Ok(self.plain.bit_xor(a, b)?.into())
+            }
+            _ => unimplemented!("bit_xor with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn bit_or(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => {
+                Ok(self.plain.bit_or(a, b)?.into())
+            }
+            _ => unimplemented!("bit_or with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn bit_and(&mut self, a: Self::VmType, b: Self::VmType) -> eyre::Result<Self::VmType> {
+        match (a, b) {
+            (ShamirVmType::Public(a), ShamirVmType::Public(b)) => {
+                Ok(self.plain.bit_and(a, b)?.into())
+            }
+            _ => unimplemented!("bit_and with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn is_zero(&mut self, a: Self::VmType, allow_secret_inputs: bool) -> eyre::Result<bool> {
+        if !allow_secret_inputs && self.is_shared(&a)? {
+            bail!("allow_secret_inputs is false and input is shared");
+        }
+        match a {
+            ShamirVmType::Public(a) => Ok(self.plain.is_zero(a, allow_secret_inputs)?),
+            ShamirVmType::Arithmetic(_) => {
+                unimplemented!("is_zero on shared value not implemented for Shamir")
+            }
+        }
+    }
+
+    fn is_shared(&mut self, a: &Self::VmType) -> eyre::Result<bool> {
+        match a {
+            ShamirVmType::Public(_) => Ok(false),
+            ShamirVmType::Arithmetic(_) => Ok(true),
+        }
+    }
+
+    fn to_index(&mut self, a: Self::VmType) -> eyre::Result<usize> {
+        if let ShamirVmType::Public(a) = a {
+            Ok(to_usize!(a))
+        } else {
+            bail!("ToIndex called on shared value!")
+        }
+    }
+
+    fn open(&mut self, a: Self::VmType) -> eyre::Result<Self::Public> {
+        match a {
+            ShamirVmType::Public(a) => Ok(a),
+            ShamirVmType::Arithmetic(a) => arithmetic::open(a, self.net, &mut self.state),
+        }
+    }
+
+    fn to_share(&mut self, a: Self::VmType) -> eyre::Result<Self::ArithmeticShare> {
+        match a {
+            ShamirVmType::Public(a) => Ok(arithmetic::promote_to_trivial_share(a)),
+            ShamirVmType::Arithmetic(a) => Ok(a),
+        }
+    }
+
+    fn public_one(&self) -> Self::VmType {
+        F::one().into()
+    }
+
+    fn public_zero(&self) -> Self::VmType {
+        F::zero().into()
+    }
+
+    fn compare_vm_config(&mut self, config: &VMConfig) -> eyre::Result<()> {
+        let ser = bincode::serialize(&config)?;
+        let n = self.state.num_parties;
+        let id = self.state.id();
+        let next = (id + 1) % n;
+        let prev = (id + n - 1) % n;
+        self.net.send_to(next, ser)?;
+        let recv: Vec<u8> = self.net.recv_from(prev)?;
+        let deser: VMConfig = bincode::deserialize(&recv)?;
+        if config != &deser {
+            eyre::bail!("VM Config does not match: {:?} != {:?}", config, deser);
+        }
+        Ok(())
+    }
+
+    fn num2bits(&mut self, a: Self::VmType, bits: usize) -> eyre::Result<Vec<Self::VmType>> {
+        match a {
+            ShamirVmType::Public(a) => Ok(self
+                .plain
+                .num2bits(a, bits)?
+                .into_iter()
+                .map(ShamirVmType::Public)
+                .collect()),
+            ShamirVmType::Arithmetic(_) => {
+                unimplemented!("num2bits on shared value not implemented for Shamir")
+            }
+        }
+    }
+
+    fn addbits(
+        &mut self,
+        a: Vec<Self::VmType>,
+        b: Vec<Self::VmType>,
+    ) -> eyre::Result<(Vec<Self::VmType>, Self::VmType)> {
+        let a_pub: Option<Vec<F>> = a
+            .iter()
+            .map(|x| {
+                if let ShamirVmType::Public(v) = x {
+                    Some(*v)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let b_pub: Option<Vec<F>> = b
+            .iter()
+            .map(|x| {
+                if let ShamirVmType::Public(v) = x {
+                    Some(*v)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        match (a_pub, b_pub) {
+            (Some(a), Some(b)) => {
+                let (bits, carry) = self.plain.addbits(a, b)?;
+                Ok((
+                    bits.into_iter().map(ShamirVmType::Public).collect(),
+                    carry.into(),
+                ))
+            }
+            _ => unimplemented!("addbits with shared values not implemented for Shamir"),
+        }
+    }
+
+    fn log(&mut self, a: Self::VmType, allow_leaky_logs: bool) -> eyre::Result<String> {
+        match a {
+            ShamirVmType::Public(public) => self.plain.log(public, allow_leaky_logs),
+            ShamirVmType::Arithmetic(share) => {
+                if allow_leaky_logs {
+                    let field = arithmetic::open(share, self.net, &mut self.state)?;
+                    Ok(field.to_string())
+                } else {
+                    Ok("secret".to_string())
+                }
+            }
+        }
+    }
+
+    fn poseidon2_accelerator<const T: usize>(
+        &mut self,
+        _inputs: Vec<Self::VmType>,
+    ) -> eyre::Result<(Vec<Self::VmType>, Vec<Self::VmType>)> {
+        unimplemented!("Not implemented for Shamir")
+    }
+}
+
+impl<F: PrimeField> std::fmt::Debug for ShamirVmType<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Public(field) => f.debug_tuple("Public").field(field).finish(),
+            Self::Arithmetic(share) => f.debug_tuple("Arithmetic").field(share).finish(),
+        }
+    }
+}
+
+impl<F: PrimeField> std::fmt::Display for ShamirVmType<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Public(field) => f.write_str(&format!("Public ({field})")),
+            Self::Arithmetic(arithmetic) => {
+                f.write_str(&format!("Arithmetic ({})", arithmetic.inner()))
+            }
+        }
+    }
+}

--- a/co-circom/circom-mpc-vm/src/mpc_vm.rs
+++ b/co-circom/circom-mpc-vm/src/mpc_vm.rs
@@ -3,6 +3,7 @@ use crate::mpc::batched_plain::BatchedCircomPlainVmWitnessExtension;
 use crate::mpc::batched_rep3::{BatchedCircomRep3VmWitnessExtension, BatchedRep3VmType};
 use crate::mpc::plain::CircomPlainVmWitnessExtension;
 use crate::mpc::rep3::{CircomRep3VmWitnessExtension, Rep3VmType};
+use crate::mpc::shamir::{CircomShamirVmWitnessExtension, ShamirVmType};
 use crate::types::{CoCircomCompilerParsed, FunDecl, InputList, OutputMapping, TemplateDecl};
 
 use super::accelerator::MpcAccelerator;
@@ -82,6 +83,12 @@ pub type BatchedRep3WitnessExtension<'a, F, N> =
 /// This is the only supported protocol at the moment.
 pub type Rep3WitnessExtension<'a, F, N> =
     WitnessExtension<F, CircomRep3VmWitnessExtension<'a, F, N>>;
+
+/// Shorthand type for the MPC-VM instantiated with a `Shamir` protocol.
+///
+/// This is the only supported protocol at the moment.  
+pub type ShamirWitnessExtension<'a, F, N> =
+    WitnessExtension<F, CircomShamirVmWitnessExtension<'a, F, N>>;
 
 type ConsumedFunCtx<T> = (usize, usize, Vec<T>, Arc<CodeBlock>, Vec<(T, Vec<T>)>);
 
@@ -1263,6 +1270,46 @@ impl<'a, F: PrimeField, N: Network> BatchedRep3WitnessExtension<'a, F, N> {
             ctx: WitnessExtensionCtx::new(
                 signals,
                 batched_constant_table,
+                parser.fun_decls.clone(),
+                parser.templ_decls.clone(),
+                parser.string_table.clone(),
+                MpcAccelerator::from_config(MpcAcceleratorConfig::from_env()),
+            ),
+            main_inputs: parser.main_inputs,
+            main_outputs: parser.main_outputs,
+            main_input_list: parser.main_input_list.clone(),
+            output_mapping: parser.output_mapping.clone(),
+            config,
+        })
+    }
+}
+
+impl<'a, F: PrimeField, N: Network> ShamirWitnessExtension<'a, F, N> {
+    /// Create a new [ShamirWitnessExtension] VM
+    pub fn new(
+        net: &'a N,
+        num_parties: usize,
+        threshold: usize,
+        amount: usize,
+        parser: &CoCircomCompilerParsed<F>,
+        config: VMConfig,
+    ) -> eyre::Result<Self> {
+        let driver = CircomShamirVmWitnessExtension::new(net, num_parties, threshold, amount)?;
+        let mut signals = vec![ShamirVmType::default(); parser.amount_signals];
+        signals[0] = ShamirVmType::Public(F::one());
+        let constant_table = parser
+            .constant_table
+            .clone()
+            .into_iter()
+            .map(ShamirVmType::Public)
+            .collect_vec();
+        Ok(Self {
+            driver,
+            signal_to_witness: parser.signal_to_witness.clone(),
+            main: parser.main.clone(),
+            ctx: WitnessExtensionCtx::new(
+                signals,
+                constant_table,
                 parser.fun_decls.clone(),
                 parser.templ_decls.clone(),
                 parser.string_table.clone(),

--- a/co-circom/co-circom-types/src/lib.rs
+++ b/co-circom/co-circom-types/src/lib.rs
@@ -20,6 +20,9 @@ use std::error::Error;
 /// A REP3 shared input type
 pub type Rep3SharedInput<F> = BTreeMap<String, Rep3InputType<F>>;
 
+/// A Shamir shared input type
+pub type ShamirSharedInput<F> = BTreeMap<String, ShamirInputType<F>>;
+
 /// A batched REP3 shared input type. Should be used with the batched witness extension
 pub type BatchedRep3SharedInput<F> = BTreeMap<String, Vec<Rep3InputType<F>>>;
 
@@ -84,6 +87,62 @@ impl<F: PrimeField> From<F> for Rep3InputType<F> {
 
 impl<F: PrimeField> From<Rep3PrimeFieldShare<F>> for Rep3InputType<F> {
     fn from(value: Rep3PrimeFieldShare<F>) -> Self {
+        Self::Shared(value)
+    }
+}
+
+/// A Shamir input type
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub enum ShamirInputType<F: PrimeField> {
+    /// The public variant
+    Public(
+        #[serde(
+            serialize_with = "mpc_core::serde_compat::ark_se",
+            deserialize_with = "mpc_core::serde_compat::ark_de"
+        )]
+        F,
+    ),
+    /// The shared variant
+    Shared(
+        #[serde(
+            serialize_with = "mpc_core::serde_compat::ark_se",
+            deserialize_with = "mpc_core::serde_compat::ark_de"
+        )]
+        ShamirPrimeFieldShare<F>,
+    ),
+}
+
+impl<F: PrimeField> ShamirInputType<F> {
+    /// Returns true if the input is public
+    pub fn is_public(&self) -> bool {
+        matches!(self, ShamirInputType::Public(_))
+    }
+
+    /// Returns the public input or None
+    pub fn as_public(&self) -> Option<F> {
+        match self {
+            ShamirInputType::Public(value) => Some(*value),
+            ShamirInputType::Shared(_) => None,
+        }
+    }
+
+    /// Returns the shared input or None
+    pub fn as_shared(&self) -> Option<ShamirPrimeFieldShare<F>> {
+        match self {
+            ShamirInputType::Public(_) => None,
+            ShamirInputType::Shared(share) => Some(*share),
+        }
+    }
+}
+
+impl<F: PrimeField> From<F> for ShamirInputType<F> {
+    fn from(value: F) -> Self {
+        Self::Public(value)
+    }
+}
+
+impl<F: PrimeField> From<ShamirPrimeFieldShare<F>> for ShamirInputType<F> {
+    fn from(value: ShamirPrimeFieldShare<F>) -> Self {
         Self::Shared(value)
     }
 }
@@ -363,6 +422,49 @@ pub fn split_input<F: PrimeField>(
                 shares[0].insert(k.clone(), Rep3InputType::Shared(share0));
                 shares[1].insert(k.clone(), Rep3InputType::Shared(share1));
                 shares[2].insert(k.clone(), Rep3InputType::Shared(share2));
+            }
+        }
+    }
+    Ok(shares)
+}
+
+/// Splits a JSON input into Shamir secret shares.
+pub fn split_input_shamir<F: PrimeField>(
+    input: Input,
+    public_inputs: &[String],
+    threshold: usize,
+    num_parties: usize,
+) -> eyre::Result<Vec<ShamirSharedInput<F>>> {
+    let mut shares: Vec<ShamirSharedInput<F>> = (0..num_parties)
+        .map(|_| ShamirSharedInput::<F>::default())
+        .collect();
+
+    let mut rng = rand::thread_rng();
+    for (name, val) in input {
+        let parsed_vals = if val.is_array() {
+            parse_array::<F>(&val)?
+                .into_iter()
+                .enumerate()
+                .filter_map(|(idx, field)| field.map(|field| (format!("{name}[{idx}]"), field)))
+                .collect::<BTreeMap<_, _>>()
+        } else if val.is_boolean() {
+            BTreeMap::from([(name.clone(), parse_boolean::<F>(&val)?)])
+        } else {
+            BTreeMap::from([(name.clone(), parse_field::<F>(&val)?)])
+        };
+
+        if public_inputs.contains(&name) {
+            for (k, v) in parsed_vals.into_iter() {
+                for share in shares.iter_mut() {
+                    share.insert(k.clone(), ShamirInputType::Public(v));
+                }
+            }
+        } else {
+            for (k, v) in parsed_vals.into_iter() {
+                let party_shares = shamir::share_field_element(v, threshold, num_parties, &mut rng);
+                for (share_map, party_share) in shares.iter_mut().zip(party_shares) {
+                    share_map.insert(k.clone(), ShamirInputType::Shared(party_share));
+                }
             }
         }
     }

--- a/co-circom/co-circom/src/bin/co-circom.rs
+++ b/co-circom/co-circom/src/bin/co-circom.rs
@@ -182,6 +182,12 @@ pub struct SplitInputCli {
     #[arg(long)]
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub out_dir: Option<PathBuf>,
+    /// The threshold of tolerated colluding parties (Shamir only)
+    #[arg(short, long, default_value_t = 1)]
+    pub threshold: usize,
+    /// The number of parties (Shamir only)
+    #[arg(short, long, default_value_t = 3)]
+    pub num_parties: usize,
 }
 
 /// Config for `split_input`
@@ -200,6 +206,12 @@ pub struct SplitInputConfig {
     /// MPC compiler config
     #[serde(default)]
     pub compiler: CompilerConfig,
+    /// The threshold of tolerated colluding parties (Shamir only)
+    #[serde(default = "default_threshold")]
+    pub threshold: usize,
+    /// The number of parties (Shamir only)
+    #[serde(default = "default_num_parties")]
+    pub num_parties: usize,
 }
 
 /// Cli arguments for `merge_input_shares`
@@ -278,6 +290,12 @@ pub struct GenerateWitnessCli {
     /// The simplification level passed to the circom compiler (0-2)
     #[arg(short = 'O', default_value_t = 1, value_parser = clap::value_parser!(u8).range(0..3))]
     pub simplification_level: u8,
+    /// The threshold of tolerated colluding parties (Shamir only)
+    #[arg(short, long, default_value_t = 1)]
+    pub threshold: usize,
+    /// The number of parties (Shamir only)
+    #[arg(short, long, default_value_t = 3)]
+    pub num_parties: usize,
 }
 
 /// Config for `generate_witness`
@@ -301,6 +319,20 @@ pub struct GenerateWitnessConfig {
     pub vm: VMConfig,
     /// Network config
     pub network: NetworkConfigFile,
+    /// The threshold of tolerated colluding parties (Shamir only)
+    #[serde(default = "default_threshold")]
+    pub threshold: usize,
+    /// The number of parties (Shamir only)
+    #[serde(default = "default_num_parties")]
+    pub num_parties: usize,
+}
+
+fn default_threshold() -> usize {
+    1
+}
+
+fn default_num_parties() -> usize {
+    3
 }
 
 /// Cli arguments for `translate_witness`
@@ -715,9 +747,6 @@ fn run_split_input<P: Pairing + CircomArkworksPairingBridge>(
     let protocol = config.protocol;
     let out_dir = config.out_dir;
 
-    if protocol != MPCProtocol::REP3 {
-        eyre::bail!("Only REP3 protocol is supported for splitting inputs");
-    }
     let circuit_path = PathBuf::from(&circuit);
 
     //get the public inputs if any from parser
@@ -730,22 +759,43 @@ fn run_split_input<P: Pairing + CircomArkworksPairingBridge>(
 
     tracing::info!("Starting split input...");
     let start = Instant::now();
-    let shares = co_circom::split_input::<P::ScalarField>(input, &public_inputs)?;
-    let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
-    tracing::info!("Split input took {duration_ms} ms");
 
-    // write out the shares to the output directory
     let base_name = input_path
         .file_name()
         .context("we have a file name")?
         .to_str()
         .context("input file name is not valid UTF-8")?;
-    for (i, share) in shares.iter().enumerate() {
-        let path = out_dir.join(format!("{base_name}.{i}.shared"));
-        let out_file = BufWriter::new(File::create(&path).context("while creating output file")?);
-        serde_json::to_writer(out_file, share).context("while serializing witness share")?;
-        tracing::info!("Wrote input share {} to file {}", i, path.display());
+
+    match protocol {
+        MPCProtocol::REP3 => {
+            let shares = co_circom::split_input::<P::ScalarField>(input, &public_inputs)?;
+            let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
+            tracing::info!("Split input took {duration_ms} ms");
+            for (i, share) in shares.iter().enumerate() {
+                let path = out_dir.join(format!("{base_name}.{i}.shared"));
+                let out_file =
+                    BufWriter::new(File::create(&path).context("while creating output file")?);
+                serde_json::to_writer(out_file, share).context("while serializing input share")?;
+                tracing::info!("Wrote input share {} to file {}", i, path.display());
+            }
+        }
+        MPCProtocol::SHAMIR => {
+            let t = config.threshold;
+            let n = config.num_parties;
+            let shares =
+                co_circom::split_input_shamir::<P::ScalarField>(input, &public_inputs, t, n)?;
+            let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
+            tracing::info!("Split input took {duration_ms} ms");
+            for (i, share) in shares.iter().enumerate() {
+                let path = out_dir.join(format!("{base_name}.{i}.shared"));
+                let out_file =
+                    BufWriter::new(File::create(&path).context("while creating output file")?);
+                serde_json::to_writer(out_file, share).context("while serializing input share")?;
+                tracing::info!("Wrote input share {} to file {}", i, path.display());
+            }
+        }
     }
+
     tracing::info!("Split input into shares successfully");
     Ok(ExitCode::SUCCESS)
 }
@@ -805,40 +855,68 @@ fn run_generate_witness<P: Pairing + CircomArkworksPairingBridge>(
     let protocol = config.protocol;
     let out = config.out;
     let network_config = NetworkConfig::try_from(config.network)?;
+    let n = network_config.parties.len();
+    let t = config.threshold;
 
-    if protocol != MPCProtocol::REP3 {
-        eyre::bail!("Only REP3 protocol is supported for witness generation");
+    if protocol == MPCProtocol::SHAMIR && n != config.num_parties {
+        eyre::bail!(
+            "Number of parties in network config ({n}) does not match configured num_parties ({})",
+            config.num_parties
+        );
     }
 
     // connect to network
     let [net0, net1] =
         TcpNetwork::networks::<2>(network_config).context("while connecting to network")?;
 
-    // parse input shares
-    let input_share_file =
-        BufReader::new(File::open(&input).context("while opening input share file")?);
-    let input_share: Rep3SharedInput<P::ScalarField> =
-        serde_json::from_reader(input_share_file).context("trying to parse input share file")?;
-
     // parse circuit file & put through our compiler
     let circuit = CoCircomCompiler::<P>::parse(circuit, config.compiler)
         .context("while parsing circuit file")?;
 
-    // Extend the witness
-    tracing::info!("Starting witness generation...");
-    let start = Instant::now();
-    let result_witness_share =
-        co_circom::generate_witness_rep3(&circuit, input_share, config.vm, &net0, &net1)?;
-    let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
-    tracing::info!("Generate witness took {duration_ms} ms");
+    match protocol {
+        MPCProtocol::REP3 => {
+            // parse input shares
+            let input_share_file =
+                BufReader::new(File::open(&input).context("while opening input share file")?);
+            let input_share: Rep3SharedInput<P::ScalarField> =
+                serde_json::from_reader(input_share_file)
+                    .context("trying to parse input share file")?;
 
-    // write result to output file
-    let out_file = BufWriter::new(std::fs::File::create(&out)?);
-    bincode::serialize_into(
-        out_file,
-        &CompressedRep3SharedWitness::from(result_witness_share),
-    )?;
-    tracing::info!("Witness successfully written to {}", out.display());
+            tracing::info!("Starting witness generation...");
+            let start = Instant::now();
+            let result_witness_share =
+                co_circom::generate_witness_rep3(&circuit, input_share, config.vm, &net0, &net1)?;
+            let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
+            tracing::info!("Generate witness took {duration_ms} ms");
+
+            let out_file = BufWriter::new(std::fs::File::create(&out)?);
+            bincode::serialize_into(
+                out_file,
+                &CompressedRep3SharedWitness::from(result_witness_share),
+            )?;
+            tracing::info!("Witness successfully written to {}", out.display());
+        }
+        MPCProtocol::SHAMIR => {
+            // parse input shares
+            let input_share_file =
+                BufReader::new(File::open(&input).context("while opening input share file")?);
+            let input_share: co_circom::ShamirSharedInput<P::ScalarField> =
+                serde_json::from_reader(input_share_file)
+                    .context("trying to parse input share file")?;
+
+            tracing::info!("Starting witness generation...");
+            let start = Instant::now();
+            // TODO we are not creating any randomness here
+            let result_witness_share =
+                co_circom::generate_witness_shamir(&circuit, input_share, config.vm, &net0, n, t)?;
+            let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
+            tracing::info!("Generate witness took {duration_ms} ms");
+
+            let out_file = BufWriter::new(std::fs::File::create(&out)?);
+            bincode::serialize_into(out_file, &result_witness_share)?;
+            tracing::info!("Witness successfully written to {}", out.display());
+        }
+    }
     Ok(ExitCode::SUCCESS)
 }
 

--- a/co-circom/co-circom/src/lib.rs
+++ b/co-circom/co-circom/src/lib.rs
@@ -3,8 +3,11 @@
 #![warn(missing_docs)]
 
 use ark_ff::PrimeField;
-use circom_mpc_vm::{Rep3VmType, mpc_vm::Rep3WitnessExtension};
-use co_circom_types::{CompressedRep3SharedWitness, Rep3InputType, SharedWitness};
+use circom_mpc_vm::{
+    Rep3VmType, ShamirVmType,
+    mpc_vm::{Rep3WitnessExtension, ShamirWitnessExtension},
+};
+use co_circom_types::{CompressedRep3SharedWitness, Rep3InputType, ShamirInputType, SharedWitness};
 use color_eyre::eyre::{self, Context};
 use mpc_core::protocols::{
     rep3::{self, Rep3ShareVecType},
@@ -27,7 +30,7 @@ pub use circom_types::{
     traits::CircomArkworksPairingBridge,
 };
 pub use co_circom_types::{
-    Compression, Input, Rep3SharedInput, Rep3SharedWitness, ShamirSharedWitness,
+    Compression, Input, Rep3SharedInput, Rep3SharedWitness, ShamirSharedInput, ShamirSharedWitness,
 };
 pub use co_groth16::{CircomReduction, ConstraintMatrices, ProvingKey};
 pub use co_groth16::{Groth16, Rep3CoGroth16, ShamirCoGroth16};
@@ -37,6 +40,7 @@ pub use serde_json::Value;
 
 pub use co_circom_types::merge_input_shares;
 pub use co_circom_types::split_input;
+pub use co_circom_types::split_input_shamir;
 
 /// Split the witness into REP3 shares
 pub fn split_witness_rep3<F: PrimeField>(
@@ -133,6 +137,37 @@ pub fn generate_witness_rep3<F: PrimeField, N: Network>(
 
     // execute witness generation in MPC
     let witness_share = rep3_vm
+        .run(input, num_public_inputs)
+        .context("while running witness generation")?;
+
+    Ok(witness_share.into_shared_witness())
+}
+
+/// Generate a Shamir shared witness
+pub fn generate_witness_shamir<F: PrimeField, N: Network>(
+    circuit: &CoCircomCompilerParsed<F>,
+    input: ShamirSharedInput<F>,
+    config: VMConfig,
+    net: &N,
+    num_parties: usize,
+    threshold: usize,
+) -> eyre::Result<ShamirSharedWitness<F>> {
+    // init MPC protocol
+    // TODO we are not creating any randomness here
+    let shamir_vm = ShamirWitnessExtension::new(net, num_parties, threshold, 0, circuit, config)
+        .context("while constructing MPC VM")?;
+
+    let num_public_inputs = input
+        .values()
+        .filter(|i| matches!(i, ShamirInputType::Public(_)))
+        .count();
+    let input = input
+        .into_iter()
+        .map(|(name, vale)| (name, ShamirVmType::from(vale)))
+        .collect();
+
+    // execute witness generation in MPC
+    let witness_share = shamir_vm
         .run(input, num_public_inputs)
         .context("while running witness generation")?;
 

--- a/co-noir/co-acvm/src/solver.rs
+++ b/co-noir/co-acvm/src/solver.rs
@@ -234,6 +234,22 @@ impl<'a, N: Network> ShamirCoSolver<'a, ark_bn254::Fr, N> {
 
         Self::new_bn254_with_witness(ShamirAcvmSolver::new(net, state), compiled_program, witness)
     }
+
+    pub fn new_with_witness_and_amount(
+        net: &'a N,
+        num_parties: usize,
+        threshold: usize,
+        amount: usize,
+        compiled_program: ProgramArtifact,
+        witness: WitnessMap<
+            <ShamirAcvmSolver<ark_bn254::Fr, N> as NoirWitnessExtensionProtocol::<ark_bn254::Fr>>::AcvmType,
+        >,
+    ) -> eyre::Result<Self> {
+        let preprocessing = ShamirPreprocessing::new(num_parties, threshold, amount, net)?;
+        let state = ShamirState::from(preprocessing);
+
+        Self::new_bn254_with_witness(ShamirAcvmSolver::new(net, state), compiled_program, witness)
+    }
 }
 
 impl<F: PrimeField> PlainCoSolver<F> {

--- a/co-noir/co-noir-types/src/lib.rs
+++ b/co-noir/co-noir-types/src/lib.rs
@@ -13,6 +13,9 @@ pub type Rep3SharedInput<F> = BTreeMap<String, Rep3Type<F>>;
 /// A REP3 shared witness type
 pub type Rep3SharedWitness<F> = Vec<Rep3Type<F>>;
 
+/// A shamir shared input type
+pub type ShamirSharedInput<F> = BTreeMap<String, ShamirType<F>>;
+
 /// A shamir shared witness type
 pub type ShamirSharedWitness<F> = Vec<ShamirType<F>>;
 
@@ -108,6 +111,35 @@ pub fn split_input_rep3<F: PrimeField>(
                 let shares = rep3::share_field_element(v, &mut rng);
                 for (w, share) in witnesses.iter_mut().zip(shares) {
                     w.insert(witness.clone(), Rep3Type::Shared(share));
+                }
+            }
+        }
+    }
+
+    witnesses
+}
+
+/// Split input into Shamir shares
+pub fn split_input_shamir<F: PrimeField>(
+    initial_witness: BTreeMap<String, PubPrivate<F>>,
+    degree: usize,
+    num_parties: usize,
+) -> Vec<ShamirSharedInput<F>> {
+    let mut rng = rand::thread_rng();
+    let mut witnesses = (0..num_parties)
+        .map(|_| BTreeMap::default())
+        .collect::<Vec<_>>();
+    for (witness, v) in initial_witness.into_iter() {
+        match v {
+            PubPrivate::Public(v) => {
+                for w in witnesses.iter_mut() {
+                    w.insert(witness.to_owned(), ShamirType::Public(v));
+                }
+            }
+            PubPrivate::Private(v) => {
+                let shares = shamir::share_field_element(v, degree, num_parties, &mut rng);
+                for (w, share) in witnesses.iter_mut().zip(shares) {
+                    w.insert(witness.clone(), ShamirType::Shared(share));
                 }
             }
         }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -7,9 +7,30 @@ pub mod test_utils {
     use co_circom_types::{Input, SharedWitness};
     use eyre::{Context as _, ContextCompat as _};
     use itertools::izip;
-    use mpc_core::protocols::rep3;
+    use mpc_core::protocols::{
+        rep3,
+        shamir::{self, ShamirPrimeFieldShare},
+    };
     use num_bigint::BigUint;
     use num_traits::Num as _;
+
+    pub fn combine_field_elements_for_vm_shamir(
+        a: SharedWitness<ark_bn254::Fr, ShamirPrimeFieldShare<ark_bn254::Fr>>,
+        b: SharedWitness<ark_bn254::Fr, ShamirPrimeFieldShare<ark_bn254::Fr>>,
+        c: SharedWitness<ark_bn254::Fr, ShamirPrimeFieldShare<ark_bn254::Fr>>,
+    ) -> Vec<ark_bn254::Fr> {
+        let mut res = Vec::with_capacity(a.public_inputs.len() + a.witness.len());
+        for (pa, pb, pc) in izip!(a.public_inputs, b.public_inputs, c.public_inputs) {
+            assert_eq!(pa, pb);
+            assert_eq!(pb, pc);
+            res.push(pa);
+        }
+        res.extend(
+            shamir::combine_field_elements(&[a.witness, b.witness, c.witness], &[1, 2, 3], 1)
+                .unwrap(),
+        );
+        res
+    }
 
     pub fn combine_field_elements_for_vm(
         a: SharedWitness<ark_bn254::Fr, rep3::arithmetic::FieldShare<ark_bn254::Fr>>,

--- a/tests/tests/circom/witness_extension_tests/mod.rs
+++ b/tests/tests/circom/witness_extension_tests/mod.rs
@@ -1,2 +1,3 @@
 mod plain_vm;
 mod rep3;
+mod shamir;

--- a/tests/tests/circom/witness_extension_tests/shamir.rs
+++ b/tests/tests/circom/witness_extension_tests/shamir.rs
@@ -1,0 +1,245 @@
+use ark_bn254::Bn254;
+use circom_mpc_compiler::CoCircomCompiler;
+use circom_types::Witness;
+use itertools::izip;
+use mpc_core::protocols::shamir;
+use mpc_net::local::LocalNetwork;
+use rand::thread_rng;
+use std::fs;
+use std::fs::File;
+use std::str::FromStr;
+
+use circom_mpc_compiler::CompilerConfig;
+use circom_mpc_vm::{
+    mpc_vm::{ShamirWitnessExtension, VMConfig},
+    ShamirVmType,
+};
+
+pub struct TestInputs {
+    inputs: Vec<Vec<ark_bn254::Fr>>,
+    witnesses: Vec<Witness<ark_ff::Fp<ark_ff::MontBackend<ark_bn254::FrConfig, 4>, 4>>>,
+}
+
+fn read_field_element(s: &str) -> ark_bn254::Fr {
+    if let Some(striped) = s.strip_prefix('-') {
+        -ark_bn254::Fr::from_str(striped).unwrap()
+    } else {
+        ark_bn254::Fr::from_str(s).unwrap()
+    }
+}
+
+pub fn from_test_name(fn_name: &str) -> TestInputs {
+    let mut witnesses: Vec<Witness<ark_ff::Fp<ark_ff::MontBackend<ark_bn254::FrConfig, 4>, 4>>> =
+        Vec::new();
+    let mut inputs: Vec<Vec<ark_bn254::Fr>> = Vec::new();
+    let mut i = 0;
+    loop {
+        if fs::metadata(format!(
+            "../test_vectors/WitnessExtension/kats/{fn_name}/witness{i}.wtns"
+        ))
+        .is_err()
+        {
+            break;
+        }
+        let witness = File::open(format!(
+            "../test_vectors/WitnessExtension/kats/{fn_name}/witness{i}.wtns"
+        ))
+        .unwrap();
+        let should_witness = Witness::<ark_bn254::Fr>::from_reader(witness).unwrap();
+        witnesses.push(should_witness);
+        let input_file = File::open(format!(
+            "../test_vectors/WitnessExtension/kats/{fn_name}/input{i}.json"
+        ))
+        .unwrap();
+        let json_str: serde_json::Value = serde_json::from_reader(input_file).unwrap();
+        let input = json_str
+            .get("in")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| read_field_element(s.as_str().unwrap()))
+            .collect::<Vec<_>>();
+        inputs.push(input);
+        i += 1
+    }
+    if inputs.is_empty() {
+        panic!("No test cases found for {fn_name}");
+    }
+    TestInputs { inputs, witnesses }
+}
+
+macro_rules! run_test {
+    ($file: expr, $input: expr, $config: expr) => {{
+        use tests::test_utils;
+        let mut rng = thread_rng();
+        // degree=1, num_parties=3
+        let inputs = shamir::share_field_elements($input, 1, 3, &mut rng);
+        let net = LocalNetwork::new_3_parties();
+        let mut threads = vec![];
+
+        let configs = [$config.clone(), $config.clone(), $config];
+
+        for (net_, input, config) in izip!(net, inputs, configs) {
+            threads.push(std::thread::spawn(move || {
+                let mut compiler_config = config;
+                compiler_config.simplification =
+                    circom_mpc_compiler::SimplificationLevel::O2(usize::MAX);
+                compiler_config
+                    .link_library
+                    .push("../test_vectors/WitnessExtension/tests/libs/".into());
+                let circuit =
+                    CoCircomCompiler::<Bn254>::parse($file.to_owned(), compiler_config).unwrap();
+                // TODO we are not creating any randomness here
+                let witness_extension =
+                    ShamirWitnessExtension::new(&net_, 3, 1, 0, &circuit, VMConfig::default())
+                        .unwrap();
+                witness_extension
+                    .run_with_flat(
+                        input
+                            .into_iter()
+                            .map(|x| ShamirVmType::Arithmetic(x))
+                            .collect(),
+                        0,
+                    )
+                    .unwrap()
+                    .into_shared_witness()
+            }));
+        }
+        let result3 = threads.pop().unwrap().join().unwrap();
+        let result2 = threads.pop().unwrap().join().unwrap();
+        let result1 = threads.pop().unwrap().join().unwrap();
+        test_utils::combine_field_elements_for_vm_shamir(result1, result2, result3)
+    }};
+}
+
+macro_rules! witness_extension_test_shamir {
+    ($name: ident) => {
+        mod $name {
+            use super::*;
+            fn inner(config: CompilerConfig) {
+                let inp: TestInputs = from_test_name(stringify!($name));
+                for i in 0..inp.inputs.len() {
+                    let is_witness = run_test!(
+                        format!(
+                            "../test_vectors/WitnessExtension/tests/{}.circom",
+                            stringify!($name),
+                        ),
+                        &inp.inputs[i],
+                        config.clone()
+                    );
+                    assert_eq!(is_witness, inp.witnesses[i].values);
+                }
+            }
+
+            #[test]
+            fn debug() {
+                inner(CompilerConfig::default());
+            }
+
+            #[test]
+            fn release() {
+                inner(CompilerConfig::release());
+            }
+        }
+    };
+}
+
+// Ignored due to unimplemented functionality in the Shamir witness extension.
+macro_rules! witness_extension_test_shamir_ignored {
+    ($name: ident) => {
+        mod $name {
+            use super::*;
+            fn inner(config: CompilerConfig) {
+                let inp: TestInputs = from_test_name(stringify!($name));
+                for i in 0..inp.inputs.len() {
+                    let is_witness = run_test!(
+                        format!(
+                            "../test_vectors/WitnessExtension/tests/{}.circom",
+                            stringify!($name),
+                        ),
+                        &inp.inputs[i],
+                        config.clone()
+                    );
+                    assert_eq!(is_witness, inp.witnesses[i].values);
+                }
+            }
+
+            #[test]
+            #[ignore]
+            fn debug() {
+                inner(CompilerConfig::default());
+            }
+
+            #[test]
+            #[ignore]
+            fn release() {
+                inner(CompilerConfig::release());
+            }
+        }
+    };
+}
+
+witness_extension_test_shamir_ignored!(aliascheck_test);
+witness_extension_test_shamir_ignored!(array_equals);
+witness_extension_test_shamir_ignored!(babyadd_tester);
+witness_extension_test_shamir_ignored!(babycheck_test);
+witness_extension_test_shamir_ignored!(babypbk_test);
+witness_extension_test_shamir_ignored!(binsub_test);
+witness_extension_test_shamir_ignored!(binsum_test);
+witness_extension_test_shamir_ignored!(constants_test);
+witness_extension_test_shamir!(control_flow);
+witness_extension_test_shamir_ignored!(eddsa_test);
+witness_extension_test_shamir_ignored!(eddsa_verify);
+witness_extension_test_shamir_ignored!(eddsamimc_test);
+witness_extension_test_shamir_ignored!(eddsaposeidon_test);
+witness_extension_test_shamir_ignored!(edwards2montgomery);
+witness_extension_test_shamir_ignored!(escalarmul_test);
+witness_extension_test_shamir_ignored!(escalarmul_test_min);
+witness_extension_test_shamir_ignored!(escalarmulany_test);
+witness_extension_test_shamir_ignored!(escalarmulfix_test);
+witness_extension_test_shamir!(escalarmulw4table_test);
+witness_extension_test_shamir!(escalarmulw4table_test3);
+witness_extension_test_shamir_ignored!(functions);
+witness_extension_test_shamir_ignored!(greatereqthan);
+witness_extension_test_shamir_ignored!(greaterthan);
+witness_extension_test_shamir_ignored!(isequal);
+witness_extension_test_shamir_ignored!(iszero);
+witness_extension_test_shamir_ignored!(lesseqthan);
+witness_extension_test_shamir_ignored!(lessthan);
+witness_extension_test_shamir!(mimc_hasher);
+witness_extension_test_shamir!(mimc_sponge_hash_test);
+witness_extension_test_shamir!(mimc_sponge_test);
+witness_extension_test_shamir!(mimc_test);
+witness_extension_test_shamir_ignored!(montgomery2edwards);
+witness_extension_test_shamir_ignored!(montgomeryadd);
+witness_extension_test_shamir_ignored!(montgomerydouble);
+witness_extension_test_shamir!(multiplier16);
+witness_extension_test_shamir_ignored!(mux1_1);
+witness_extension_test_shamir_ignored!(mux2_1);
+witness_extension_test_shamir_ignored!(mux3_1);
+witness_extension_test_shamir_ignored!(mux4_1);
+witness_extension_test_shamir_ignored!(pedersen2_test);
+witness_extension_test_shamir_ignored!(pedersen_hasher);
+witness_extension_test_shamir_ignored!(pedersen_test);
+witness_extension_test_shamir_ignored!(pointbits_loopback);
+witness_extension_test_shamir!(poseidon3_test);
+witness_extension_test_shamir!(poseidon6_test);
+witness_extension_test_shamir!(poseidon_hasher1);
+witness_extension_test_shamir!(poseidon_hasher16);
+witness_extension_test_shamir!(poseidon_hasher2);
+witness_extension_test_shamir!(poseidonex_test);
+witness_extension_test_shamir_ignored!(sha256_2_test);
+witness_extension_test_shamir_ignored!(sha256_test448);
+witness_extension_test_shamir_ignored!(sha256_test512);
+witness_extension_test_shamir_ignored!(shared_control_flow);
+witness_extension_test_shamir_ignored!(shared_control_flow_arrays);
+witness_extension_test_shamir_ignored!(sign_test);
+witness_extension_test_shamir_ignored!(sqrt_test);
+witness_extension_test_shamir_ignored!(smtprocessor10_test);
+witness_extension_test_shamir_ignored!(smtverifier10_test);
+witness_extension_test_shamir_ignored!(sum_test);
+witness_extension_test_shamir_ignored!(winner);
+witness_extension_test_shamir_ignored!(bitonic_sort);
+witness_extension_test_shamir_ignored!(num2bits_accelerator);
+witness_extension_test_shamir_ignored!(reclaim_addbits_accelerator);

--- a/tests/tests/noir/witness_extension_tests/mod.rs
+++ b/tests/tests/noir/witness_extension_tests/mod.rs
@@ -1,10 +1,11 @@
 use acir::native_types::{WitnessMap, WitnessStack};
 use ark_ff::PrimeField;
-use co_acvm::Rep3AcvmType;
+use co_acvm::{Rep3AcvmType, ShamirAcvmType};
 use itertools::izip;
 
 mod plain_solver;
 mod rep3;
+mod shamir;
 
 macro_rules! add_plain_acvm_test {
         ($name: expr) => {
@@ -138,5 +139,113 @@ fn combine_field_elements_for_acvm<F: PrimeField>(
     res
 }
 
+macro_rules! add_shamir_acvm_test {
+    ($name: expr) => {
+        paste::item! {
+            #[test]
+            fn [< test_shamir_ $name >]() {
+                let root = std::env!("CARGO_MANIFEST_DIR");
+                let program = std::fs::read_to_string(format!(
+                    "{root}/../test_vectors/noir/{}/kat/{}.json",
+                    $name, $name
+                ))
+                .unwrap();
+                let program_artifact = serde_json::from_str::<ProgramArtifact>(&program)
+                    .expect("failed to parse program artifact");
+
+                let should_witness =
+                    std::fs::read(format!("{root}/../test_vectors/noir/{}/kat/{}.gz", $name, $name)).unwrap();
+                let should_witness =
+                   WitnessStack::deserialize(should_witness.as_slice()).unwrap();
+                let input = PathBuf::from(format!(
+                    "{root}/../test_vectors/noir/{}/Prover.toml",
+                    $name
+                ));
+                let inputs = noir_types::partially_read_abi_bn254(
+                    std::fs::File::open(input).unwrap(),
+                    &program_artifact.abi,
+                    &program_artifact.bytecode.functions[0].public_inputs().indices(),
+                ).expect("can share field elements for noir witness extension");
+
+                // degree=1, num_parties=3
+                let shares = co_noir_types::split_input_shamir(inputs, 1, 3);
+                let nets = LocalNetwork::new_3_parties();
+                let mut threads = vec![];
+                for (net, program_artifact, share) in izip!(
+                    nets,
+                    [
+                        program_artifact.clone(),
+                        program_artifact.clone(),
+                        program_artifact
+                    ],
+                    shares
+                ) {
+                    threads.push(std::thread::spawn(move || {
+                        let input_share = co_noir::witness_map_from_string_map(share, &program_artifact.abi)
+                            .expect("can translate witness for noir witness extension");
+                        let solver = ShamirCoSolver::new_with_witness(&net, 3, 1, program_artifact, input_share)
+                            .unwrap();
+                        solver.solve().unwrap()
+                    }));
+                }
+
+                let result3 = threads.pop().unwrap().join().unwrap();
+                let result2 = threads.pop().unwrap().join().unwrap();
+                let result1 = threads.pop().unwrap().join().unwrap();
+                let is_witness = super::combine_shamir_field_elements_for_acvm(result1, result2, result3);
+                let is_witness = PlainCoSolver::convert_to_plain_acvm_witness(is_witness);
+                assert_eq!(should_witness, is_witness)
+            }
+        }
+    };
+}
+
+fn combine_shamir_field_elements_for_acvm<F: PrimeField>(
+    mut a: WitnessStack<ShamirAcvmType<F>>,
+    mut b: WitnessStack<ShamirAcvmType<F>>,
+    mut c: WitnessStack<ShamirAcvmType<F>>,
+) -> WitnessStack<F> {
+    let mut res = WitnessStack::default();
+    assert_eq!(a.length(), b.length());
+    assert_eq!(b.length(), c.length());
+    while let Some(stack_item_a) = a.pop() {
+        let stack_item_b = b.pop().unwrap();
+        let stack_item_c = c.pop().unwrap();
+        assert_eq!(stack_item_a.index, stack_item_b.index);
+        assert_eq!(stack_item_b.index, stack_item_c.index);
+        let mut witness_map = WitnessMap::default();
+        for ((witness_a, share_a), (witness_b, share_b), (witness_c, share_c)) in izip!(
+            stack_item_a.witness.into_iter(),
+            stack_item_b.witness.into_iter(),
+            stack_item_c.witness.into_iter()
+        ) {
+            assert_eq!(witness_a, witness_b);
+            assert_eq!(witness_b, witness_c);
+            let reconstructed = match (share_a, share_b, share_c) {
+                (
+                    ShamirAcvmType::Public(a),
+                    ShamirAcvmType::Public(b),
+                    ShamirAcvmType::Public(c),
+                ) => {
+                    assert_eq!(a, b);
+                    assert_eq!(b, c);
+                    a
+                }
+                (
+                    ShamirAcvmType::Shared(a),
+                    ShamirAcvmType::Shared(b),
+                    ShamirAcvmType::Shared(c),
+                ) => mpc_core::protocols::shamir::combine_field_element(&[a, b, c], &[1, 2, 3], 1)
+                    .expect("shamir reconstruction succeeded"),
+                _ => unimplemented!(),
+            };
+            witness_map.insert(witness_a, reconstructed);
+        }
+        res.push(stack_item_a.index, witness_map);
+    }
+    res
+}
+
 use add_plain_acvm_test;
 use add_rep3_acvm_test;
+use add_shamir_acvm_test;

--- a/tests/tests/noir/witness_extension_tests/shamir.rs
+++ b/tests/tests/noir/witness_extension_tests/shamir.rs
@@ -1,0 +1,21 @@
+use acir::native_types::WitnessStack;
+use co_acvm::solver::PlainCoSolver;
+use co_acvm::solver::ShamirCoSolver;
+use itertools::izip;
+use mpc_net::local::LocalNetwork;
+use noirc_artifacts::program::ProgramArtifact;
+use std::path::PathBuf;
+
+use super::add_shamir_acvm_test;
+
+add_shamir_acvm_test!("add3u64");
+add_shamir_acvm_test!("addition_multiplication");
+add_shamir_acvm_test!("assert");
+add_shamir_acvm_test!("if_then");
+add_shamir_acvm_test!("negative");
+add_shamir_acvm_test!("poseidon");
+add_shamir_acvm_test!("poseidon2");
+add_shamir_acvm_test!("poseidon_input2");
+add_shamir_acvm_test!("poseidon_stdlib");
+add_shamir_acvm_test!("unconstrained_fn_field");
+add_shamir_acvm_test!("blackbox_poseidon2");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large new MPC path with many `unimplemented!` shared ops—complex circuits can panic at runtime; witness generation uses preprocessing amount 0 with TODOs on randomness.
> 
> **Overview**
> Adds **Shamir secret-sharing** as an MPC backend for Circom witness extension, alongside existing REP3.
> 
> The MPC-VM gains `ShamirVmType`, `CircomShamirVmWitnessExtension`, and `ShamirWitnessExtension` wired through `VmCircomWitnessExtension`, with core arithmetic (`add`/`sub`/`mul`/`div`), boolean ops, `cmux`, and `open` on shares; comparisons, bit ops, `num2bits`, `addbits`, `sqrt`, and **Poseidon2** on shared values still **`unimplemented!`**.
> 
> **Types and tooling:** `ShamirInputType`, `ShamirSharedInput`, `split_input_shamir`, and `generate_witness_shamir` connect CLI `split_input` / `generate_witness` to `MPCProtocol::SHAMIR` with `threshold` and `num_parties`. Noir gets `split_input_shamir` and `ShamirCoSolver::new_with_witness_and_amount` for configurable preprocessing.
> 
> **Tests:** Circom Shamir witness-extension KATs (many circuits **ignored** until shared ops exist); Noir Shamir ACVM tests for a subset of programs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138ac36fbd9afa2ab3321a5df73ddcb7fc293072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->