### PR TITLE
feat: add shamir bridge QoL prove for REP3

### DIFF
--- a/co-circom/co-groth16/src/groth16.rs
+++ b/co-circom/co-groth16/src/groth16.rs
@@ -5,7 +5,7 @@ use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{FftField, LegendreSymbol, PrimeField};
 use ark_groth16::{Proof, ProvingKey};
 use co_circom_types::{Rep3SharedWitness, ShamirSharedWitness, SharedWitness};
-use eyre::Result;
+use eyre::{Context, Result};
 use mpc_core::MpcState;
 use mpc_core::protocols::rep3::Rep3State;
 use mpc_core::protocols::rep3::conversion::A2BType;
@@ -349,7 +349,14 @@ where
     C1: SWCurveConfig<ScalarField = P::ScalarField>,
     C2: SWCurveConfig<ScalarField = P::ScalarField>,
 {
-    /// Create a [`Proof`].
+    /// Create a [`Proof`] by running the collaborative Groth16 prover under 3-party replicated
+    /// (REP3) secret sharing, secure against a single semi-honest corruption.
+    ///
+    /// `net0` and `net1` must be two independent networks connecting the same three parties,
+    /// since the prover runs two network legs concurrently. All three parties return the same
+    /// [`Proof`]. If the Shamir prover is available to all parties,
+    /// [`Self::prove_with_shamir_bridge`] produces a proof under the same trust assumption with a
+    /// cheaper online phase.
     pub fn prove<N: Network, R: R1CSToQAP>(
         net0: &N,
         net1: &N,
@@ -370,6 +377,44 @@ where
             witness,
         )
     }
+
+    /// Create a [`Proof`] by locally translating the REP3 `witness` into a 3-party Shamir
+    /// sharing (threshold 1) via [`ShamirState::translate_primefield_repshare_vec`], and then
+    /// running [`ShamirCoGroth16::prove`]. The translation requires no communication, but it is
+    /// deterministic and consumes no fresh randomness, so it is a hand-off, not a re-sharing: the
+    /// REP3 witness shares must not be reused after calling this.
+    ///
+    /// This is typically faster than [`Self::prove`], since the Shamir prover's online phase is
+    /// cheaper, while keeping the same trust assumption (3 parties, at most one semi-honest
+    /// corruption). The resulting proof differs from one produced by [`Self::prove`] only through
+    /// fresh randomness (`r`, `s`); both verify under the same verification key.
+    ///
+    /// # Errors
+    /// Returns an error if `net0.id()` is not a valid REP3 party id (0, 1, or 2).
+    pub fn prove_with_shamir_bridge<N: Network, R: R1CSToQAP>(
+        net0: &N,
+        net1: &N,
+        pkey: &ProvingKey<P>,
+        matrices: &ConstraintMatrices<P::ScalarField>,
+        witness: Rep3SharedWitness<P::ScalarField>,
+    ) -> eyre::Result<Proof<P>> {
+        let translated_witness = ShamirState::translate_primefield_repshare_vec(
+            witness.witness,
+            net0.id().try_into().context("not a valid party id")?,
+        );
+        ShamirCoGroth16::prove::<_, R>(
+            net0,
+            net1,
+            3, // number of parties is 3 for REP3
+            1, // threshold is 1 for REP3
+            pkey,
+            matrices,
+            SharedWitness {
+                public_inputs: witness.public_inputs,
+                witness: translated_witness,
+            },
+        )
+    }
 }
 
 impl<P, C1, C2> ShamirCoGroth16<P>
@@ -383,7 +428,14 @@ where
     C1: SWCurveConfig<ScalarField = P::ScalarField>,
     C2: SWCurveConfig<ScalarField = P::ScalarField>,
 {
-    /// Create a [`Proof`].
+    /// Create a [`Proof`] by running the collaborative Groth16 prover under Shamir secret
+    /// sharing, secure against `threshold` semi-honest corruptions among `num_parties` parties.
+    /// `num_parties` must be at least `2 * threshold + 1`, since `g_c` is opened as a
+    /// degree-`2*threshold` sharing.
+    ///
+    /// `net0` and `net1` must be two independent networks connecting all parties: correlated
+    /// randomness is preprocessed over `net0` before the online phase, and the online phase
+    /// itself runs two network legs concurrently.
     pub fn prove<N: Network, R: R1CSToQAP>(
         net0: &N,
         net1: &N,
@@ -426,6 +478,9 @@ where
     /// initialized with the [`PlainGroth16Driver`].
     ///
     /// DOES NOT PERFORM ANY MPC. For a plain prover checkout the [Groth16 implementation of arkworks](https://docs.rs/ark-groth16/latest/ark_groth16/).
+    ///
+    /// Takes the proving key and constraint matrices from the zkey, and the full witness (public
+    /// inputs plus private witness) in the clear.
     pub fn plain_prove<R: R1CSToQAP>(
         pkey: &ProvingKey<P>,
         matrices: &ConstraintMatrices<P::ScalarField>,

--- a/tests/tests/circom/e2e_tests/rep3.rs
+++ b/tests/tests/circom/e2e_tests/rep3.rs
@@ -86,6 +86,57 @@ macro_rules! add_test_impl_g16 {
             }
 
             #[test]
+            fn [< e2e_proof_ $name _ $curve:lower _ groth16_shamir_bridge>] () {
+                let zkey_file =
+                    File::open(format!("../test_vectors/{}/{}/{}/circuit.zkey", "Groth16", stringify!([< $curve:lower >]), $name)).unwrap();
+                let r1cs_file =
+                    File::open(format!("../test_vectors/{}/{}/{}/circuit.r1cs", "Groth16", stringify!([< $curve:lower >]), $name)).unwrap();
+                let witness_file =
+                    File::open(format!("../test_vectors/{}/{}/{}/witness.wtns", "Groth16", stringify!([< $curve:lower >]), $name)).unwrap();
+                let witness = Witness::<[< ark_ $curve:lower >]::Fr>::from_reader(witness_file).unwrap();
+                let zkey1 = Groth16ZK::<$curve>::from_reader(zkey_file, CheckElement::No).unwrap();
+                let zkey1: (ConstraintMatrices<_>, ProvingKey<_>) = zkey1.into();
+                let zkey1 = Arc::new(zkey1);
+                let zkey2 = Arc::clone(&zkey1);
+                let zkey3 = Arc::clone(&zkey1);
+                let r1cs = R1CS::<$curve>::from_reader(r1cs_file).unwrap();
+                //ignore leading 1 for verification
+                let public_input = witness.values[1..r1cs.num_inputs].to_vec();
+                let mut rng = thread_rng();
+                let [witness_share1, witness_share2, witness_share3] =
+                    SharedWitness::share_rep3(witness, r1cs.num_inputs, &mut rng);
+                let nets0 = LocalNetwork::new_3_parties();
+                let nets1 = LocalNetwork::new_3_parties();
+                let mut threads = vec![];
+                for (net0, net1, x, zkey) in izip!(
+                    nets0,
+                    nets1,
+                    [witness_share1, witness_share2, witness_share3].into_iter(),
+                    [zkey1, zkey2, zkey3].into_iter()
+                ) {
+                    threads.push(std::thread::spawn(move || {
+                        Rep3CoGroth16::<$curve>::prove_with_shamir_bridge::<_, CircomReduction>(&net0, &net1, &zkey.1, &zkey.0, x).unwrap()
+                    }));
+                }
+                let result3 = threads.pop().unwrap().join().unwrap();
+                let result2 = threads.pop().unwrap().join().unwrap();
+                let result1 = threads.pop().unwrap().join().unwrap();
+                assert_eq!(result1, result2);
+                assert_eq!(result2, result3);
+                let proof = CircomGroth16Proof::from(result1);
+                let ser_proof = serde_json::to_string(&proof).unwrap();
+                let der_proof = serde_json::from_str::<CircomGroth16Proof<$curve>>(&ser_proof).unwrap();
+                let vk: Groth16VK<$curve> = serde_json::from_reader(
+                    File::open(format!("../test_vectors/{}/{}/{}/verification_key.json", "Groth16", stringify!([< $curve:lower >]), $name)).unwrap(),
+                )
+                .unwrap();
+                let vk = vk.into();
+                let der_proof = der_proof.into();
+                assert_eq!(der_proof, result2);
+                Groth16::<$curve>::verify(&vk, &der_proof, &public_input).expect("can verify");
+            }
+
+            #[test]
             fn [< e2e_proof_verify_snarkjs_proof_ $name _ $curve:lower _ groth16>] () {
                 let snarkjs_proof_file =
                     File::open(format!("../test_vectors/{}/{}/{}/circom.proof", "Groth16", stringify!([< $curve:lower >]), $name)).unwrap();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New proving path changes how REP3 witnesses are consumed and routes proof generation through Shamir MPC; misuse (reusing translated shares) or party-id handling could break correctness, though tests cover the happy path.
> 
> **Overview**
> Adds **`Rep3CoGroth16::prove_with_shamir_bridge`**, so parties can keep REP3 witness shares and still run the Shamir collaborative Groth16 prover (3 parties, threshold 1). The bridge **locally** maps witness shares via `ShamirState::translate_primefield_repshare_vec` (no extra messages), then calls `ShamirCoGroth16::prove`. Docs spell out that this is a one-way hand-off—REP3 witness shares must not be reused afterward—and that proofs may differ from native REP3 `prove` only in prover randomness while still verifying under the same VK.
> 
> **`prove`**, **`ShamirCoGroth16::prove`**, and **`plain_prove`** gain clearer security and networking documentation. REP3 Groth16 e2e tests add a **`groth16_shamir_bridge`** case mirroring the existing REP3 prove test (consistency across parties, serde round-trip, verification).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fab2a002e2e0dd74bd9669c7930832fcb0838a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->