### PR TITLE
fix: edge case for the Poseidon accelerator for T=4

### DIFF
--- a/mpc-core/src/gadgets/poseidon2/poseidon2_bn254_t4.rs
+++ b/mpc-core/src/gadgets/poseidon2/poseidon2_bn254_t4.rs
@@ -421,6 +421,12 @@ pub static POSEIDON2_BN254_T4_PARAMS: LazyLock<Poseidon2Params<Scalar, T, D>> =
         )
     });
 
+// NOTE: this list is consumed positionally by the trace writers (in
+// `poseidon2_circom_accelerator.rs` / `poseidon2_shamir_circom_accelerator.rs`), in the fixed
+// value-stream order: states -> matmul_external -> sq1/qu1 -> sq3/qu3 -> sq2/qu2 -> final_mul ->
+// last_double_in3 -> last_matmul_external. It is therefore NOT sorted by witness index: the
+// trailing `813` corresponds to the last full round's `ExternalMatMul4.double_in3` signal, which
+// is only known (and emitted into the trace) after `final_mul`, i.e. last in the stream.
 pub(crate) const WITNESS_INDICES_T4: &[u16] = &[
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 19, 23, 27, 31, 35, 39, 43, 47, 51,
     55, 59, 63, 67, 71, 75, 79, 83, 87, 91, 95, 99, 103, 107, 111, 115, 119, 123, 127, 131, 135,
@@ -436,7 +442,7 @@ pub(crate) const WITNESS_INDICES_T4: &[u16] = &[
     1783, 1784, 1816, 1817, 1849, 1850, 1882, 1883, 1915, 1916, 1948, 1949, 1981, 1982, 2014, 2015,
     2047, 2048, 2080, 2081, 2113, 2114, 2146, 2147, 2179, 2180, 2212, 2213, 2245, 2246, 2278, 2279,
     2311, 2312, 2344, 2345, 2377, 2378, 2410, 2411, 2443, 2444, 2476, 2477, 2509, 2510, 2542, 2543,
-    2575, 2576, 2608, 2609, 2641, 2642, 2674, 2675, 2684,
+    2575, 2576, 2608, 2609, 2641, 2642, 2674, 2675, 2684, 813,
 ];
 
 pub(crate) const WITNESS_INDICES_SIZE_T4: usize = 2685;

--- a/mpc-core/src/gadgets/poseidon2/poseidon2_circom_accelerator.rs
+++ b/mpc-core/src/gadgets/poseidon2/poseidon2_circom_accelerator.rs
@@ -153,7 +153,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             let (squares_, quads_, sbox_0) = if r == self.params.rounds_f_beginning - 1 && T == 16 {
                 self.rep3_external_round_precomp_matmul_intermediate(state, r, precomp, net)?
             } else {
-                let (squares_, quads_, sbox_0, _, _) =
+                let (squares_, quads_, sbox_0, _, _, _) =
                     self.rep3_external_round_precomp_intermediate(state, r, precomp, net)?;
                 (squares_, quads_, sbox_0)
             };
@@ -193,16 +193,18 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         }
 
         let mut last_matmul_external = None;
+        let mut last_double_in3 = None;
 
         // Remaining external rounds
         for r in self.params.rounds_f_beginning
             ..self.params.rounds_f_beginning + self.params.rounds_f_end
         {
-            let (squares_, quads_, sbox_0, sbox_1, matmul_external) =
+            let (squares_, quads_, sbox_0, sbox_1, sbox_3, matmul_external) =
                 self.rep3_external_round_precomp_intermediate(state, r, precomp, net)?;
             if r == self.params.rounds_f_beginning + self.params.rounds_f_end - 1 {
                 squares_3.push(sbox_0);
                 quads_3.push(sbox_1);
+                last_double_in3 = Some(sbox_3 + sbox_3);
             }
             squares_3.extend(squares_);
             quads_3.extend(quads_);
@@ -271,6 +273,12 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             trace[idx as usize] = val;
         }
 
+        if T == 4
+            && let (Some(idx), Some(val)) = (wtns_indices_iter.next(), last_double_in3)
+        {
+            trace[idx as usize] = val;
+        }
+
         if let Some(last_matmul_external) = last_matmul_external {
             for s in &last_matmul_external {
                 if let Some(idx) = wtns_indices_iter.next() {
@@ -296,6 +304,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Vec<Rep3PrimeFieldShare<F>>,
         Rep3PrimeFieldShare<F>,
         Rep3PrimeFieldShare<F>,
+        Rep3PrimeFieldShare<F>,
         Option<Vec<Rep3PrimeFieldShare<F>>>,
     )> {
         let id = PartyID::try_from(net.id())?;
@@ -303,13 +312,14 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         let (squares, quads) = Self::sbox_rep3_precomp_intermediate(state, precomp, net)?;
         let sbox_0 = state[0];
         let sbox_1 = state[1];
+        let sbox_3 = state.get(3).copied().unwrap_or_default();
         let matmul_external = if T == 16 {
             Some(Self::matmul_external_rep3_intermediate_t16(state))
         } else {
             Self::matmul_external_rep3(state);
             None
         };
-        Ok((squares, quads, sbox_0, sbox_1, matmul_external))
+        Ok((squares, quads, sbox_0, sbox_1, sbox_3, matmul_external))
     }
 
     /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
@@ -346,6 +356,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         [Vec<Rep3PrimeFieldShare<F>>; BATCH_SIZE],
         [Rep3PrimeFieldShare<F>; BATCH_SIZE],
         [Rep3PrimeFieldShare<F>; BATCH_SIZE],
+        [Rep3PrimeFieldShare<F>; BATCH_SIZE],
         Option<[Vec<Rep3PrimeFieldShare<F>>; BATCH_SIZE]>,
     )> {
         assert!(state.len().is_multiple_of(T));
@@ -356,6 +367,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         let (squares, quads) = Self::sbox_rep3_precomp_intermediate_packed(state, precomp, net)?;
         let sboxes_0: [_; BATCH_SIZE] = array::from_fn(|i| state[i * T]);
         let sboxes_1: [_; BATCH_SIZE] = array::from_fn(|i| state[i * T + 1]);
+        let sboxes_3: [_; BATCH_SIZE] =
+            array::from_fn(|i| state.get(i * T + 3).copied().unwrap_or_default());
         let matmul_external = if T == 16 {
             let mut res = Vec::with_capacity(state.len() / T);
             for state_chunk in state.chunks_exact_mut(T) {
@@ -370,7 +383,14 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             }
             None
         };
-        Ok((squares, quads, sboxes_0, sboxes_1, matmul_external))
+        Ok((
+            squares,
+            quads,
+            sboxes_0,
+            sboxes_1,
+            sboxes_3,
+            matmul_external,
+        ))
     }
 
     /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
@@ -421,6 +441,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         Vec<Vec<Rep3PrimeFieldShare<F>>>,
         Vec<Rep3PrimeFieldShare<F>>,
         Vec<Rep3PrimeFieldShare<F>>,
+        Vec<Rep3PrimeFieldShare<F>>,
         Option<Vec<Vec<Rep3PrimeFieldShare<F>>>>,
     )> {
         assert!(state.len().is_multiple_of(T));
@@ -431,6 +452,11 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         let (squares, quads) = Self::sbox_rep3_precomp_intermediate_vec(state, precomp, net)?;
         let sboxes_0 = state.iter().step_by(T).cloned().collect::<Vec<_>>();
         let sboxes_1 = state.iter().skip(1).step_by(T).cloned().collect::<Vec<_>>();
+        let sboxes_3 = if T >= 4 {
+            state.iter().skip(3).step_by(T).cloned().collect::<Vec<_>>()
+        } else {
+            vec![Rep3PrimeFieldShare::<F>::default(); state.len() / T]
+        };
         let matmul_external = if T == 16 {
             let mut res = Vec::with_capacity(state.len() / T);
             for state_chunk in state.chunks_exact_mut(T) {
@@ -445,7 +471,14 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             }
             None
         };
-        Ok((squares, quads, sboxes_0, sboxes_1, matmul_external))
+        Ok((
+            squares,
+            quads,
+            sboxes_0,
+            sboxes_1,
+            sboxes_3,
+            matmul_external,
+        ))
     }
 
     /// One external round of the Poseidon2 permutation using Poseidon2Precomputations. Implemented for the Rep3 MPC protocol.
@@ -827,22 +860,24 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         }
     }
 
+    #[expect(clippy::type_complexity)]
     fn external_round_intermediate(
         &self,
         state: &mut [F; T],
         r: usize,
-    ) -> (Vec<F>, Vec<F>, F, F, Option<Vec<F>>) {
+    ) -> (Vec<F>, Vec<F>, F, F, F, Option<Vec<F>>) {
         self.add_rc_external(state, r);
         let (squares, quads) = Self::sbox_plain_intermediate(state);
         let sbox_0 = state[0];
         let sbox_1 = state[1];
+        let sbox_3 = state.get(3).copied().unwrap_or_default();
         let matmul_external = if T == 16 {
             Some(Self::matmul_external_intermediate_t16(state))
         } else {
             Self::matmul_external(state);
             None
         };
-        (squares, quads, sbox_0, sbox_1, matmul_external)
+        (squares, quads, sbox_0, sbox_1, sbox_3, matmul_external)
     }
 
     fn external_round_matmul_intermediate(
@@ -992,7 +1027,8 @@ impl<F: PrimeField, const T: usize> CircomTracePlainHasher<F, T> for Poseidon2<F
             let (squares_, quads_, res) = if r == self.params.rounds_f_beginning - 1 && T == 16 {
                 self.external_round_matmul_intermediate(&mut state, r)
             } else {
-                let (squares_, quads_, res, _, _) = self.external_round_intermediate(&mut state, r);
+                let (squares_, quads_, res, _, _, _) =
+                    self.external_round_intermediate(&mut state, r);
                 (squares_, quads_, res)
             };
 
@@ -1030,17 +1066,19 @@ impl<F: PrimeField, const T: usize> CircomTracePlainHasher<F, T> for Poseidon2<F
         }
 
         let mut last_matmul_external = None;
+        let mut last_double_in3 = None;
 
         // Remaining external rounds
         for r in self.params.rounds_f_beginning
             ..self.params.rounds_f_beginning + self.params.rounds_f_end
         {
-            let (squares_, quads_, sbox_0, sbox_1, matmul_external) =
+            let (squares_, quads_, sbox_0, sbox_1, sbox_3, matmul_external) =
                 self.external_round_intermediate(&mut state, r);
 
             if r == self.params.rounds_f_beginning + self.params.rounds_f_end - 1 {
                 squares_3.push(sbox_0);
                 quads_3.push(sbox_1);
+                last_double_in3 = Some(sbox_3 + sbox_3);
             }
             squares_3.extend(squares_);
             quads_3.extend(quads_);
@@ -1105,6 +1143,12 @@ impl<F: PrimeField, const T: usize> CircomTracePlainHasher<F, T> for Poseidon2<F
 
         if T == 4
             && let (Some(idx), Some(val)) = (wtns_indices_iter.next(), final_mul[1])
+        {
+            trace[idx as usize] = val;
+        }
+
+        if T == 4
+            && let (Some(idx), Some(val)) = (wtns_indices_iter.next(), last_double_in3)
         {
             trace[idx as usize] = val;
         }
@@ -1250,7 +1294,7 @@ impl<F: PrimeField, const T: usize> CircomTraceBatchedHasher<F, T> for Poseidon2
                     &mut state, r, precomp, net,
                 )?
             } else {
-                let (squares_, quads_, res, _, _) = self
+                let (squares_, quads_, res, _, _, _) = self
                     .rep3_external_round_precomp_intermediate_packed(&mut state, r, precomp, net)?;
                 (squares_, quads_, res)
             };
@@ -1341,12 +1385,14 @@ impl<F: PrimeField, const T: usize> CircomTraceBatchedHasher<F, T> for Poseidon2
         };
 
         let mut last_matmul_external: Option<[Vec<Rep3PrimeFieldShare<F>>; BATCH_SIZE]> = None;
+        let mut last_double_in3: Option<[Rep3PrimeFieldShare<F>; BATCH_SIZE]> = None;
 
         // Remaining external rounds
         for r in self.params.rounds_f_beginning
             ..self.params.rounds_f_beginning + self.params.rounds_f_end
         {
-            let (squares_, quads_, sboxes_0, sboxes_1, matmul_external): (
+            let (squares_, quads_, sboxes_0, sboxes_1, sboxes_3, matmul_external): (
+                [_; BATCH_SIZE],
                 [_; BATCH_SIZE],
                 [_; BATCH_SIZE],
                 [_; BATCH_SIZE],
@@ -1361,6 +1407,7 @@ impl<F: PrimeField, const T: usize> CircomTraceBatchedHasher<F, T> for Poseidon2
                 for (quads_3_, sbox_1) in quads_3.iter_mut().zip(sboxes_1.iter()) {
                     quads_3_.push(*sbox_1);
                 }
+                last_double_in3 = Some(array::from_fn(|i| sboxes_3[i] + sboxes_3[i]));
             }
             for (squares_3_, squares__, quads_3_, quads__) in izip!(
                 squares_3.iter_mut(),
@@ -1439,6 +1486,15 @@ impl<F: PrimeField, const T: usize> CircomTraceBatchedHasher<F, T> for Poseidon2
                 if let Some(val) = final_mul_[1] {
                     traces[i][wtns_indices[counter] as usize] = val;
                 }
+            }
+            counter += 1;
+        }
+
+        if T == 4
+            && let Some(last_double_in3) = last_double_in3
+        {
+            for (i, val) in last_double_in3.iter().enumerate() {
+                traces[i][wtns_indices[counter] as usize] = *val;
             }
         }
 
@@ -1533,7 +1589,7 @@ impl<F: PrimeField, const T: usize> CircomTraceBatchedHasher<F, T> for Poseidon2
                     &mut state, r, precomp, net,
                 )?
             } else {
-                let (squares_, quads_, res, _, _) =
+                let (squares_, quads_, res, _, _, _) =
                     self.rep3_external_round_precomp_intermediate_vec(&mut state, r, precomp, net)?;
                 (squares_, quads_, res)
             };
@@ -1624,12 +1680,13 @@ impl<F: PrimeField, const T: usize> CircomTraceBatchedHasher<F, T> for Poseidon2
         };
 
         let mut last_matmul_external = None;
+        let mut last_double_in3: Option<Vec<Rep3PrimeFieldShare<F>>> = None;
 
         // Remaining external rounds
         for r in self.params.rounds_f_beginning
             ..self.params.rounds_f_beginning + self.params.rounds_f_end
         {
-            let (squares_, quads_, sboxes_0, sboxes_1, matmul_external) =
+            let (squares_, quads_, sboxes_0, sboxes_1, sboxes_3, matmul_external) =
                 self.rep3_external_round_precomp_intermediate_vec(&mut state, r, precomp, net)?;
             if r == self.params.rounds_f_beginning + self.params.rounds_f_end - 1 {
                 for (squares_3_, sbox_0) in squares_3.iter_mut().zip(sboxes_0.iter()) {
@@ -1638,6 +1695,7 @@ impl<F: PrimeField, const T: usize> CircomTraceBatchedHasher<F, T> for Poseidon2
                 for (quads_3_, sbox_1) in quads_3.iter_mut().zip(sboxes_1.iter()) {
                     quads_3_.push(*sbox_1);
                 }
+                last_double_in3 = Some(sboxes_3.iter().map(|s| *s + *s).collect());
             }
             for (squares_3_, squares__, quads_3_, quads__) in izip!(
                 squares_3.iter_mut(),
@@ -1716,6 +1774,15 @@ impl<F: PrimeField, const T: usize> CircomTraceBatchedHasher<F, T> for Poseidon2
                 if let Some(val) = final_mul_[1] {
                     traces[i][wtns_indices[counter] as usize] = val;
                 }
+            }
+            counter += 1;
+        }
+
+        if T == 4
+            && let Some(last_double_in3) = last_double_in3
+        {
+            for (i, val) in last_double_in3.iter().enumerate() {
+                traces[i][wtns_indices[counter] as usize] = *val;
             }
         }
 

--- a/mpc-core/src/gadgets/poseidon2/poseidon2_shamir_circom_accelerator.rs
+++ b/mpc-core/src/gadgets/poseidon2/poseidon2_shamir_circom_accelerator.rs
@@ -344,6 +344,7 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         Vec<ShamirPrimeFieldShare<F>>,
         ShamirPrimeFieldShare<F>,
         ShamirPrimeFieldShare<F>,
+        ShamirPrimeFieldShare<F>,
         Option<Vec<ShamirPrimeFieldShare<F>>>,
     )> {
         for (s, &rc) in state
@@ -356,13 +357,14 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
             Self::sbox_shamir_precomp_intermediate(state, precomp, net, shamir_state)?;
         let sbox_0 = state[0];
         let sbox_1 = state[1];
+        let sbox_3 = state.get(3).copied().unwrap_or_default();
         let matmul_external = if T == 16 {
             Some(Self::matmul_external_shamir_intermediate_t16(state))
         } else {
             Self::matmul_external_shamir_shares(state);
             None
         };
-        Ok((squares, quads, sbox_0, sbox_1, matmul_external))
+        Ok((squares, quads, sbox_0, sbox_1, sbox_3, matmul_external))
     }
 
     #[expect(clippy::type_complexity)]
@@ -432,6 +434,7 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         [Vec<ShamirPrimeFieldShare<F>>; BATCH_SIZE],
         [ShamirPrimeFieldShare<F>; BATCH_SIZE],
         [ShamirPrimeFieldShare<F>; BATCH_SIZE],
+        [ShamirPrimeFieldShare<F>; BATCH_SIZE],
         Option<[Vec<ShamirPrimeFieldShare<F>>; BATCH_SIZE]>,
     )> {
         assert!(state.len().is_multiple_of(T));
@@ -452,6 +455,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         )?;
         let sboxes_0: [_; BATCH_SIZE] = array::from_fn(|i| state[i * T]);
         let sboxes_1: [_; BATCH_SIZE] = array::from_fn(|i| state[i * T + 1]);
+        let sboxes_3: [_; BATCH_SIZE] =
+            array::from_fn(|i| state.get(i * T + 3).copied().unwrap_or_default());
         let matmul_external = if T == 16 {
             let mut me = Vec::with_capacity(BATCH_SIZE);
             for chunk in state.chunks_exact_mut(T) {
@@ -466,7 +471,14 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
             }
             None
         };
-        Ok((squares, quads, sboxes_0, sboxes_1, matmul_external))
+        Ok((
+            squares,
+            quads,
+            sboxes_0,
+            sboxes_1,
+            sboxes_3,
+            matmul_external,
+        ))
     }
 
     #[expect(clippy::type_complexity)]
@@ -568,6 +580,7 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         Vec<Vec<ShamirPrimeFieldShare<F>>>,
         Vec<ShamirPrimeFieldShare<F>>,
         Vec<ShamirPrimeFieldShare<F>>,
+        Vec<ShamirPrimeFieldShare<F>>,
         Option<Vec<Vec<ShamirPrimeFieldShare<F>>>>,
     )> {
         assert!(state.len().is_multiple_of(T));
@@ -584,6 +597,11 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
             Self::sbox_shamir_precomp_intermediate_vec(state, precomp, net, shamir_state)?;
         let sboxes_0 = state.iter().step_by(T).cloned().collect();
         let sboxes_1 = state.iter().skip(1).step_by(T).cloned().collect();
+        let sboxes_3 = if T >= 4 {
+            state.iter().skip(3).step_by(T).cloned().collect::<Vec<_>>()
+        } else {
+            vec![ShamirPrimeFieldShare::<F>::default(); state.len() / T]
+        };
         let matmul_external = if T == 16 {
             let mut res = Vec::with_capacity(state.len() / T);
             for chunk in state.chunks_exact_mut(T) {
@@ -598,7 +616,14 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
             }
             None
         };
-        Ok((squares, quads, sboxes_0, sboxes_1, matmul_external))
+        Ok((
+            squares,
+            quads,
+            sboxes_0,
+            sboxes_1,
+            sboxes_3,
+            matmul_external,
+        ))
     }
 
     #[expect(clippy::type_complexity)]
@@ -686,7 +711,7 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
                     shamir_state,
                 )?
             } else {
-                let (sq, qu, s0, _, _) = self.shamir_external_round_precomp_intermediate(
+                let (sq, qu, s0, _, _, _) = self.shamir_external_round_precomp_intermediate(
                     state,
                     r,
                     precomp,
@@ -735,19 +760,16 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         }
 
         let mut last_matmul_external = None;
+        let mut last_double_in3 = None;
         for r in self.params.rounds_f_beginning
             ..self.params.rounds_f_beginning + self.params.rounds_f_end
         {
-            let (sq, qu, sbox_0, sbox_1, me) = self.shamir_external_round_precomp_intermediate(
-                state,
-                r,
-                precomp,
-                net,
-                shamir_state,
-            )?;
+            let (sq, qu, sbox_0, sbox_1, sbox_3, me) = self
+                .shamir_external_round_precomp_intermediate(state, r, precomp, net, shamir_state)?;
             if r == self.params.rounds_f_beginning + self.params.rounds_f_end - 1 {
                 squares_3.push(sbox_0);
                 quads_3.push(sbox_1);
+                last_double_in3 = Some(sbox_3 + sbox_3);
                 squares_3.extend(sq);
                 quads_3.extend(qu);
                 last_matmul_external = me;
@@ -801,6 +823,11 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         }
         if T == 4
             && let (Some(idx), Some(val)) = (it.next(), final_mul[1])
+        {
+            trace[idx as usize] = val;
+        }
+        if T == 4
+            && let (Some(idx), Some(val)) = (it.next(), last_double_in3)
         {
             trace[idx as usize] = val;
         }
@@ -942,7 +969,7 @@ impl<F: PrimeField, const T: usize> CircomTraceShamirHasher<F, T> for Poseidon2<
                         shamir_state,
                     )?
                 } else {
-                    let (sq, qu, res, _, _) = self
+                    let (sq, qu, res, _, _, _) = self
                         .shamir_external_round_precomp_intermediate_packed::<N, BATCH_SIZE>(
                             state.as_mut_slice(),
                             r,
@@ -1025,10 +1052,11 @@ impl<F: PrimeField, const T: usize> CircomTraceShamirHasher<F, T> for Poseidon2<
         }
 
         let mut last_matmul_external: Option<[Vec<ShamirPrimeFieldShare<F>>; BATCH_SIZE]> = None;
+        let mut last_double_in3: Option<[ShamirPrimeFieldShare<F>; BATCH_SIZE]> = None;
         for r in self.params.rounds_f_beginning
             ..self.params.rounds_f_beginning + self.params.rounds_f_end
         {
-            let (sq_, qu_, sboxes_0, sboxes_1, me) = self
+            let (sq_, qu_, sboxes_0, sboxes_1, sboxes_3, me) = self
                 .shamir_external_round_precomp_intermediate_packed::<N, BATCH_SIZE>(
                     state.as_mut_slice(),
                     r,
@@ -1043,6 +1071,7 @@ impl<F: PrimeField, const T: usize> CircomTraceShamirHasher<F, T> for Poseidon2<
                 for (qu3, s1) in quads_3.iter_mut().zip(sboxes_1.iter()) {
                     qu3.push(*s1);
                 }
+                last_double_in3 = Some(array::from_fn(|i| sboxes_3[i] + sboxes_3[i]));
                 for (sq3, sq, qu3, qu) in izip!(
                     squares_3.iter_mut(),
                     sq_.iter(),
@@ -1132,6 +1161,14 @@ impl<F: PrimeField, const T: usize> CircomTraceShamirHasher<F, T> for Poseidon2<
             counter += 1;
         }
 
+        if T == 4
+            && let Some(last_double_in3) = last_double_in3
+        {
+            for (i, val) in last_double_in3.iter().enumerate() {
+                traces[i][wtns_indices[counter] as usize] = *val;
+            }
+        }
+
         if let Some(lme) = last_matmul_external {
             for (i, lme_) in lme.iter().enumerate() {
                 for (j, s) in lme_.iter().enumerate() {
@@ -1218,7 +1255,7 @@ impl<F: PrimeField, const T: usize> CircomTraceShamirHasher<F, T> for Poseidon2<
                     shamir_state,
                 )?
             } else {
-                let (sq, qu, res, _, _) = self.shamir_external_round_precomp_intermediate_vec(
+                let (sq, qu, res, _, _, _) = self.shamir_external_round_precomp_intermediate_vec(
                     &mut state,
                     r,
                     precomp,
@@ -1300,10 +1337,11 @@ impl<F: PrimeField, const T: usize> CircomTraceShamirHasher<F, T> for Poseidon2<
         }
 
         let mut last_matmul_external = None;
+        let mut last_double_in3: Option<Vec<ShamirPrimeFieldShare<F>>> = None;
         for r in self.params.rounds_f_beginning
             ..self.params.rounds_f_beginning + self.params.rounds_f_end
         {
-            let (sq_, qu_, sboxes_0, sboxes_1, me) = self
+            let (sq_, qu_, sboxes_0, sboxes_1, sboxes_3, me) = self
                 .shamir_external_round_precomp_intermediate_vec(
                     &mut state,
                     r,
@@ -1318,6 +1356,7 @@ impl<F: PrimeField, const T: usize> CircomTraceShamirHasher<F, T> for Poseidon2<
                 for (qu3, s1) in quads_3.iter_mut().zip(sboxes_1.iter()) {
                     qu3.push(*s1);
                 }
+                last_double_in3 = Some(sboxes_3.iter().map(|s| *s + *s).collect());
                 for (sq3, sq, qu3, qu) in izip!(
                     squares_3.iter_mut(),
                     sq_.iter(),
@@ -1404,6 +1443,14 @@ impl<F: PrimeField, const T: usize> CircomTraceShamirHasher<F, T> for Poseidon2<
                 }
             }
             counter += 1;
+        }
+
+        if T == 4
+            && let Some(last_double_in3) = last_double_in3
+        {
+            for (i, val) in last_double_in3.iter().enumerate() {
+                traces[i][wtns_indices[counter] as usize] = *val;
+            }
         }
 
         if let Some(lme) = last_matmul_external {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes witness layout for T=4 Poseidon2 proofs; incorrect indexing would break verification, but the change is narrowly scoped to one known missing signal.
> 
> **Overview**
> Fixes **Poseidon2 BN254 T=4** Circom accelerator witness alignment by filling a missing intermediate the circuit expects from the **last full external round**.
> 
> External-round helpers now also surface **post-sbox state lane 3** (`sbox_3`). On the **final** external round in the closing block, the trace writers record **`last_double_in3` = `2 * sbox_3`** (the `ExternalMatMul4.double_in3` signal), **only when `T == 4`**, in the same order as other streamed values: after **`final_mul`**, before **`last_matmul_external`**. The same logic is applied across **Rep3** and **Shamir** paths (single, plain, packed, and vec batched trace builders).
> 
> **`WITNESS_INDICES_T4`** gains witness index **`813`** at the end of the positional list, with a comment that the table follows **value-stream order**, not sorted witness indices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6dfc022e39deb318ed0d10410871165bb583a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->