### PR TITLE
build(deps): arkworks 0.6 update [TAC-1176]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@ version = 4
 
 [[package]]
 name = "acir"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir_field",
  "base64",
@@ -25,11 +25,11 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
- "ark-bn254 0.5.0",
- "ark-ff 0.5.0",
+ "ark-bn254",
+ "ark-ff 0.6.0",
  "cfg-if",
  "hex",
  "num-bigint 0.4.6",
@@ -38,8 +38,8 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -54,11 +54,11 @@ dependencies = [
 
 [[package]]
 name = "acvm_blackbox_solver"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir",
- "aes",
+ "aes 0.9.2",
  "blake2 0.11.0-rc.6",
  "blake3",
  "cbc",
@@ -103,8 +103,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.1",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -230,7 +241,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c26d3bddbe5a0adf5bc717f5e146b977dcd686440d9e71827171b61bfbcebad6"
 dependencies = [
- "ark-ec 0.6.0",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-std 0.6.0",
 ]
@@ -241,21 +252,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
- "ark-ec 0.6.0",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-serialize 0.6.0",
  "ark-std 0.6.0",
-]
-
-[[package]]
-name = "ark-bn254"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
-dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -264,7 +264,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
 dependencies = [
- "ark-ec 0.6.0",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-std 0.6.0",
 ]
@@ -277,7 +277,7 @@ checksum = "31b3409b1846fe459d19c95df039481575ac6d5842ae63858ad75cc31219bfc1"
 dependencies = [
  "ahash",
  "ark-crypto-primitives-macros",
- "ark-ec 0.6.0",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-r1cs-std",
  "ark-relations",
@@ -308,34 +308,13 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
-dependencies = [
- "ahash",
- "ark-ff 0.5.0",
- "ark-poly 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "educe",
- "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
  "ark-ff 0.6.0",
- "ark-poly 0.6.0",
+ "ark-poly",
  "ark-serialize 0.6.0",
  "ark-std 0.6.0",
  "educe",
@@ -523,9 +502,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a293328aa422e65527e285614ce5d1dceb0bd7b8b18d18b1b63191ee1f74cb41"
 dependencies = [
  "ark-crypto-primitives",
- "ark-ec 0.6.0",
+ "ark-ec",
  "ark-ff 0.6.0",
- "ark-poly 0.6.0",
+ "ark-poly",
  "ark-relations",
  "ark-serialize 0.6.0",
  "ark-snark",
@@ -539,25 +518,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2c969a12ceed8881e5c66277dabd3e7a5aa2c72c9370f3f42eca3f2dd33a21a"
 dependencies = [
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-std 0.6.0",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
-dependencies = [
- "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "educe",
- "fnv",
- "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -582,7 +546,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291f1c6628bfcac79b0dc2adbe401aa9100e2e96daa971645e0b18fc94de9a98"
 dependencies = [
- "ark-ec 0.6.0",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-relations",
  "ark-std 0.6.0",
@@ -601,7 +565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4c11c797a64b8a23e22bf4e77bf582ac27bb21395e3183a9a506ba2561e9f9"
 dependencies = [
  "ark-ff 0.6.0",
- "ark-poly 0.6.0",
+ "ark-poly",
  "ark-serialize 0.6.0",
  "ark-std 0.6.0",
  "foldhash",
@@ -638,7 +602,6 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
@@ -651,23 +614,12 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
- "ark-serialize-derive 0.6.0",
+ "ark-serialize-derive",
  "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint 0.4.6",
  "rayon",
  "serde_with",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -930,17 +882,17 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array 0.14.7",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "brillig"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir_field",
  "itertools 0.14.0",
@@ -949,8 +901,8 @@ dependencies = [
 
 [[package]]
 name = "brillig_vm"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -1021,11 +973,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
 dependencies = [
- "cipher",
+ "cipher 0.5.1",
 ]
 
 [[package]]
@@ -1104,15 +1056,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+dependencies = [
+ "crypto-common 0.2.1",
+ "inout 0.2.2",
 ]
 
 [[package]]
 name = "circom-mpc-compiler"
 version = "0.10.0"
 dependencies = [
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "circom-mpc-vm",
  "clap",
@@ -1219,8 +1181,8 @@ name = "co-acvm"
 version = "0.7.0"
 dependencies = [
  "acir",
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-grumpkin",
  "blake2 0.10.6",
@@ -1271,11 +1233,11 @@ name = "co-builder"
 version = "0.5.0"
 dependencies = [
  "acir",
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-grumpkin",
- "ark-poly 0.6.0",
+ "ark-poly",
  "blake3",
  "co-acvm",
  "co-noir-common",
@@ -1298,8 +1260,8 @@ name = "co-circom"
 version = "0.10.0"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "bincode",
  "circom-mpc-compiler",
@@ -1347,11 +1309,11 @@ version = "0.10.0"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-groth16",
- "ark-poly 0.6.0",
+ "ark-poly",
  "ark-relations",
  "ark-serialize 0.6.0",
  "co-circom-types",
@@ -1372,8 +1334,8 @@ name = "co-noir"
 version = "0.7.0"
 dependencies = [
  "acir",
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "bincode",
  "clap",
@@ -1404,11 +1366,11 @@ dependencies = [
 name = "co-noir-common"
 version = "0.2.0"
 dependencies = [
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-grumpkin",
- "ark-poly 0.6.0",
+ "ark-poly",
  "ark-serialize 0.6.0",
  "eyre",
  "itertools 0.14.0",
@@ -1442,10 +1404,10 @@ name = "co-plonk"
 version = "0.7.0"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
- "ark-poly 0.6.0",
+ "ark-poly",
  "ark-serialize 0.6.0",
  "co-circom-types",
  "eyre",
@@ -1466,10 +1428,10 @@ dependencies = [
 name = "co-ultrahonk"
 version = "0.6.0"
 dependencies = [
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
- "ark-poly 0.6.0",
+ "ark-poly",
  "co-noir-common",
  "criterion",
  "eyre",
@@ -1521,16 +1483,6 @@ name = "codespan-reporting"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e0762455306b1ed42bc651ef6a2197aabda5e1d4a43c34d5eab5c1a3634e81d"
-dependencies = [
- "termcolor",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width 0.1.14",
@@ -2282,10 +2234,10 @@ dependencies = [
 
 [[package]]
 name = "fm"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
- "codespan-reporting 0.11.1",
+ "codespan-reporting 0.13.1",
  "iter-extended",
  "itertools 0.14.0",
  "serde",
@@ -2507,7 +2459,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
  "foldhash",
 ]
 
@@ -2665,8 +2616,17 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2694,8 +2654,8 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iter-extended"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 
 [[package]]
 name = "itertools"
@@ -3032,8 +2992,8 @@ dependencies = [
 name = "mpc-core"
 version = "0.10.0"
 dependencies = [
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-grumpkin",
  "ark-serialize 0.6.0",
@@ -3113,7 +3073,7 @@ name = "noir-types"
 version = "0.1.1"
 dependencies = [
  "acir",
- "ark-bn254 0.6.0",
+ "ark-bn254",
  "ark-ff 0.6.0",
  "co-noir-types",
  "eyre",
@@ -3127,8 +3087,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_abi"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acvm",
  "iter-extended",
@@ -3144,13 +3104,13 @@ dependencies = [
 
 [[package]]
 name = "noirc_artifacts"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir",
  "acvm",
  "base64",
- "codespan-reporting 0.11.1",
+ "codespan-reporting 0.13.1",
  "flate2",
  "fm",
  "noirc_abi",
@@ -3164,10 +3124,10 @@ dependencies = [
 
 [[package]]
 name = "noirc_errors"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
- "codespan-reporting 0.11.1",
+ "codespan-reporting 0.13.1",
  "fm",
  "noirc_span",
  "rangemap",
@@ -3177,8 +3137,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_printable_type"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acvm",
  "iter-extended",
@@ -3189,8 +3149,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_span"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "codespan 0.13.1",
  "serde",
@@ -4639,9 +4599,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
@@ -4807,8 +4767,8 @@ version = "0.6.0"
 source = "git+https://github.com/TaceoLabs/circom-helpers.git?rev=e0122f8738f48a3e330e1df58558a909736c11cb#e0122f8738f48a3e330e1df58558a909736c11cb"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-serialize 0.6.0",
  "num-bigint 0.4.6",
@@ -4821,11 +4781,11 @@ version = "0.2.5"
 source = "git+https://github.com/TaceoLabs/circom-helpers.git?rev=e0122f8738f48a3e330e1df58558a909736c11cb#e0122f8738f48a3e330e1df58558a909736c11cb"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-groth16",
- "ark-poly 0.6.0",
+ "ark-poly",
  "ark-relations",
  "ark-serialize 0.6.0",
  "ark-std 0.6.0",
@@ -4844,10 +4804,10 @@ name = "taceo-groth16"
 version = "0.1.3"
 source = "git+https://github.com/TaceoLabs/circom-helpers.git?rev=e0122f8738f48a3e330e1df58558a909736c11cb#e0122f8738f48a3e330e1df58558a909736c11cb"
 dependencies = [
- "ark-ec 0.6.0",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-groth16",
- "ark-poly 0.6.0",
+ "ark-poly",
  "ark-relations",
  "eyre",
  "rayon",
@@ -4899,8 +4859,8 @@ version = "0.1.12"
 dependencies = [
  "acir",
  "ark-bls12-381",
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-grumpkin",
  "ark-std 0.6.0",
@@ -5281,9 +5241,9 @@ dependencies = [
 name = "ultrahonk"
 version = "0.6.0"
 dependencies = [
- "ark-ec 0.6.0",
+ "ark-ec",
  "ark-ff 0.6.0",
- "ark-poly 0.6.0",
+ "ark-poly",
  "co-noir-common",
  "eyre",
  "itertools 0.14.0",
@@ -5357,7 +5317,7 @@ name = "vectoreyes"
 version = "0.6.0"
 source = "git+https://github.com/GaloisInc/swanky?rev=5ff648457218b74da9d8323b7ca47166ff5be4b3#5ff648457218b74da9d8323b7ca47166ff5be4b3"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "bytemuck",
  "lazy_static",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2063,7 +2063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2643,7 +2643,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3172,7 +3172,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4164,7 +4164,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4223,7 +4223,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4554,7 +4554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4763,8 +4763,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-ark-serde-compat"
-version = "0.6.0"
-source = "git+https://github.com/TaceoLabs/circom-helpers.git?rev=e0122f8738f48a3e330e1df58558a909736c11cb#e0122f8738f48a3e330e1df58558a909736c11cb"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7a255d21a01f083cf373ff6b4903f9dafad1e0a2a1a2119a4cee971d1bb995"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4777,8 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-circom-types"
-version = "0.2.5"
-source = "git+https://github.com/TaceoLabs/circom-helpers.git?rev=e0122f8738f48a3e330e1df58558a909736c11cb#e0122f8738f48a3e330e1df58558a909736c11cb"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26809b64b4b3f1540eef51b7f5a8d3d3df837db9fc7bd620eac9a99875a6e4a"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4801,8 +4803,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-groth16"
-version = "0.1.3"
-source = "git+https://github.com/TaceoLabs/circom-helpers.git?rev=e0122f8738f48a3e330e1df58558a909736c11cb#e0122f8738f48a3e330e1df58558a909736c11cb"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875d57ca43e964c44b9c9e462d053d452a0795a9655e84d9cb6113d8c9e7bead"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",
@@ -4830,7 +4833,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5503,7 +5506,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4104,14 +4104,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ name = "acir_field"
 version = "1.0.0-beta.20"
 source = "git+https://github.com/noir-lang/noir/?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
 dependencies = [
- "ark-bn254",
+ "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
  "cfg-if",
  "hex",
@@ -44,7 +44,7 @@ dependencies = [
  "acir",
  "acvm_blackbox_solver",
  "brillig_vm",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "rustc-hash",
  "serde",
@@ -145,6 +145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,25 +226,25 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ark-bls12-377"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfedac3173d12820a5e0d6cd4de31b49719a74f4a41dc09b6652d0276a3b2cd4"
+checksum = "c26d3bddbe5a0adf5bc717f5e146b977dcd686440d9e71827171b61bfbcebad6"
 dependencies = [
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -244,30 +253,44 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-std 0.5.0",
 ]
 
 [[package]]
-name = "ark-crypto-primitives"
-version = "0.5.0"
+name = "ark-bn254"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0c292754729c8a190e50414fd1a37093c786c709899f29c9f7daccecfa855e"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
+]
+
+[[package]]
+name = "ark-crypto-primitives"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b3409b1846fe459d19c95df039481575ac6d5842ae63858ad75cc31219bfc1"
 dependencies = [
  "ahash",
  "ark-crypto-primitives-macros",
- "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-r1cs-std",
  "ark-relations",
- "ark-serialize 0.5.0",
+ "ark-serialize 0.6.0",
  "ark-snark",
- "ark-std 0.5.0",
+ "ark-std 0.6.0",
  "blake2 0.10.6",
+ "blake3",
  "derivative",
  "digest 0.10.7",
  "fnv",
  "merlin",
+ "num-bigint 0.4.6",
  "rayon",
  "sha2 0.10.9",
 ]
@@ -291,13 +314,34 @@ checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
- "ark-poly",
+ "ark-poly 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
@@ -360,6 +404,23 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint 0.4.6",
+ "num-traits",
  "rayon",
  "zeroize",
 ]
@@ -389,6 +450,16 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -433,31 +504,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-groth16"
-version = "0.5.0"
+name = "ark-ff-macros"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f1d0f3a534bb54188b8dcc104307db6c56cdae574ddc3212aec0625740fc7e"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-groth16"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a293328aa422e65527e285614ce5d1dceb0bd7b8b18d18b1b63191ee1f74cb41"
 dependencies = [
  "ark-crypto-primitives",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-poly",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
  "ark-relations",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize 0.6.0",
+ "ark-snark",
+ "ark-std 0.6.0",
  "rayon",
 ]
 
 [[package]]
 name = "ark-grumpkin"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef677b59f5aff4123207c4dceb1c0ec8fdde2d4af7886f48be42ad864bfa0352"
+checksum = "c2c969a12ceed8881e5c66277dabd3e7a5aa2c72c9370f3f42eca3f2dd33a21a"
 dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -473,19 +558,57 @@ dependencies = [
  "educe",
  "fnv",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.0",
  "rayon",
 ]
 
 [[package]]
-name = "ark-relations"
-version = "0.5.1"
+name = "ark-r1cs-std"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+checksum = "291f1c6628bfcac79b0dc2adbe401aa9100e2e96daa971645e0b18fc94de9a98"
 dependencies = [
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-relations",
+ "ark-std 0.6.0",
+ "educe",
+ "itertools 0.14.0",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
  "tracing",
- "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4c11c797a64b8a23e22bf4e77bf582ac27bb21395e3183a9a506ba2561e9f9"
+dependencies = [
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "foldhash",
+ "indexmap 2.14.0",
+ "rayon",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -515,12 +638,25 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
  "num-bigint 0.4.6",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint 0.4.6",
  "rayon",
+ "serde_with",
 ]
 
 [[package]]
@@ -535,15 +671,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-snark"
-version = "0.5.1"
+name = "ark-serialize-derive"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d368e2848c2d4c129ce7679a7d0d2d612b6a274d3ea6a13bad4445d61b381b88"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
- "ark-ff 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-snark"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bdb461d2be9b2bd6f303c79fffc89f5858790a7b4d33257bca3178e2c071fb9"
+dependencies = [
+ "ark-ff 0.6.0",
  "ark-relations",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -571,6 +718,16 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -804,6 +961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +1059,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,9 +1111,9 @@ dependencies = [
 name = "circom-mpc-compiler"
 version = "0.10.0"
 dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "circom-mpc-vm",
  "clap",
  "co-groth16",
@@ -957,8 +1135,8 @@ dependencies = [
 name = "circom-mpc-vm"
 version = "0.9.0"
 dependencies = [
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "bincode",
  "co-circom-types",
  "eyre",
@@ -1041,9 +1219,9 @@ name = "co-acvm"
 version = "0.7.0"
 dependencies = [
  "acir",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "ark-grumpkin",
  "blake2 0.10.6",
  "blake3",
@@ -1075,7 +1253,7 @@ version = "0.4.0"
 dependencies = [
  "acir",
  "acvm",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "brillig",
  "eyre",
  "itertools 0.14.0",
@@ -1093,11 +1271,11 @@ name = "co-builder"
 version = "0.5.0"
 dependencies = [
  "acir",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "ark-grumpkin",
- "ark-poly",
+ "ark-poly 0.6.0",
  "blake3",
  "co-acvm",
  "co-noir-common",
@@ -1120,9 +1298,9 @@ name = "co-circom"
 version = "0.10.0"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "bincode",
  "circom-mpc-compiler",
  "circom-mpc-vm",
@@ -1143,15 +1321,15 @@ dependencies = [
  "taceo-circom-types",
  "toml",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "co-circom-types"
 version = "0.6.0"
 dependencies = [
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "eyre",
  "mpc-core",
  "num-bigint 0.4.6",
@@ -1169,13 +1347,13 @@ version = "0.10.0"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "ark-groth16",
- "ark-poly",
+ "ark-poly 0.6.0",
  "ark-relations",
- "ark-serialize 0.5.0",
+ "ark-serialize 0.6.0",
  "co-circom-types",
  "eyre",
  "mpc-core",
@@ -1185,6 +1363,7 @@ dependencies = [
  "rayon",
  "serde_json",
  "taceo-circom-types",
+ "taceo-groth16",
  "tracing",
 ]
 
@@ -1193,9 +1372,9 @@ name = "co-noir"
 version = "0.7.0"
 dependencies = [
  "acir",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "bincode",
  "clap",
  "co-acvm",
@@ -1218,19 +1397,19 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "co-noir-common"
 version = "0.2.0"
 dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "ark-grumpkin",
- "ark-poly",
- "ark-serialize 0.5.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
  "eyre",
  "itertools 0.14.0",
  "mpc-core",
@@ -1251,7 +1430,7 @@ dependencies = [
 name = "co-noir-types"
 version = "0.1.1"
 dependencies = [
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "eyre",
  "mpc-core",
  "rand 0.8.6",
@@ -1263,11 +1442,11 @@ name = "co-plonk"
 version = "0.7.0"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-poly",
- "ark-serialize 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
  "co-circom-types",
  "eyre",
  "itertools 0.14.0",
@@ -1287,10 +1466,10 @@ dependencies = [
 name = "co-ultrahonk"
 version = "0.6.0"
 dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-poly",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
  "co-noir-common",
  "criterion",
  "eyre",
@@ -1750,6 +1929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1827,6 +2007,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -2311,6 +2497,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2324,6 +2516,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -2380,6 +2575,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2629,17 @@ name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -2802,12 +3032,12 @@ dependencies = [
 name = "mpc-core"
 version = "0.10.0"
 dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "ark-grumpkin",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "bytes",
  "criterion",
  "eyre",
@@ -2856,7 +3086,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2883,8 +3113,8 @@ name = "noir-types"
 version = "0.1.1"
 dependencies = [
  "acir",
- "ark-bn254",
- "ark-ff 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ff 0.6.0",
  "co-noir-types",
  "eyre",
  "noirc_abi",
@@ -3334,7 +3564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3756,6 +3986,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4058,6 +4308,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4210,6 +4484,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -4497,16 +4790,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "taceo-ark-serde-compat"
-version = "0.5.0"
+name = "syn"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fcd6f55fec9dd131019bdc0319db2271915056607b75bf8b8bc0a6ec496347"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "taceo-ark-serde-compat"
+version = "0.6.0"
+source = "git+https://github.com/TaceoLabs/circom-helpers.git?rev=e0122f8738f48a3e330e1df58558a909736c11cb#e0122f8738f48a3e330e1df58558a909736c11cb"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "num-bigint 0.4.6",
  "serde",
 ]
@@ -4514,24 +4817,39 @@ dependencies = [
 [[package]]
 name = "taceo-circom-types"
 version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae56552ed9a44722d293640d5aedd90b9940284bf1f1bf4df727b3ce5bc34b"
+source = "git+https://github.com/TaceoLabs/circom-helpers.git?rev=e0122f8738f48a3e330e1df58558a909736c11cb#e0122f8738f48a3e330e1df58558a909736c11cb"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "ark-groth16",
- "ark-poly",
+ "ark-poly 0.6.0",
  "ark-relations",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "byteorder",
  "rayon",
  "serde",
  "serde_json",
  "taceo-ark-serde-compat",
+ "taceo-groth16",
  "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "taceo-groth16"
+version = "0.1.3"
+source = "git+https://github.com/TaceoLabs/circom-helpers.git?rev=e0122f8738f48a3e330e1df58558a909736c11cb#e0122f8738f48a3e330e1df58558a909736c11cb"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-groth16",
+ "ark-poly 0.6.0",
+ "ark-relations",
+ "eyre",
+ "rayon",
  "tracing",
 ]
 
@@ -4580,11 +4898,11 @@ version = "0.1.12"
 dependencies = [
  "acir",
  "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
  "ark-grumpkin",
- "ark-std 0.5.0",
+ "ark-std 0.6.0",
  "blake2 0.10.6",
  "blake3",
  "circom-mpc-compiler",
@@ -4616,7 +4934,7 @@ dependencies = [
  "sha3",
  "taceo-circom-types",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4684,10 +5002,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4695,6 +5015,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -4805,7 +5135,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -4819,7 +5149,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.2",
@@ -4880,7 +5210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4891,15 +5221,6 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
  "tracing-core",
 ]
 
@@ -4959,9 +5280,9 @@ dependencies = [
 name = "ultrahonk"
 version = "0.6.0"
 dependencies = [
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-poly",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
  "co-noir-common",
  "eyre",
  "itertools 0.14.0",
@@ -5153,7 +5474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5166,7 +5487,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver 1.0.28",
 ]
 
@@ -5231,10 +5552,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -5510,7 +5884,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5541,7 +5915,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5560,7 +5934,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver 1.0.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,24 +38,24 @@ brillig = { version = "1.0.0-beta.20", git = "https://github.com/noir-lang/noir/
 noirc-abi = { version = "1.0.0-beta.20", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.20", package = "noirc_abi" }
 noirc-artifacts = { version = "1.0.0-beta.20", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.20", package = "noirc_artifacts" }
 
-ark-bls12-377 = "0.5"
-ark-bls12-381 = "0.5"
-ark-bn254 = "0.5"
-ark-ec = { version = "0.5", default-features = false }
-ark-groth16 = { version = "0.5" }
-ark-ff = "0.5"
-ark-grumpkin = "0.5"
-ark-poly = "0.5"
-ark-relations = "0.5"
-ark-serialize = { version = "0.5", features = ["derive", "std"] }
-ark-std = { version = "0.5", features = ["std"] }
+ark-bls12-377 = "0.6"
+ark-bls12-381 = "0.6"
+ark-bn254 = "0.6"
+ark-ec = { version = "0.6", default-features = false }
+ark-groth16 = { version = "0.6" }
+ark-ff = "0.6"
+ark-grumpkin = "0.6"
+ark-poly = "0.6"
+ark-relations = "0.6"
+ark-serialize = { version = "0.6", features = ["derive", "std"] }
+ark-std = { version = "0.6", features = ["std"] }
 bincode = "1.3"
 blake2 = "0.10"
 blake3 = "1.6"
 bytemuck = { version = "1.25", features = ["derive"] }
 byteorder = "1.5"
 bytes = "1.11"
-circom-types = { package = "taceo-circom-types", version = "0.2" }
+circom-types = { package = "taceo-circom-types", git = "https://github.com/TaceoLabs/circom-helpers.git", rev = "e0122f8738f48a3e330e1df58558a909736c11cb", version = "0.2.5" }
 clap = { version = "4.5", features = ["derive"] }
 color-eyre = "0.6"
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ publish = false
 readme = "./README.md"
 
 [workspace.dependencies]
-acir = { version = "1.0.0-beta.20", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.20", package = "acir" }
-acvm = { version = "1.0.0-beta.20", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.20", package = "acvm" }
-brillig = { version = "1.0.0-beta.20", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.20", package = "brillig" }
-noirc-abi = { version = "1.0.0-beta.20", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.20", package = "noirc_abi" }
-noirc-artifacts = { version = "1.0.0-beta.20", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.20", package = "noirc_artifacts" }
+acir = { version = "1.0.0-beta.21", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.21", package = "acir" }
+acvm = { version = "1.0.0-beta.21", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.21", package = "acvm" }
+brillig = { version = "1.0.0-beta.21", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.21", package = "brillig" }
+noirc-abi = { version = "1.0.0-beta.21", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.21", package = "noirc_abi" }
+noirc-artifacts = { version = "1.0.0-beta.21", git = "https://github.com/noir-lang/noir/", tag = "v1.0.0-beta.21", package = "noirc_artifacts" }
 
 ark-bls12-377 = "0.6"
 ark-bls12-381 = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ ark-bls12-381 = "0.6"
 ark-bn254 = "0.6"
 ark-ec = { version = "0.6", default-features = false }
 ark-groth16 = { version = "0.6" }
-ark-ff = "0.6"
+ark-ff = { version = "0.6", features = ["asm"] }
 ark-grumpkin = "0.6"
 ark-poly = "0.6"
 ark-relations = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ libaes = "0.7"
 sha2 = { version = "0.10", features = ["compress"] }
 sha3 = "0.10"
 nom = "7"
-ruint = "1.17"
+ruint = "1.20"
 subtle = "2.6"
 thiserror = "2"
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ blake3 = "1.6"
 bytemuck = { version = "1.25", features = ["derive"] }
 byteorder = "1.5"
 bytes = "1.11"
-circom-types = { package = "taceo-circom-types", git = "https://github.com/TaceoLabs/circom-helpers.git", rev = "e0122f8738f48a3e330e1df58558a909736c11cb", version = "0.2.5" }
+circom-types = { package = "taceo-circom-types", version = "0.3.1" }
 clap = { version = "4.5", features = ["derive"] }
 color-eyre = "0.6"
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/co-circom/co-groth16/Cargo.toml
+++ b/co-circom/co-groth16/Cargo.toml
@@ -22,7 +22,7 @@ ark-ff = { workspace = true }
 ark-groth16 = { workspace = true }
 ark-poly = { workspace = true }
 ark-relations = { workspace = true }
-taceo-groth16 = { package = "taceo-groth16", git = "https://github.com/TaceoLabs/circom-helpers.git", rev = "e0122f8738f48a3e330e1df58558a909736c11cb", version = "0.1.3" }
+taceo-groth16 = { package = "taceo-groth16", version = "0.2.0" }
 ark-serialize = { workspace = true }
 co-circom-types = { version = "0.6.0", path = "../co-circom-types" }
 eyre = { workspace = true }

--- a/co-circom/co-groth16/Cargo.toml
+++ b/co-circom/co-groth16/Cargo.toml
@@ -22,6 +22,7 @@ ark-ff = { workspace = true }
 ark-groth16 = { workspace = true }
 ark-poly = { workspace = true }
 ark-relations = { workspace = true }
+taceo-groth16 = { package = "taceo-groth16", git = "https://github.com/TaceoLabs/circom-helpers.git", rev = "e0122f8738f48a3e330e1df58558a909736c11cb", version = "0.1.3" }
 ark-serialize = { workspace = true }
 co-circom-types = { version = "0.6.0", path = "../co-circom-types" }
 eyre = { workspace = true }

--- a/co-circom/co-groth16/src/groth16.rs
+++ b/co-circom/co-groth16/src/groth16.rs
@@ -4,7 +4,6 @@ use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{FftField, LegendreSymbol, PrimeField};
 use ark_groth16::{Proof, ProvingKey};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
-use taceo_groth16::ConstraintMatrices;
 use co_circom_types::{Rep3SharedWitness, ShamirSharedWitness, SharedWitness};
 use eyre::Result;
 use mpc_core::MpcState;
@@ -14,6 +13,7 @@ use mpc_core::protocols::shamir::{ShamirPreprocessing, ShamirState};
 use mpc_net::Network;
 use num_traits::ToPrimitive;
 use std::marker::PhantomData;
+use taceo_groth16::ConstraintMatrices;
 use tracing::instrument;
 
 pub use crate::mpc::CircomGroth16Prover;

--- a/co-circom/co-groth16/src/groth16.rs
+++ b/co-circom/co-groth16/src/groth16.rs
@@ -4,7 +4,7 @@ use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{FftField, LegendreSymbol, PrimeField};
 use ark_groth16::{Proof, ProvingKey};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
-use ark_relations::r1cs::ConstraintMatrices;
+use taceo_groth16::ConstraintMatrices;
 use co_circom_types::{Rep3SharedWitness, ShamirSharedWitness, SharedWitness};
 use eyre::Result;
 use mpc_core::MpcState;

--- a/co-circom/co-groth16/src/groth16.rs
+++ b/co-circom/co-groth16/src/groth16.rs
@@ -185,7 +185,7 @@ impl<P: Pairing, T: CircomGroth16Prover<P>> CoGroth16<P, T> {
 
         let (priv_acc, pub_acc) = rayon::join(
             || T::msm_public_points_hs(&query[1 + pub_len..], aux_assignment),
-            || C::msm_unchecked(&query[1..=pub_len], input_assignment),
+            || mpc_core::msm::msm_unchecked::<C>(&query[1..=pub_len], input_assignment),
         );
 
         let mut res = initial;

--- a/co-circom/co-groth16/src/groth16/reduction.rs
+++ b/co-circom/co-groth16/src/groth16/reduction.rs
@@ -2,12 +2,12 @@ use ark_ec::pairing::Pairing;
 use ark_ff::{FftField, Field, One};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_relations::utils::matrix::Matrix;
-use taceo_groth16::ConstraintMatrices;
 use eyre::Result;
 use mpc_core::MpcState;
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
 };
+use taceo_groth16::ConstraintMatrices;
 use tracing::instrument;
 
 use crate::mpc::CircomGroth16Prover;

--- a/co-circom/co-groth16/src/groth16/reduction.rs
+++ b/co-circom/co-groth16/src/groth16/reduction.rs
@@ -1,7 +1,8 @@
 use ark_ec::pairing::Pairing;
 use ark_ff::{FftField, Field, One};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
-use ark_relations::r1cs::{ConstraintMatrices, Matrix};
+use ark_relations::utils::matrix::Matrix;
+use taceo_groth16::ConstraintMatrices;
 use eyre::Result;
 use mpc_core::MpcState;
 use rayon::iter::{

--- a/co-circom/co-groth16/src/lib.rs
+++ b/co-circom/co-groth16/src/lib.rs
@@ -13,7 +13,7 @@ pub use groth16::{
 };
 
 pub use ark_groth16::{Proof, ProvingKey, VerifyingKey};
-pub use ark_relations::r1cs::ConstraintMatrices;
+pub use taceo_groth16::ConstraintMatrices;
 
 #[cfg(test)]
 #[cfg(feature = "verifier")]
@@ -22,7 +22,8 @@ mod tests {
     use ark_bls12_381::Bls12_381;
     use ark_bn254::Bn254;
     use ark_groth16::{ProvingKey, VerifyingKey};
-    use ark_relations::r1cs::{ConstraintMatrices, Matrix};
+    use ark_relations::utils::matrix::Matrix;
+    use taceo_groth16::ConstraintMatrices;
     use ark_serialize::CanonicalDeserialize;
     use circom_types::{
         CheckElement, Witness,

--- a/co-circom/co-groth16/src/lib.rs
+++ b/co-circom/co-groth16/src/lib.rs
@@ -23,7 +23,6 @@ mod tests {
     use ark_bn254::Bn254;
     use ark_groth16::{ProvingKey, VerifyingKey};
     use ark_relations::utils::matrix::Matrix;
-    use taceo_groth16::ConstraintMatrices;
     use ark_serialize::CanonicalDeserialize;
     use circom_types::{
         CheckElement, Witness,
@@ -34,6 +33,7 @@ mod tests {
     };
     use co_circom_types::SharedWitness;
     use std::fs::{self, File};
+    use taceo_groth16::ConstraintMatrices;
 
     use crate::{CircomReduction, LibSnarkReduction, groth16::Groth16};
 

--- a/co-circom/co-groth16/src/mpc/plain.rs
+++ b/co-circom/co-groth16/src/mpc/plain.rs
@@ -69,7 +69,7 @@ impl<P: Pairing> CircomGroth16Prover<P> for PlainGroth16Driver {
     where
         C: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
     {
-        C::msm_unchecked(points, scalars)
+        mpc_core::msm::msm_unchecked::<C>(points, scalars)
     }
 
     fn promote_to_trivial_shares(

--- a/co-circom/co-groth16/src/mpc/rep3.rs
+++ b/co-circom/co-groth16/src/mpc/rep3.rs
@@ -127,7 +127,7 @@ impl<P: Pairing> CircomGroth16Prover<P> for Rep3Groth16Driver {
     where
         C: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
     {
-        C::msm_unchecked(points, scalars)
+        mpc_core::msm::msm_unchecked::<C>(points, scalars)
     }
 
     fn scalar_mul_public_point_hs<C>(a: &C, b: Self::ArithmeticHalfShare) -> Self::PointHalfShare<C>

--- a/co-circom/co-groth16/src/mpc/shamir.rs
+++ b/co-circom/co-groth16/src/mpc/shamir.rs
@@ -114,7 +114,7 @@ impl<P: Pairing> CircomGroth16Prover<P> for ShamirGroth16Driver {
     where
         C: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
     {
-        C::msm_unchecked(points, scalars)
+        mpc_core::msm::msm_unchecked::<C>(points, scalars)
     }
 
     fn scalar_mul_public_point_hs<C>(a: &C, b: Self::ArithmeticHalfShare) -> Self::PointHalfShare<C>

--- a/co-circom/co-plonk/src/mpc/plain.rs
+++ b/co-circom/co-plonk/src/mpc/plain.rs
@@ -1,5 +1,4 @@
 use ark_ec::pairing::Pairing;
-use ark_ec::scalar_mul::variable_base::VariableBaseMSM;
 use ark_ff::Field;
 use ark_ff::UniformRand;
 use ark_poly::Polynomial;
@@ -176,7 +175,7 @@ impl<P: Pairing> CircomPlonkProver<P> for PlainPlonkDriver {
         points: &[P::G1Affine],
         scalars: &[Self::ArithmeticShare],
     ) -> Self::PointShareG1 {
-        P::G1::msm_unchecked(points, scalars)
+        mpc_core::msm::msm_unchecked::<P::G1>(points, scalars)
     }
 
     fn evaluate_poly_public(

--- a/co-noir/co-acvm/src/solver/memory_solver.rs
+++ b/co-noir/co-acvm/src/solver/memory_solver.rs
@@ -1,12 +1,10 @@
 use crate::mpc::NoirWitnessExtensionProtocol;
 use acir::{
     acir_field::GenericFieldElement,
-    circuit::opcodes::{BlockId, MemOp},
+    circuit::opcodes::{BlockId, MemOp, MemOpKind},
     native_types::Witness,
 };
 use ark_ff::PrimeField;
-
-use crate::solver::solver_utils;
 
 use super::{CoAcvmResult, CoSolver};
 
@@ -49,59 +47,37 @@ where
         op: &MemOp<GenericFieldElement<F>>,
     ) -> CoAcvmResult<()> {
         tracing::trace!("solving memory op {:?}", op);
-        let index = self.evaluate_expression(&op.index)?;
+        let index = Self::witness_to_value(self.witness(), op.index)?.to_owned();
         tracing::trace!("index is {}", index);
-        let value = self.simplify_expression(&op.value)?;
-        tracing::trace!("value is {}", solver_utils::expr_to_string(&value));
-        let read_write = op.operation.q_c.into_repr();
-        if read_write.is_zero() {
-            // read the value from the LUT
-            tracing::trace!("reading value from LUT");
-            // this is the to_witness method. We cannot call it on AcvmType because
-            // of AcirField trait bound - maybe put it at some utils method
-            // if we need it more than once
-            let witness = if value.is_degree_one_univariate() {
-                //we can get the witness
-                let (coef, witness) = &value.linear_combinations[0];
-                if T::is_public_one(coef) && T::is_public_zero(&value.q_c) {
-                    Ok(*witness)
-                } else {
-                    Err(eyre::eyre!(
-                        "value for mem op must be a degree one univariate polynomial with coef 1 and constant 0"
-                    ))
-                }
-            } else {
-                Err(eyre::eyre!(
-                    "value for mem op must be a degree one univariate polynomial"
-                ))
-            }?;
-            let lut = self
-                .memory_access
-                .get(block_id.0.into())
-                .ok_or(eyre::eyre!(
-                    "tried to access block {} but not present",
-                    block_id.0
-                ))?;
-            let value = self.driver.read_lut_by_acvm_type(index, lut)?;
+        match op.operation {
+            MemOpKind::Read => {
+                // read the value from the LUT
+                tracing::trace!("reading value from LUT");
+                let lut = self
+                    .memory_access
+                    .get(block_id.0.into())
+                    .ok_or(eyre::eyre!(
+                        "tried to access block {} but not present",
+                        block_id.0
+                    ))?;
+                let value = self.driver.read_lut_by_acvm_type(index, lut)?;
 
-            self.witness().insert(witness, value);
-        } else if read_write.is_one() {
-            // write value to LUT
-            tracing::trace!("writing value to LUT");
-            let lut = self
-                .memory_access
-                .get_mut(block_id.0.into())
-                .ok_or(eyre::eyre!(
-                    "tried to access block {} but not present",
-                    block_id.0
-                ))?;
+                self.witness().insert(op.value, value);
+            }
+            MemOpKind::Write => {
+                // write value to LUT
+                tracing::trace!("writing value to LUT");
+                let value = Self::witness_to_value(self.witness(), op.value)?.to_owned();
+                let lut = self
+                    .memory_access
+                    .get_mut(block_id.0.into())
+                    .ok_or(eyre::eyre!(
+                        "tried to access block {} but not present",
+                        block_id.0
+                    ))?;
 
-            self.driver.write_lut_by_acvm_type(index, value.q_c, lut)?;
-        } else {
-            Err(eyre::eyre!(
-                "Got unknown operation {} for mem op - this is a bug",
-                op.operation.q_c
-            ))?
+                self.driver.write_lut_by_acvm_type(index, value, lut)?;
+            }
         }
         Ok(())
     }

--- a/co-noir/co-builder/src/acir_format.rs
+++ b/co-noir/co-builder/src/acir_format.rs
@@ -2,7 +2,7 @@ use acir::{
     acir_field::GenericFieldElement,
     circuit::{
         Circuit,
-        opcodes::{BlackBoxFuncCall, FunctionInput, MemOp as AcirMemOp},
+        opcodes::{BlackBoxFuncCall, FunctionInput, MemOp as AcirMemOp, MemOpKind},
     },
     native_types::{Expression, Witness, WitnessMap},
 };
@@ -331,9 +331,8 @@ impl<F: PrimeField> AcirFormat<F> {
                 }
             }
             acir::circuit::Opcode::MemoryOp { op, .. } => {
-                self.update_max_witness_index_from_expression(&op.index);
-                self.update_max_witness_index_from_expression(&op.value);
-                self.update_max_witness_index_from_expression(&op.operation);
+                update_max_witness_index_from_witness(self, &op.index);
+                update_max_witness_index_from_witness(self, &op.value);
             }
             acir::circuit::Opcode::BrilligCall {
                 inputs,
@@ -911,74 +910,9 @@ impl<F: PrimeField> AcirFormat<F> {
         mem_op: AcirMemOp<GenericFieldElement<F>>,
         block: &mut BlockConstraint<F>,
     ) {
-        // Convert an Acir expression to witness index
-        let acir_expression_to_witness_or_constant =
-            |expr: &Expression<GenericFieldElement<F>>| -> WitnessOrConstant<F> {
-                // Noir gives us witnesses or constants for read/write operations. We use the following assertions to ensure
-                // that the data coming from Noir is in the correct form.
-                assert!(
-                    expr.mul_terms.is_empty(),
-                    "MemoryOp should not have multiplication terms"
-                );
-                assert!(
-                    expr.linear_combinations.len() <= 1,
-                    "MemoryOp should have at most one linear term"
-                );
-
-                let a_scaling = if expr.linear_combinations.len() == 1 {
-                    expr.linear_combinations[0].0.into_repr()
-                } else {
-                    F::zero()
-                };
-                let constant_term = expr.q_c.into_repr();
-
-                let is_witness = a_scaling.is_one() && constant_term.is_zero();
-                let is_constant = a_scaling.is_zero();
-                assert!(
-                    is_witness || is_constant,
-                    "MemoryOp expression must be a witness or a constant"
-                );
-
-                WitnessOrConstant {
-                    index: if is_witness {
-                        expr.linear_combinations[0].1.0
-                    } else {
-                        u32::MAX
-                    },
-                    value: if is_constant {
-                        constant_term
-                    } else {
-                        F::zero()
-                    },
-                    is_constant,
-                }
-            };
-
-        // Determine whether this op is read or write.
-        let is_read_operation = |expr: &Expression<GenericFieldElement<F>>| -> bool {
-            assert!(
-                expr.mul_terms.is_empty(),
-                "MemoryOp expression should not have multiplication terms"
-            );
-            assert!(
-                expr.linear_combinations.is_empty(),
-                "MemoryOp expression should not have linear terms"
-            );
-
-            let const_term = expr.q_c.into_repr();
-            assert!(
-                const_term.is_one() || const_term.is_zero(),
-                "MemoryOp expression should be either zero or one"
-            );
-
-            // A read operation is encoded by a zero expression.
-            const_term.is_zero()
-        };
-
-        let access_type = if is_read_operation(&mem_op.operation) {
-            0 // Read
-        } else {
-            1 // Write
+        let access_type = match mem_op.operation {
+            MemOpKind::Read => 0,
+            MemOpKind::Write => 1,
         };
 
         if access_type == 1 {
@@ -988,8 +922,8 @@ impl<F: PrimeField> AcirFormat<F> {
             block.type_ = BlockType::RAM;
         }
 
-        let index = acir_expression_to_witness_or_constant(&mem_op.index);
-        let value = acir_expression_to_witness_or_constant(&mem_op.value);
+        let index = WitnessOrConstant::from_index(mem_op.index.0);
+        let value = WitnessOrConstant::from_index(mem_op.value.0);
 
         let acir_mem_op = MemOp {
             access_type,

--- a/co-noir/co-noir-common/src/mpc/plain.rs
+++ b/co-noir/co-noir-common/src/mpc/plain.rs
@@ -268,7 +268,7 @@ impl<P: CurveGroup> NoirUltraHonkProver<P> for PlainUltraHonkDriver {
         points: &[P::Affine],
         scalars: &[Self::ArithmeticShare],
     ) -> Self::PointShare {
-        P::msm_unchecked(points, scalars)
+        mpc_core::msm::msm_unchecked::<P>(points, scalars)
     }
 
     fn eval_poly(coeffs: &[Self::ArithmeticShare], point: P::ScalarField) -> Self::ArithmeticShare {

--- a/co-noir/co-noir-common/src/utils.rs
+++ b/co-noir/co-noir-common/src/utils.rs
@@ -35,7 +35,7 @@ impl Utils {
         if poly.len() > crs.len() {
             return Err(HonkProofError::CrsTooSmall);
         }
-        Ok(P::msm_unchecked(crs, poly))
+        Ok(mpc_core::msm::msm_unchecked::<P>(crs, poly))
     }
 
     pub fn get_msb32(inp: u32) -> u32 {

--- a/co-noir/co-noir/Readme.md
+++ b/co-noir/co-noir/Readme.md
@@ -27,7 +27,7 @@ First, one needs to create the circuit file from a Noir source code. Your Noir p
 - `Nargo.toml`: Similar to Cargo.toml, just for Noir projects.
 - `Prover.toml`: The inputs for the main function in `src/main.nr` used in proof generation.
 
-To create the circuit file used in Co-Noir, one needs to install Nargo following the instructions in [https://noir-lang.org/docs/getting_started/noir_installation/](https://noir-lang.org/docs/getting_started/noir_installation/). Our prover is compatible with Nargo version v1.0.0-beta.20.
+To create the circuit file used in Co-Noir, one needs to install Nargo following the instructions in [https://noir-lang.org/docs/getting_started/noir_installation/](https://noir-lang.org/docs/getting_started/noir_installation/). Our prover is compatible with Nargo version v1.0.0-beta.21.
 Then you can just execute the following command:
 
 ```bash

--- a/co-noir/co-noir/examples/compare.sh
+++ b/co-noir/co-noir/examples/compare.sh
@@ -1,7 +1,7 @@
 export CARGO_TERM_QUIET=true
 BARRETENBERG_BINARY=~/.bb/bb  ##specify the $BARRETENBERG_BINARY path here
 
-NARGO_VERSION=1.0.0-beta.20 ##specify the desired nargo version here
+NARGO_VERSION=1.0.0-beta.21 ##specify the desired nargo version here
 BARRETENBERG_VERSION=5.0.0-nightly.20260324 ##specify the desired barretenberg version here or use the corresponding one for this nargo version
 PLAINDRIVER="../../../target/release/plaindriver"
 exit_code=0

--- a/co-noir/co-noir/examples/compare_mpc.sh
+++ b/co-noir/co-noir/examples/compare_mpc.sh
@@ -2,7 +2,7 @@ export CARGO_TERM_QUIET=true
 export RAYON_NUM_THREADS=$(($(nproc --all)/3)) # Limit the number of threads to prevent parties stealing from each other
 BARRETENBERG_BINARY=~/.bb/bb  ##specify the $BARRETENBERG_BINARY path here
 
-NARGO_VERSION=1.0.0-beta.20 ##specify the desired nargo version here
+NARGO_VERSION=1.0.0-beta.21 ##specify the desired nargo version here
 BARRETENBERG_VERSION=5.0.0-nightly.20260324 ##specify the desired barretenberg version here or use the corresponding one for this nargo version
 
 exit_code=0

--- a/co-noir/co-noir/examples/compile.sh
+++ b/co-noir/co-noir/examples/compile.sh
@@ -2,7 +2,7 @@
 
 script_dir="$(dirname "$(realpath "$0")")"
 
-NARGO_VERSION=1.0.0-beta.20 ##specify the desired nargo version here
+NARGO_VERSION=1.0.0-beta.21 ##specify the desired nargo version here
 
 ## install noirup: curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
 r=$(bash -c "nargo --version")

--- a/mpc-core/src/lib.rs
+++ b/mpc-core/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod gadgets;
 pub mod lut;
+pub mod msm;
 pub mod protocols;
 pub mod serde_compat;
 

--- a/mpc-core/src/msm.rs
+++ b/mpc-core/src/msm.rs
@@ -1,0 +1,206 @@
+//! Temporary variable-base MSM implementation for co-snarks.
+//! This is a temporary performance workaround for the Arkworks 0.6
+//! `msm_bigint_wnaf` scheduling strategy. Arkworks splits each MSM according to
+//! the total Rayon pool size, which performs poorly when co-snarks runs several
+//! MSMs concurrently.
+
+use ark_ec::{CurveGroup, VariableBaseMSM};
+use ark_ff::{BigInteger, PrimeField};
+use rayon::prelude::*;
+
+/// Computes an inner product between the [`PrimeField`] elements in `scalars`
+/// and the corresponding group elements in `bases`.
+///
+/// If the elements have different length, it will chop the slices to the
+/// shortest length between `scalars.len()` and `bases.len()`.
+///
+/// Reference: [`VariableBaseMSM::msm_unchecked`]
+pub fn msm_unchecked<C: CurveGroup>(bases: &[C::Affine], scalars: &[C::ScalarField]) -> C {
+    let bigints = scalars
+        .par_iter()
+        .map(|scalar| scalar.into_bigint())
+        .collect::<Vec<_>>();
+    msm_bigint::<C>(bases, &bigints)
+}
+
+/// Optimized implementation of multi-scalar multiplication.
+///
+/// WARNING: This is a temporary performance workaround for the Arkworks 0.6
+/// `msm_bigint_wnaf` scheduling strategy. Arkworks splits each MSM according to
+/// the total Rayon pool size, which performs poorly when co-snarks runs several
+/// MSMs concurrently.
+///
+/// TODO: Replace this implementation with the upstream Arkworks MSM once its
+/// parallel scheduling composes efficiently with nested/concurrent callers.
+pub fn msm_bigint<V: VariableBaseMSM>(
+    bases: &[V::MulBase],
+    bigints: &[<V::ScalarField as PrimeField>::BigInt],
+) -> V {
+    msm_bigint_wnaf::<V>(bases, bigints)
+}
+
+// Compute msm using windowed non-adjacent form
+fn msm_bigint_wnaf_parallel<V: VariableBaseMSM>(
+    bases: &[V::MulBase],
+    bigints: &[<V::ScalarField as PrimeField>::BigInt],
+) -> V {
+    let size = bases.len().min(bigints.len());
+    let scalars = &bigints[..size];
+    let bases = &bases[..size];
+
+    let c = if size < 32 {
+        3
+    } else {
+        ln_without_floats(size) + 2
+    };
+
+    let num_bits = V::ScalarField::MODULUS_BIT_SIZE as usize;
+    let digits_count = num_bits.div_ceil(c);
+    let scalar_digits = scalars
+        .par_iter()
+        .flat_map_iter(|s| make_digits(s, c, num_bits))
+        .collect::<Vec<_>>();
+
+    let zero = V::ZERO_BUCKET;
+    let window_sums: Vec<_> = (0..digits_count)
+        .into_par_iter()
+        .map(|i| {
+            let mut buckets = vec![zero; 1 << c];
+            for (digits, base) in scalar_digits.chunks(digits_count).zip(bases) {
+                use std::cmp::Ordering;
+                let scalar = digits[i];
+                match 0.cmp(&scalar) {
+                    Ordering::Less => buckets[(scalar - 1) as usize] += base,
+                    Ordering::Greater => buckets[(-scalar - 1) as usize] -= base,
+                    Ordering::Equal => (),
+                }
+            }
+
+            // prefix sum
+            let mut running_sum = V::ZERO_BUCKET;
+            let mut res = V::ZERO_BUCKET;
+            buckets.into_iter().rev().for_each(|b| {
+                running_sum += &b;
+                res += &running_sum;
+            });
+            res
+        })
+        .collect();
+
+    // We store the sum for the lowest window.
+    let lowest: V = (*window_sums.first().unwrap()).into();
+
+    // We're traversing windows from high to low.
+    lowest
+        + (&window_sums[1..])
+            .iter()
+            .rev()
+            .fold(V::ZERO, |mut total, sum_i| {
+                total += sum_i;
+                for _ in 0..c {
+                    total.double_in_place();
+                }
+                total
+            })
+}
+
+/// Computes an MSM using the windowed non-adjacent form (WNAF) algorithm.
+fn msm_bigint_wnaf<V: VariableBaseMSM>(
+    bases: &[V::MulBase],
+    scalars: &[<V::ScalarField as PrimeField>::BigInt],
+) -> V {
+    let size = bases.len().min(scalars.len());
+    if size == 0 {
+        return V::ZERO;
+    }
+
+    // WARNING: Unlike Arkworks 0.6, do not split this into per-thread chunks.
+    // Doing so regresses co-snarks because several MSMs already run concurrently.
+    msm_bigint_wnaf_parallel::<V>(&bases[..size], &scalars[..size])
+}
+
+const fn log2(value: usize) -> u32 {
+    if value == 0 {
+        0
+    } else if value.is_power_of_two() {
+        1usize.leading_zeros() - value.leading_zeros()
+    } else {
+        0usize.leading_zeros() - value.leading_zeros()
+    }
+}
+
+/// The result of this function is only approximately `ln(a)`
+/// [`Explanation of usage`]
+///
+/// [`Explanation of usage`]: https://github.com/scipr-lab/zexe/issues/79#issue-556220473
+const fn ln_without_floats(a: usize) -> usize {
+    // log2(a) * ln(2)
+    (log2(a) * 69 / 100) as usize
+}
+
+// From: https://github.com/arkworks-rs/gemini/blob/main/src/kzg/msm/variable_base.rs#L20
+fn make_digits(a: &impl BigInteger, w: usize, num_bits: usize) -> impl Iterator<Item = i64> + '_ {
+    let scalar = a.as_ref();
+    let radix: u64 = 1 << w;
+    let window_mask: u64 = radix - 1;
+
+    let mut carry = 0u64;
+    let num_bits = if num_bits == 0 {
+        a.num_bits() as usize
+    } else {
+        num_bits
+    };
+    let digits_count = num_bits.div_ceil(w);
+
+    (0..digits_count).map(move |i| {
+        // Construct a buffer of bits of the scalar, starting at `bit_offset`.
+        let bit_offset = i * w;
+        let u64_idx = bit_offset / 64;
+        let bit_idx = bit_offset % 64;
+        // Read the bits from the scalar
+        let bit_buf = if bit_idx < 64 - w || u64_idx == scalar.len() - 1 {
+            // This window's bits are contained in a single u64,
+            // or it's the last u64 anyway.
+            scalar[u64_idx] >> bit_idx
+        } else {
+            // Combine the current u64's bits with the bits from the next u64
+            (scalar[u64_idx] >> bit_idx) | (scalar[1 + u64_idx] << (64 - bit_idx))
+        };
+
+        // Read the actual coefficient value from the window
+        let coef = carry + (bit_buf & window_mask); // coef = [0, 2^r)
+
+        // Recenter coefficients from [0,2^w) to [-2^w/2, 2^w/2)
+        carry = (coef + radix / 2) >> w;
+        let mut digit = (coef as i64) - (carry << w) as i64;
+
+        if i == digits_count - 1 {
+            digit += (carry << w) as i64;
+        }
+        digit
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bn254::{Fr, G1Projective};
+    use ark_ff::UniformRand;
+    use rand::{SeedableRng, rngs::StdRng};
+
+    #[test]
+    fn matches_arkworks_msm() {
+        let mut rng = StdRng::seed_from_u64(0x5eed);
+        for size in [0, 1, 31, 32, 213, 810] {
+            let projective = (0..size)
+                .map(|_| G1Projective::rand(&mut rng))
+                .collect::<Vec<_>>();
+            let bases = G1Projective::normalize_batch(&projective);
+            let scalars = (0..size).map(|_| Fr::rand(&mut rng)).collect::<Vec<_>>();
+
+            let expected = G1Projective::msm_unchecked(&bases, &scalars);
+            let actual = msm_unchecked::<G1Projective>(&bases, &scalars);
+            assert_eq!(actual, expected);
+        }
+    }
+}

--- a/mpc-core/src/msm.rs
+++ b/mpc-core/src/msm.rs
@@ -92,7 +92,7 @@ fn msm_bigint_wnaf_parallel<V: VariableBaseMSM>(
 
     // We're traversing windows from high to low.
     lowest
-        + (&window_sums[1..])
+        + window_sums[1..]
             .iter()
             .rev()
             .fold(V::ZERO, |mut total, sum_i| {

--- a/mpc-core/src/protocols/rep3/pointshare.rs
+++ b/mpc-core/src/protocols/rep3/pointshare.rs
@@ -208,8 +208,8 @@ pub fn msm_public_points<C: CurveGroup>(
         .map(|share| (share.a.into_bigint(), share.b.into_bigint()))
         .collect::<(Vec<_>, Vec<_>)>();
     let (res_a, res_b) = rayon::join(
-        || C::msm_bigint(points, &a_bigints),
-        || C::msm_bigint(points, &b_bigints),
+        || crate::msm::msm_bigint::<C>(points, &a_bigints),
+        || crate::msm::msm_bigint::<C>(points, &b_bigints),
     );
     tracing::trace!("< MSM public points for {} elements", points.len());
     PointShare::new(res_a, res_b)

--- a/mpc-core/src/protocols/shamir/pointshare.rs
+++ b/mpc-core/src/protocols/shamir/pointshare.rs
@@ -209,10 +209,8 @@ pub fn msm_public_points<C: CurveGroup>(
 ) -> PointShare<C> {
     tracing::trace!("> MSM public points for {} elements", points.len());
     debug_assert_eq!(points.len(), scalars.len());
-    let res = crate::msm::msm_unchecked::<C>(
-        points,
-        &scalars.iter().map(|s| s.a).collect::<Vec<_>>(),
-    );
+    let res =
+        crate::msm::msm_unchecked::<C>(points, &scalars.iter().map(|s| s.a).collect::<Vec<_>>());
     tracing::trace!("< MSM public points for {} elements", points.len());
     PointShare::<C> { a: res }
 }

--- a/mpc-core/src/protocols/shamir/pointshare.rs
+++ b/mpc-core/src/protocols/shamir/pointshare.rs
@@ -209,7 +209,10 @@ pub fn msm_public_points<C: CurveGroup>(
 ) -> PointShare<C> {
     tracing::trace!("> MSM public points for {} elements", points.len());
     debug_assert_eq!(points.len(), scalars.len());
-    let res = C::msm_unchecked(points, &scalars.iter().map(|s| s.a).collect::<Vec<_>>());
+    let res = crate::msm::msm_unchecked::<C>(
+        points,
+        &scalars.iter().map(|s| s.a).collect::<Vec<_>>(),
+    );
     tracing::trace!("< MSM public points for {} elements", points.len());
     PointShare::<C> { a: res }
 }

--- a/test_vectors/noir/compile.sh
+++ b/test_vectors/noir/compile.sh
@@ -2,7 +2,7 @@
 
 script_dir="$(dirname "$(realpath "$0")")"
 
-NARGO_VERSION=1.0.0-beta.20 ##specify the desired nargo version here
+NARGO_VERSION=1.0.0-beta.21 ##specify the desired nargo version here
 
 ## install noirup: curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
 r=$(bash -c "nargo --version")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large dependency upgrade across proof systems (Groth16, Plonk, Honk) plus a custom MSM on the hot path; correctness and performance need regression coverage on MPC proving.
> 
> **Overview**
> Bumps the workspace to **arkworks 0.6**, **Noir/ACIR v1.0.0-beta.21**, **`taceo-circom-types` 0.3.1**, and **`ruint` 1.20**, with matching `Cargo.lock` churn (e.g. ark 0.6, crypto crate version splits).
> 
> **Groth16 / Circom:** `ConstraintMatrices` now comes from **`taceo-groth16`** instead of `ark_relations::r1cs`; **`co-groth16`** depends on **`taceo-groth16`**. Matrix types use **`ark_relations::utils::matrix::Matrix`**.
> 
> **MSM:** Adds **`mpc-core::msm`** with a custom WNAF MSM that avoids Ark 0.6’s Rayon pool–based chunking when many MSMs run in parallel. Groth16, Plonk, Honk paths, and rep3/shamir point MSMs route through **`mpc_core::msm::msm_unchecked`** / **`msm_bigint`** instead of **`CurveGroup::msm_unchecked`**.
> 
> **Noir / ACIR beta.21:** Memory ops use **`MemOpKind::Read`/`Write`** and witness indices directly (co-acvm solver, co-builder `acir_format`). Docs and example scripts target **Nargo beta.21**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a872295fa8800bbc7d14e1d15ae7b7669b2d1901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->