### PR TITLE
perf(mpc-core): serialize rep3 broadcast payloads once

### DIFF
--- a/mpc-core/src/protocols/rep3/network.rs
+++ b/mpc-core/src/protocols/rep3/network.rs
@@ -70,13 +70,26 @@ pub trait Rep3NetworkExt: Network {
         //
         // Safe for arbitrarily large frames on the current transports: the peer's
         // background reader thread drains the socket independently of its main
-        // thread's phase, so `send_many` here cannot deadlock against a peer that
+        // thread's phase, so the sends here cannot deadlock against a peer that
         // is itself still in its send phase.
-        self.send_many(prev_id, data)?;
-        self.send_many(next_id, data)?;
+        self.send_both_many(data)?;
         let prev_res = self.recv_many(prev_id)?;
         let next_res = self.recv_many(next_id)?;
         Ok((prev_res, next_res))
+    }
+
+    /// Sends the same data to the other two parties, serializing it only once.
+    #[inline(always)]
+    fn send_both_many<F: CanonicalSerialize>(&self, data: &[F]) -> eyre::Result<()> {
+        let id = PartyID::try_from(self.id())?;
+        let size = data.serialized_size(ark_serialize::Compress::No);
+        let mut ser_data = Vec::with_capacity(size);
+        data.serialize_uncompressed(&mut ser_data)?;
+        // `clone` on `Bytes` is a refcount bump, not a copy
+        let ser_data = Bytes::from(ser_data);
+        self.send(id.prev().into(), ser_data.clone())?;
+        self.send(id.next().into(), ser_data)?;
+        Ok(())
     }
 
     /// Sends data to the target party.

--- a/mpc-core/src/protocols/rep3/yao/evaluator.rs
+++ b/mpc-core/src/protocols/rep3/yao/evaluator.rs
@@ -118,12 +118,10 @@ impl<'a, N: Network> Rep3Evaluator<'a, N> {
             gate.copy_from_slice(block.as_ref());
             blocks.push(gate);
         }
-        let (send1, send2) = mpc_net::join(
-            || self.net.send_many(PartyID::ID1, &blocks),
-            || self.net.send_many(PartyID::ID2, &blocks),
-        );
-        send1?;
-        send2?;
+        // The evaluator is ID0, so ID1 and ID2 are the other two parties. This
+        // serializes once and enqueues on the non-blocking send queues, so no
+        // threads are needed.
+        self.net.send_both_many(&blocks)?;
 
         Ok(())
     }

--- a/mpc-core/src/protocols/rep3_ring/gadgets/sort.rs
+++ b/mpc-core/src/protocols/rep3_ring/gadgets/sort.rs
@@ -723,12 +723,10 @@ where
                 let index = pi[pi_2].a.0 as usize;
                 shuffled.push(gamma[index] + delta[index]);
             }
-            let (send0, send1) = mpc_net::join(
-                || net.send_many(PartyID::ID0, &shuffled),
-                || net.send_many(PartyID::ID1, &shuffled),
-            );
-            send0?;
-            send1?;
+            // ID0 and ID1 are the other two parties from ID2's view. This
+            // serializes once and enqueues on the non-blocking send queues, so
+            // no threads are needed.
+            net.send_both_many(&shuffled)?;
             shuffled
         }
     };


### PR DESCRIPTION
Broadcasting previously serialized the same data once per recipient.
Add Rep3NetworkExt::send_both_many, which serializes once and sends the
refcounted Bytes to both other parties, and use it in broadcast_many,
the yao evaluator output, and the rep3_ring shuffle. This also drops
two mpc_net::join thread spawns around what are non-blocking enqueues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Networking optimization only: same recipients and message semantics, with lower CPU and fewer threads; no change to MPC logic or crypto.
> 
> **Overview**
> Adds **`Rep3NetworkExt::send_both_many`**, which serializes a payload once and delivers the same **`Bytes`** buffer to both other Rep3 parties (refcount clone on the second send). **`broadcast_many`** now uses this instead of two separate **`send_many`** calls that each serialized the data.
> 
> The Yao evaluator’s **`output_garbler`** and the Rep3 ring **`shuffle_reveal`** path for party ID2 switch from **`mpc_net::join`** around dual **`send_many`** calls to a single **`send_both_many`**, on the grounds that sends are non-blocking enqueues and no longer need parallel threads to avoid ring deadlocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e357196a1a4c3360d3d48f8f5d8b603ff84dd92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->