### PR TITLE
Fix lints and advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/co-circom/co-plonk/src/round1.rs
+++ b/co-circom/co-plonk/src/round1.rs
@@ -112,10 +112,8 @@ impl<'a, P: Pairing, T: CircomPlonkProver<P>, N: Network + 'static> Round1<'a, P
         let mut buffer = Vec::with_capacity(zkey.n_constraints);
         debug_assert_eq!(zkey.n_constraints, map.len());
         for index in map {
-            match plonk_utils::get_witness(id, witness, zkey, *index) {
-                Ok(witness) => buffer.push(witness),
-                Err(err) => return Err(err),
-            }
+            let witness = plonk_utils::get_witness(id, witness, zkey, *index)?;
+            buffer.push(witness);
         }
         buffer.resize(zkey.domain_size, T::ArithmeticShare::default());
         // Compute the coefficients of the wire polynomials a(X), b(X) and c(X) from A,B & C buffers

--- a/co-noir/co-acvm/src/solver/blackbox_solver.rs
+++ b/co-noir/co-acvm/src/solver/blackbox_solver.rs
@@ -109,7 +109,7 @@ where
         if let Some(w_value) = T::get_public(&w_value) {
             let w_value = GenericFieldElement::from_repr(w_value);
             if w_value.num_bits() > num_bits {
-                return Err(eyre::eyre!("UnsatisfiedConstraint"))?;
+                return Err(eyre::eyre!("UnsatisfiedConstraint").into());
             }
         }
         Ok(())
@@ -196,7 +196,8 @@ where
                 "InvalidInputBitSize: expected at most {} bits, got {}",
                 num_bits,
                 public_value.num_bits()
-            ))?;
+            )
+            .into());
         }
         Ok(())
     }

--- a/co-noir/co-builder/src/acir_format.rs
+++ b/co-noir/co-builder/src/acir_format.rs
@@ -748,22 +748,8 @@ impl<F: PrimeField> AcirFormat<F> {
                     .blake3_constraints
                     .push(opcode_index);
             }
-            BlackBoxFuncCall::EcdsaSecp256k1 {
-                public_key_x: _,
-                public_key_y: _,
-                signature: _,
-                hashed_message: _,
-                output: _,
-                predicate: _,
-            } => todo!("BlackBoxFuncCall::EcdsaSecp256k1"),
-            BlackBoxFuncCall::EcdsaSecp256r1 {
-                public_key_x: _,
-                public_key_y: _,
-                signature: _,
-                hashed_message: _,
-                output: _,
-                ..
-            } => todo!("BlackBoxFuncCall::EcdsaSecp256r1"),
+            BlackBoxFuncCall::EcdsaSecp256k1 { .. } => todo!("BlackBoxFuncCall::EcdsaSecp256k1"),
+            BlackBoxFuncCall::EcdsaSecp256r1 { .. } => todo!("BlackBoxFuncCall::EcdsaSecp256r1"),
             BlackBoxFuncCall::MultiScalarMul {
                 points,
                 scalars,
@@ -804,10 +790,7 @@ impl<F: PrimeField> AcirFormat<F> {
                     .ec_add_constraints
                     .push(opcode_index);
             }
-            BlackBoxFuncCall::Keccakf1600 {
-                inputs: _,
-                outputs: _,
-            } => todo!("BlackBoxFuncCall::Keccakf1600"),
+            BlackBoxFuncCall::Keccakf1600 { .. } => todo!("BlackBoxFuncCall::Keccakf1600"),
             BlackBoxFuncCall::RecursiveAggregation {
                 verification_key,
                 proof,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical lint and dependency updates; error paths and unimplemented opcode handling behave the same.
> 
> **Overview**
> Addresses **Clippy** and a **Cargo advisory** without changing proof or constraint semantics.
> 
> **`crossbeam-epoch`** is bumped **0.9.18 → 0.9.20** in `Cargo.lock`.
> 
> In **`co-plonk` round1**, witness gathering uses **`?`** in the loop instead of an explicit `match` on `get_witness`.
> 
> In **`co-acvm` blackbox solver**, range and bit-size failures return **`Err(... .into())`** instead of **`Err(...)?`**, which was invalid for those return paths.
> 
> In **`acir_format`**, unimplemented ECDSA and **Keccakf1600** black-box arms use **`{ .. }`** instead of long `_`-field destructuring (style only; still `todo!`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e13abad2a1780560fe907cca1146bede6d5e8eb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->