### PR TITLE
fix(circom-mpc-vm): precompute only one Poseidon2 permutation

### DIFF
--- a/co-circom/circom-mpc-vm/src/mpc/rep3.rs
+++ b/co-circom/circom-mpc-vm/src/mpc/rep3.rs
@@ -671,9 +671,8 @@ impl<F: PrimeField, N: Network> VmCircomWitnessExtension<F>
             .iter()
             .any(|x| matches!(x, Rep3VmType::Arithmetic(_)))
         {
-            let inputs_len = inputs.len();
             let poseidon = Poseidon2::<_, T, 5>::default();
-            let mut precomp = poseidon.precompute_rep3(inputs_len, self.net0, &mut self.state0)?;
+            let mut precomp = poseidon.precompute_rep3(1, self.net0, &mut self.state0)?;
 
             // We promote all inputs to arithmetic shares here
             let mut iter = inputs.into_iter();

--- a/co-circom/circom-mpc-vm/src/mpc/shamir.rs
+++ b/co-circom/circom-mpc-vm/src/mpc/shamir.rs
@@ -466,9 +466,8 @@ impl<F: PrimeField, N: Network> VmCircomWitnessExtension<F>
             .iter()
             .any(|x| matches!(x, ShamirVmType::Arithmetic(_)))
         {
-            let inputs_len = inputs.len();
             let poseidon = Poseidon2::<_, T, 5>::default();
-            let mut precomp = poseidon.precompute_shamir(inputs_len, self.net, &mut self.state)?;
+            let mut precomp = poseidon.precompute_shamir(1, self.net, &mut self.state)?;
 
             let mut iter = inputs.into_iter();
             let mut state: [ShamirPrimeFieldShare<F>; T] = std::array::from_fn(|_| {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Tiny behavioral fix in Poseidon2 accelerator setup; aligns precomp size with one permutation and should reduce cost without changing the hash logic path.
> 
> **Overview**
> **Poseidon2 MPC precomputation in the Circom VM** was keyed off `inputs.len()`, which could reserve randomness and precomp for multiple permutations even though `poseidon2_accelerator` only runs **one** permutation per call (a fixed `T`-wide state from the input vector).
> 
> Rep3 and Shamir witness extensions now call `precompute_rep3(1, …)` and `precompute_shamir(1, …)`, matching other single-permutation call sites and avoiding extra MPC preprocessing work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea873f3053fd540fd9f07011be515b2e1c3e4a03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->