### PR TITLE
refactor: rewrite g16 proof to only use one network

### DIFF
--- a/co-circom/co-circom/src/bin/co-circom.rs
+++ b/co-circom/co-circom/src/bin/co-circom.rs
@@ -999,8 +999,7 @@ where
     tracing::info!("Starting proof generation...");
     let public_input = match proof_system {
         ProofSystem::Groth16 => {
-            let [net0, net1] =
-                TcpNetwork::networks::<2>(network_config).context("while connecting to network")?;
+            let net = TcpNetwork::new(network_config).context("while connecting to network")?;
 
             let zkey = Groth16ZKey::<P>::from_reader(zkey_file, check).context("reading zkey")?;
             let (matrices, pkey) = zkey.into();
@@ -1013,13 +1012,12 @@ where
 
                     let witness_share: CompressedRep3SharedWitness<P::ScalarField> =
                         bincode::deserialize_from(witness_file)?;
-                    let witness_share = co_circom::uncompress_shared_witness(witness_share, &net0)?;
+                    let witness_share = co_circom::uncompress_shared_witness(witness_share, &net)?;
                     let public_input = witness_share.public_inputs.clone();
 
                     let start = Instant::now();
                     let proof = Rep3CoGroth16::prove::<_, CircomReduction>(
-                        &net0,
-                        &net1,
+                        &net,
                         &pkey,
                         &matrices,
                         witness_share,
@@ -1036,8 +1034,7 @@ where
 
                     let start = Instant::now();
                     let proof = ShamirCoGroth16::prove::<_, CircomReduction>(
-                        &net0,
-                        &net1,
+                        &net,
                         n,
                         t,
                         &pkey,

--- a/co-circom/co-circom/src/bin/poseidon2_bench.rs
+++ b/co-circom/co-circom/src/bin/poseidon2_bench.rs
@@ -299,8 +299,8 @@ where
         let poseidon2 = Poseidon2::<F, T, D>::default();
 
         let start = Instant::now();
-        for input in input.chunks_exact_mut(T) {
-            poseidon2.permutation_in_place(input.try_into().unwrap());
+        for input in input.as_chunks_mut::<T>().0 {
+            poseidon2.permutation_in_place(input);
         }
         let duration = start.elapsed().as_micros() as f64;
         times.push(duration);

--- a/co-circom/co-groth16/src/groth16.rs
+++ b/co-circom/co-groth16/src/groth16.rs
@@ -123,10 +123,8 @@ where
     /// This version takes the Circom-generated constraint matrices as input and does not re-calculate them.
     #[instrument(level = "debug", name = "Groth16 - Proof", skip_all)]
     fn prove_inner<N: Network, R: R1CSToQAP>(
-        net0: &N,
-        net1: &N,
-        state0: &mut T::State,
-        state1: &mut T::State,
+        net: &N,
+        state: &mut T::State,
         pkey: &ProvingKey<P>,
         matrices: &ConstraintMatrices<P::ScalarField>,
         private_witness: SharedWitness<P::ScalarField, T::ArithmeticShare>,
@@ -149,12 +147,12 @@ where
         }
 
         let h = R::witness_map_from_matrices::<P, T>(
-            state0,
+            state,
             matrices,
             &public_inputs,
             &private_witness.witness,
         )?;
-        let (r, s) = (T::rand(net0, state0)?, T::rand(net0, state0)?);
+        let (r, s) = (T::rand(net, state)?, T::rand(net, state)?);
 
         let private_witness_half_share: Vec<_> = private_witness
             .witness
@@ -163,10 +161,8 @@ where
             .collect();
 
         Self::create_proof_with_assignment(
-            net0,
-            net1,
-            state0,
-            state1,
+            net,
+            state,
             pkey,
             r,
             s,
@@ -205,10 +201,8 @@ where
     #[instrument(level = "debug", name = "create proof with assignment", skip_all)]
     #[expect(clippy::too_many_arguments)]
     fn create_proof_with_assignment<N: Network>(
-        net0: &N,
-        net1: &N,
-        state0: &mut T::State,
-        state1: &mut T::State,
+        net: &N,
+        state: &mut T::State,
         pkey: &ProvingKey<P>,
         r: T::ArithmeticShare,
         s: T::ArithmeticShare,
@@ -218,7 +212,7 @@ where
     ) -> eyre::Result<Proof<P>> {
         let delta_g1 = pkey.delta_g1.into_group();
 
-        let id = state0.id();
+        let id = state.id();
         let alpha_g1 = pkey.vk.alpha_g1;
         let beta_g1 = pkey.beta_g1;
         let beta_g2 = pkey.vk.beta_g2;
@@ -294,20 +288,19 @@ where
         );
 
         let rs_span = tracing::debug_span!("r*s without networking").entered();
-        let rs = T::local_mul_vec(vec![r], vec![s], state0).pop().unwrap();
+        let rs = T::local_mul_vec(vec![r], vec![s], state).pop().unwrap();
         let r_s_delta_g1 = T::scalar_mul_public_point_hs(&delta_g1, rs);
         rs_span.exit();
 
         let g_a = r_g1;
         let g1_b = s_g1;
 
+        // Opening g1_b = B*G1 is safe: B is masked by the fresh uniform s, and its exponent is
+        // published in the proof as b = B*G2 anyway. With B*G1 public, r*B*G1 is a local
+        // scalar multiplication, so both values can be opened in a single round.
         let network_round = tracing::debug_span!("network round after calc coeff").entered();
-        let (g_a_opened, r_g1_b) = mpc_net::join(
-            || T::open_half_point(g_a, net0, state0),
-            || T::scalar_mul(&g1_b, r, net1, state1),
-        );
-        let g_a_opened = g_a_opened?;
-        let r_g1_b = r_g1_b?;
+        let (g_a_opened, g1_b_opened) = T::open_two_half_points(g_a, g1_b, net, state)?;
+        let r_g1_b = T::scalar_mul_public_point_hs(&g1_b_opened, T::to_half_share(r));
         network_round.exit();
 
         let last_round = tracing::debug_span!("finish - open two points and some adds").entered();
@@ -322,12 +315,7 @@ where
         g_c += h_acc;
 
         let g2_b = s_g2;
-        let (g_c_opened, g2_b_opened) = mpc_net::join(
-            || T::open_half_point(g_c, net0, state0),
-            || T::open_half_point(g2_b, net1, state1),
-        );
-        let g_c_opened = g_c_opened?;
-        let g2_b_opened = g2_b_opened?;
+        let (g_c_opened, g2_b_opened) = T::open_two_half_points(g_c, g2_b, net, state)?;
         last_round.exit();
 
         Ok(Proof {
@@ -352,30 +340,18 @@ where
     /// Create a [`Proof`] by running the collaborative Groth16 prover under 3-party replicated
     /// (REP3) secret sharing, secure against a single semi-honest corruption.
     ///
-    /// `net0` and `net1` must be two independent networks connecting the same three parties,
-    /// since the prover runs two network legs concurrently. All three parties return the same
-    /// [`Proof`]. If the Shamir prover is available to all parties,
-    /// [`Self::prove_with_shamir_bridge`] produces a proof under the same trust assumption with a
-    /// cheaper online phase.
+    /// All three parties return the same [`Proof`]. If the Shamir prover is available to all
+    /// parties, [`Self::prove_with_shamir_bridge`] produces a proof under the same trust
+    /// assumption with a cheaper online phase.
     pub fn prove<N: Network, R: R1CSToQAP>(
-        net0: &N,
-        net1: &N,
+        net: &N,
         pkey: &ProvingKey<P>,
         matrices: &ConstraintMatrices<P::ScalarField>,
         witness: Rep3SharedWitness<P::ScalarField>,
     ) -> eyre::Result<Proof<P>> {
-        let mut state0 = Rep3State::new(net0, A2BType::default())?;
-        let mut state1 = state0.fork(0)?;
+        let mut state = Rep3State::new(net, A2BType::default())?;
         // execute prover in MPC
-        Self::prove_inner::<N, R>(
-            net0,
-            net1,
-            &mut state0,
-            &mut state1,
-            pkey,
-            matrices,
-            witness,
-        )
+        Self::prove_inner::<N, R>(net, &mut state, pkey, matrices, witness)
     }
 
     /// Create a [`Proof`] by locally translating the REP3 `witness` into a 3-party Shamir
@@ -390,21 +366,19 @@ where
     /// fresh randomness (`r`, `s`); both verify under the same verification key.
     ///
     /// # Errors
-    /// Returns an error if `net0.id()` is not a valid REP3 party id (0, 1, or 2).
+    /// Returns an error if `net.id()` is not a valid REP3 party id (0, 1, or 2).
     pub fn prove_with_shamir_bridge<N: Network, R: R1CSToQAP>(
-        net0: &N,
-        net1: &N,
+        net: &N,
         pkey: &ProvingKey<P>,
         matrices: &ConstraintMatrices<P::ScalarField>,
         witness: Rep3SharedWitness<P::ScalarField>,
     ) -> eyre::Result<Proof<P>> {
         let translated_witness = ShamirState::translate_primefield_repshare_vec(
             witness.witness,
-            net0.id().try_into().context("not a valid party id")?,
+            net.id().try_into().context("not a valid party id")?,
         );
         ShamirCoGroth16::prove::<_, R>(
-            net0,
-            net1,
+            net,
             3, // number of parties is 3 for REP3
             1, // threshold is 1 for REP3
             pkey,
@@ -433,33 +407,21 @@ where
     /// `num_parties` must be at least `2 * threshold + 1`, since `g_c` is opened as a
     /// degree-`2*threshold` sharing.
     ///
-    /// `net0` and `net1` must be two independent networks connecting all parties: correlated
-    /// randomness is preprocessed over `net0` before the online phase, and the online phase
-    /// itself runs two network legs concurrently.
+    /// Correlated randomness is preprocessed over `net` before the online phase.
     pub fn prove<N: Network, R: R1CSToQAP>(
-        net0: &N,
-        net1: &N,
+        net: &N,
         num_parties: usize,
         threshold: usize,
         pkey: &ProvingKey<P>,
         matrices: &ConstraintMatrices<P::ScalarField>,
         witness: ShamirSharedWitness<P::ScalarField>,
     ) -> eyre::Result<Proof<P>> {
-        // we need 3 number of corr rand pairs. 2 for two rand calls, 1 for scalar_mul
-        let num_pairs = 3;
-        let preprocessing = ShamirPreprocessing::new(num_parties, threshold, num_pairs, net0)?;
-        let mut state0 = ShamirState::from(preprocessing);
-        let mut state1 = state0.fork(1)?;
+        // we need 2 corr rand pairs for the two rand calls
+        let num_pairs = 2;
+        let preprocessing = ShamirPreprocessing::new(num_parties, threshold, num_pairs, net)?;
+        let mut state = ShamirState::from(preprocessing);
         // execute prover in MPC
-        Self::prove_inner::<N, R>(
-            net0,
-            net1,
-            &mut state0,
-            &mut state1,
-            pkey,
-            matrices,
-            witness,
-        )
+        Self::prove_inner::<N, R>(net, &mut state, pkey, matrices, witness)
     }
 }
 
@@ -486,6 +448,6 @@ where
         matrices: &ConstraintMatrices<P::ScalarField>,
         private_witness: SharedWitness<P::ScalarField, P::ScalarField>,
     ) -> Result<Proof<P>> {
-        Self::prove_inner::<_, R>(&(), &(), &mut (), &mut (), pkey, matrices, private_witness)
+        Self::prove_inner::<_, R>(&(), &mut (), pkey, matrices, private_witness)
     }
 }

--- a/co-circom/co-groth16/src/mpc.rs
+++ b/co-circom/co-groth16/src/mpc.rs
@@ -119,20 +119,15 @@ pub trait CircomGroth16Prover<P: Pairing>: Send + Sized {
         b: &C,
     );
 
-    /// Reconstructs a shared point: A = Open(\[A\]).
-    fn open_half_point<N: Network, C>(
-        a: Self::PointHalfShare<C>,
+    /// Reconstructs two shared points (potentially on different curves) in a single
+    /// communication round: (A, B) = (Open(\[A\]), Open(\[B\])).
+    fn open_two_half_points<N: Network, C1, C2>(
+        a: Self::PointHalfShare<C1>,
+        b: Self::PointHalfShare<C2>,
         net: &N,
         state: &mut Self::State,
-    ) -> eyre::Result<C>
+    ) -> eyre::Result<(C1, C2)>
     where
-        C: CurveGroup<ScalarField = P::ScalarField>;
-
-    /// Multiplies a share b to the shared point A: \[A\] *= \[b\]. Requires network communication.
-    fn scalar_mul<N: Network>(
-        a: &Self::PointHalfShare<P::G1>,
-        b: Self::ArithmeticShare,
-        net: &N,
-        state: &mut Self::State,
-    ) -> eyre::Result<Self::PointHalfShare<P::G1>>;
+        C1: CurveGroup<ScalarField = P::ScalarField>,
+        C2: CurveGroup<ScalarField = P::ScalarField>;
 }

--- a/co-circom/co-groth16/src/mpc/plain.rs
+++ b/co-circom/co-groth16/src/mpc/plain.rs
@@ -112,23 +112,16 @@ impl<P: Pairing> CircomGroth16Prover<P> for PlainGroth16Driver {
         *a * b
     }
 
-    fn open_half_point<N: Network, C>(
-        a: Self::PointHalfShare<C>,
+    fn open_two_half_points<N: Network, C1, C2>(
+        a: Self::PointHalfShare<C1>,
+        b: Self::PointHalfShare<C2>,
         _: &N,
         _: &mut Self::State,
-    ) -> eyre::Result<C>
+    ) -> eyre::Result<(C1, C2)>
     where
-        C: CurveGroup<ScalarField = P::ScalarField>,
+        C1: CurveGroup<ScalarField = P::ScalarField>,
+        C2: CurveGroup<ScalarField = P::ScalarField>,
     {
-        Ok(a)
-    }
-
-    fn scalar_mul<N: Network>(
-        a: &Self::PointHalfShare<P::G1>,
-        b: Self::ArithmeticShare,
-        _: &N,
-        _: &mut Self::State,
-    ) -> eyre::Result<Self::PointHalfShare<P::G1>> {
-        Ok(*a * b)
+        Ok((a, b))
     }
 }

--- a/co-circom/co-groth16/src/mpc/rep3.rs
+++ b/co-circom/co-groth16/src/mpc/rep3.rs
@@ -2,10 +2,7 @@ use ark_ec::short_weierstrass::{Affine, Projective, SWCurveConfig};
 use ark_ec::{CurveGroup, pairing::Pairing};
 use mpc_core::{
     MpcState,
-    protocols::rep3::{
-        Rep3PointShare, Rep3PrimeFieldShare, Rep3State, arithmetic, id::PartyID,
-        network::Rep3NetworkExt, pointshare,
-    },
+    protocols::rep3::{Rep3PrimeFieldShare, Rep3State, arithmetic, id::PartyID, pointshare},
 };
 use mpc_net::Network;
 use rayon::prelude::*;
@@ -138,25 +135,16 @@ impl<P: Pairing> CircomGroth16Prover<P> for Rep3Groth16Driver {
         *a * b
     }
 
-    fn open_half_point<N: Network, C>(
-        a: Self::PointHalfShare<C>,
+    fn open_two_half_points<N: Network, C1, C2>(
+        a: Self::PointHalfShare<C1>,
+        b: Self::PointHalfShare<C2>,
         net: &N,
         _: &mut Self::State,
-    ) -> eyre::Result<C>
+    ) -> eyre::Result<(C1, C2)>
     where
-        C: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
+        C1: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
+        C2: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
     {
-        pointshare::open_half_point(a, net)
-    }
-
-    fn scalar_mul<N: Network>(
-        a: &Self::PointHalfShare<<P as Pairing>::G1>,
-        b: Self::ArithmeticShare,
-        net: &N,
-        state: &mut Self::State,
-    ) -> eyre::Result<Self::PointHalfShare<<P as Pairing>::G1>> {
-        let a_hs = net.reshare(*a)?;
-        let point = Rep3PointShare::new(*a, a_hs);
-        Ok(pointshare::scalar_mul_local(&point, b, state))
+        pointshare::open_two_half_points(a, b, net)
     }
 }

--- a/co-circom/co-groth16/src/mpc/shamir.rs
+++ b/co-circom/co-groth16/src/mpc/shamir.rs
@@ -3,9 +3,7 @@ use ark_ec::short_weierstrass::{Affine, Projective, SWCurveConfig};
 use ark_ec::{CurveGroup, pairing::Pairing};
 use mpc_core::{
     MpcState,
-    protocols::shamir::{
-        ShamirPrimeFieldShare, ShamirState, arithmetic, network::ShamirNetworkExt, pointshare,
-    },
+    protocols::shamir::{ShamirPrimeFieldShare, ShamirState, arithmetic, pointshare},
 };
 use mpc_net::Network;
 use rayon::prelude::*;
@@ -125,24 +123,16 @@ impl<P: Pairing> CircomGroth16Prover<P> for ShamirGroth16Driver {
         *a * b
     }
 
-    fn open_half_point<N: Network, C>(
-        a: Self::PointHalfShare<C>,
+    fn open_two_half_points<N: Network, C1, C2>(
+        a: Self::PointHalfShare<C1>,
+        b: Self::PointHalfShare<C2>,
         net: &N,
         state: &mut Self::State,
-    ) -> eyre::Result<C>
+    ) -> eyre::Result<(C1, C2)>
     where
-        C: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
+        C1: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
+        C2: CurveGroup<ScalarField = <P as Pairing>::ScalarField>,
     {
-        pointshare::open_half_point(a, net, state)
-    }
-
-    fn scalar_mul<N: Network>(
-        a: &Self::PointHalfShare<<P as Pairing>::G1>,
-        b: Self::ArithmeticShare,
-        net: &N,
-        state: &mut Self::State,
-    ) -> eyre::Result<Self::PointHalfShare<<P as Pairing>::G1>> {
-        let a = net.degree_reduce_point(state, *a)?;
-        Ok(pointshare::scalar_mul_local(&a, b))
+        pointshare::open_two_half_points(a, b, net, state)
     }
 }

--- a/co-noir/co-acvm/src/mpc/rep3.rs
+++ b/co-noir/co-acvm/src/mpc/rep3.rs
@@ -1767,7 +1767,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
 
         let mut res0 = Vec::with_capacity(rotation_values.len() / 64);
         let mut res1 = Vec::with_capacity(rotation_values.len() / 64);
-        for chunk in rotation_values.chunks_exact(64) {
+        for chunk in rotation_values.as_chunks::<64>().0 {
             let vec_t0 = &chunk[..32];
             let vec_t1 = &chunk[32..];
             let mut sum_a = self.mul_with_public(base_powers[0], vec_t0[0].to_owned());
@@ -2114,7 +2114,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         let base_powers = get_base_powers::<32>(base);
         let base_powers: [F; 32] = array::from_fn(|i| F::from(base_powers[i].clone()));
         let mut res0 = Vec::with_capacity(sliced_bits.len() / 8);
-        for chunk in sliced_bits.chunks_exact(8) {
+        for chunk in sliced_bits.as_chunks::<8>().0 {
             let vec_t0 = chunk.to_vec();
             let mut sum_a = self.mul_with_public(base_powers[0], vec_t0[0].clone());
 

--- a/co-noir/co-builder/src/types/field_ct.rs
+++ b/co-noir/co-builder/src/types/field_ct.rs
@@ -2502,23 +2502,29 @@ impl<F: PrimeField, T: NoirWitnessExtensionProtocol<F>> BoolCT<F, T> {
             result.witness_index = builder.add_variable(value);
             // norm a, norm b or both inv: 1 - a - b + 2ab
             // inv a or inv b = a + b - 2ab
-            let multiplicative_coefficient;
-            let left_coefficient;
-            let right_coefficient;
-            let constant_coefficient;
-            if (self.witness_inverted && other.witness_inverted)
+
+            let (
+                multiplicative_coefficient,
+                left_coefficient,
+                right_coefficient,
+                constant_coefficient,
+            ) = if (self.witness_inverted && other.witness_inverted)
                 || (!self.witness_inverted && !other.witness_inverted)
             {
-                multiplicative_coefficient = P::ScalarField::from(2);
-                left_coefficient = -P::ScalarField::one();
-                right_coefficient = -P::ScalarField::one();
-                constant_coefficient = P::ScalarField::one();
+                (
+                    P::ScalarField::from(2),
+                    -P::ScalarField::one(),
+                    -P::ScalarField::one(),
+                    P::ScalarField::one(),
+                )
             } else {
-                multiplicative_coefficient = -P::ScalarField::from(2);
-                left_coefficient = P::ScalarField::one();
-                right_coefficient = P::ScalarField::one();
-                constant_coefficient = P::ScalarField::zero();
-            }
+                (
+                    -P::ScalarField::from(2),
+                    P::ScalarField::one(),
+                    P::ScalarField::one(),
+                    P::ScalarField::zero(),
+                )
+            };
             builder.create_arithmetic_gate(&PolyTriple {
                 a: self.witness_index,
                 b: other.witness_index,

--- a/co-noir/co-noir-common/src/crs/parse.rs
+++ b/co-noir/co-noir-common/src/crs/parse.rs
@@ -91,7 +91,7 @@ trait FileProcessor<P: HonkCurve<TranscriptFieldType>> {
         Ok(())
     }
     fn read_elements_from_buffer<G: AffineRepr>(elements: &mut [G], buffer: &mut [u8]) {
-        for (element, chunk) in elements.iter_mut().zip(buffer.chunks_exact_mut(64)) {
+        for (element, chunk) in elements.iter_mut().zip(buffer.as_chunks_mut::<64>().0) {
             Self::convert_endianness_inplace(chunk);
             #[allow(clippy::redundant_slicing)]
             if let Ok(val) = G::deserialize_uncompressed_unchecked(&chunk[..]) {
@@ -152,7 +152,7 @@ impl<P: HonkCurve<TranscriptFieldType>> FileProcessor<P> for NewFileStructure<P>
     }
 
     fn convert_endianness_inplace(buffer: &mut [u8]) {
-        for chunk in buffer.chunks_exact_mut(32) {
+        for chunk in buffer.as_chunks_mut::<32>().0 {
             chunk.reverse();
         }
     }

--- a/co-noir/co-noir-common/src/transcript.rs
+++ b/co-noir/co-noir-common/src/transcript.rs
@@ -302,6 +302,8 @@ where
     ) -> HonkProofResult<P::Affine> {
         let elements = self.receive_n_from_prover(label, H::NUM_BASEFIELD_ELEMENTS * 2)?;
 
+        // `as_chunks` is not possible here since associated consts cannot be used as const generics on stable
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         let coords = elements
             .chunks_exact(H::NUM_BASEFIELD_ELEMENTS)
             .map(H::convert_basefield_back::<P>)
@@ -326,6 +328,8 @@ where
     ) -> HonkProofResult<Vec<P::ScalarField>> {
         let elements = self.receive_n_from_prover(label, H::NUM_SCALARFIELD_ELEMENTS * n)?;
 
+        // `as_chunks` is not possible here since associated consts cannot be used as const generics on stable
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         let elements = elements
             .chunks_exact(H::NUM_SCALARFIELD_ELEMENTS)
             .map(H::convert_scalarfield_back::<P>)
@@ -341,6 +345,8 @@ where
         let mut res: [P::ScalarField; SIZE] = [P::ScalarField::zero(); SIZE];
         let elements = self.receive_n_from_prover(label, H::NUM_SCALARFIELD_ELEMENTS * SIZE)?;
 
+        // `as_chunks` is not possible here since associated consts cannot be used as const generics on stable
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         for (src, des) in elements
             .chunks_exact(H::NUM_SCALARFIELD_ELEMENTS)
             .zip(res.iter_mut())

--- a/mpc-core/src/gadgets/merkle_tree/plain.rs
+++ b/mpc-core/src/gadgets/merkle_tree/plain.rs
@@ -20,7 +20,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
 
         // Prepare for sponge mode
         let mut input = Vec::with_capacity(T * len / ARITY);
-        for inp in input_.chunks_exact(ARITY) {
+        for inp in input_.as_chunks::<ARITY>().0 {
             for i in inp {
                 input.push(*i);
             }
@@ -32,9 +32,9 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         while len > 1 {
             debug_assert_eq!(len % ARITY, 0);
             len /= ARITY;
-            for inp in input.chunks_exact_mut(T).take(len) {
+            for inp in input.as_chunks_mut::<T>().0.iter_mut().take(len) {
                 // Sponge mode
-                self.permutation_in_place(inp.try_into().unwrap());
+                self.permutation_in_place(inp);
             }
             // Only take first element as output and pad with 0 for sponge
             for i in 0..len / ARITY {
@@ -63,7 +63,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
 
         // Prepare for sponge mode
         let mut input = Vec::with_capacity(T * len / ARITY);
-        for inp in input_.chunks_exact(ARITY) {
+        for inp in input_.as_chunks::<ARITY>().0 {
             for i in inp {
                 input.push(*i);
             }
@@ -91,9 +91,9 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             });
             i /= ARITY;
 
-            for inp in input.chunks_exact_mut(T).take(len) {
+            for inp in input.as_chunks_mut::<T>().0.iter_mut().take(len) {
                 // Sponge mode
-                self.permutation_in_place(inp.try_into().unwrap());
+                self.permutation_in_place(inp);
             }
             // Only take first element as output and pad with 0 for sponge
             for i in 0..len / ARITY {
@@ -121,7 +121,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             input_
         } else {
             let mut input = Vec::with_capacity(T * len / ARITY);
-            for inp in input_.chunks_exact(ARITY) {
+            for inp in input_.as_chunks::<ARITY>().0 {
                 for i in inp {
                     input.push(*i);
                 }
@@ -135,10 +135,10 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         while len > 1 {
             debug_assert_eq!(len % ARITY, 0);
             len /= ARITY;
-            for inp in input.chunks_exact_mut(T).take(len) {
+            for inp in input.as_chunks_mut::<T>().0.iter_mut().take(len) {
                 // Compression mode
                 let feed_forward = inp[0];
-                self.permutation_in_place(inp.try_into().unwrap());
+                self.permutation_in_place(inp);
                 inp[0] += feed_forward;
             }
             // Only take first element as output and pad with 0 for compression
@@ -171,7 +171,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             input_
         } else {
             let mut input = Vec::with_capacity(T * len / ARITY);
-            for inp in input_.chunks_exact(ARITY) {
+            for inp in input_.as_chunks::<ARITY>().0 {
                 for i in inp {
                     input.push(*i);
                 }
@@ -201,10 +201,10 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             });
             i /= ARITY;
 
-            for inp in input.chunks_exact_mut(T).take(len) {
+            for inp in input.as_chunks_mut::<T>().0.iter_mut().take(len) {
                 // Compression mode
                 let feed_forward = inp[0];
-                self.permutation_in_place(inp.try_into().unwrap());
+                self.permutation_in_place(inp);
                 inp[0] += feed_forward;
             }
             // Only take first element as output and pad with 0 for compression
@@ -322,7 +322,7 @@ mod test {
 
         while input.len() > 1 {
             let mut output = Vec::with_capacity(input.len() / ARITY);
-            for inp in input.chunks_exact(ARITY) {
+            for inp in input.as_chunks::<ARITY>().0 {
                 let mut perm = [F::zero(); T];
                 for (i, p) in inp.iter().enumerate() {
                     perm[i] = *p;
@@ -353,7 +353,7 @@ mod test {
 
         while input.len() > 1 {
             let mut output = Vec::with_capacity(input.len() / ARITY);
-            for inp in input.chunks_exact(ARITY) {
+            for inp in input.as_chunks::<ARITY>().0 {
                 let mut perm = [F::zero(); T];
                 for (i, p) in inp.iter().enumerate() {
                     perm[i] = *p;

--- a/mpc-core/src/gadgets/merkle_tree/rep3.rs
+++ b/mpc-core/src/gadgets/merkle_tree/rep3.rs
@@ -23,7 +23,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
 
         // Prepare for sponge mode
         let mut input = Vec::with_capacity(T * len / ARITY);
-        for inp in input_.chunks_exact(ARITY) {
+        for inp in input_.as_chunks::<ARITY>().0 {
             for i in inp {
                 input.push(*i);
             }
@@ -75,7 +75,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             input_
         } else {
             let mut input = Vec::with_capacity(T * len / ARITY);
-            for inp in input_.chunks_exact(ARITY) {
+            for inp in input_.as_chunks::<ARITY>().0 {
                 for i in inp {
                     input.push(*i);
                 }

--- a/mpc-core/src/gadgets/merkle_tree/shamir.rs
+++ b/mpc-core/src/gadgets/merkle_tree/shamir.rs
@@ -24,7 +24,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
 
         // Prepare for sponge mode
         let mut input = Vec::with_capacity(T * len / ARITY);
-        for inp in input_.chunks_exact(ARITY) {
+        for inp in input_.as_chunks::<ARITY>().0 {
             for i in inp {
                 input.push(*i);
             }
@@ -78,7 +78,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             input_
         } else {
             let mut input = Vec::with_capacity(T * len / ARITY);
-            for inp in input_.chunks_exact(ARITY) {
+            for inp in input_.as_chunks::<ARITY>().0 {
                 for i in inp {
                     input.push(*i);
                 }

--- a/mpc-core/src/gadgets/poseidon2/poseidon2_circom_accelerator.rs
+++ b/mpc-core/src/gadgets/poseidon2/poseidon2_circom_accelerator.rs
@@ -23,8 +23,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             16 => {
                 let mut res = Vec::with_capacity(T);
                 // Applying cheap 4x4 MDS matrix to each 4-element part of the state
-                for state in input.chunks_exact_mut(4) {
-                    Self::matmul_m4_rep3(state.try_into().unwrap());
+                for state in input.as_chunks_mut::<4>().0 {
+                    Self::matmul_m4_rep3(state);
                 }
 
                 // Applying second cheap matrix for t > 4
@@ -361,8 +361,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
     )> {
         assert!(state.len().is_multiple_of(T));
         let id = PartyID::try_from(net.id())?;
-        for s in state.chunks_exact_mut(T) {
-            self.add_rc_external_rep3(s.try_into().expect("we checked sizes"), r, id);
+        for s in state.as_chunks_mut::<T>().0 {
+            self.add_rc_external_rep3(s, r, id);
         }
         let (squares, quads) = Self::sbox_rep3_precomp_intermediate_packed(state, precomp, net)?;
         let sboxes_0: [_; BATCH_SIZE] = array::from_fn(|i| state[i * T]);
@@ -371,15 +371,13 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             array::from_fn(|i| state.get(i * T + 3).copied().unwrap_or_default());
         let matmul_external = if T == 16 {
             let mut res = Vec::with_capacity(state.len() / T);
-            for state_chunk in state.chunks_exact_mut(T) {
-                res.push(Self::matmul_external_rep3_intermediate_t16(
-                    state_chunk.try_into().expect("Chunk size checked"),
-                ));
+            for state_chunk in state.as_chunks_mut::<T>().0 {
+                res.push(Self::matmul_external_rep3_intermediate_t16(state_chunk));
             }
             Some(res.try_into().expect("we checked sizes"))
         } else {
-            for state_chunk in state.chunks_exact_mut(T) {
-                Self::matmul_external_rep3(state_chunk.try_into().expect("Chunk size checked"));
+            for state_chunk in state.as_chunks_mut::<T>().0 {
+                Self::matmul_external_rep3(state_chunk);
             }
             None
         };
@@ -411,15 +409,13 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
     )> {
         assert!(state.len().is_multiple_of(T));
         let id = PartyID::try_from(net.id())?;
-        for s in state.chunks_exact_mut(T) {
-            self.add_rc_external_rep3(s.try_into().expect("we checked sizes"), r, id);
+        for s in state.as_chunks_mut::<T>().0 {
+            self.add_rc_external_rep3(s, r, id);
         }
         let (squares, quads) = Self::sbox_rep3_precomp_intermediate_packed(state, precomp, net)?;
         let mut matmul_results = Vec::with_capacity(BATCH_SIZE);
-        for s in state.chunks_exact_mut(T) {
-            matmul_results.push(Self::matmul_external_rep3_intermediate(
-                s.try_into().expect("we checked sizes"),
-            ));
+        for s in state.as_chunks_mut::<T>().0 {
+            matmul_results.push(Self::matmul_external_rep3_intermediate(s));
         }
         Ok((
             squares,
@@ -446,8 +442,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
     )> {
         assert!(state.len().is_multiple_of(T));
         let id = PartyID::try_from(net.id())?;
-        for s in state.chunks_exact_mut(T) {
-            self.add_rc_external_rep3(s.try_into().expect("we checked sizes"), r, id);
+        for s in state.as_chunks_mut::<T>().0 {
+            self.add_rc_external_rep3(s, r, id);
         }
         let (squares, quads) = Self::sbox_rep3_precomp_intermediate_vec(state, precomp, net)?;
         let sboxes_0 = state.iter().step_by(T).cloned().collect::<Vec<_>>();
@@ -459,15 +455,13 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         };
         let matmul_external = if T == 16 {
             let mut res = Vec::with_capacity(state.len() / T);
-            for state_chunk in state.chunks_exact_mut(T) {
-                res.push(Self::matmul_external_rep3_intermediate_t16(
-                    state_chunk.try_into().expect("Chunk size checked"),
-                ));
+            for state_chunk in state.as_chunks_mut::<T>().0 {
+                res.push(Self::matmul_external_rep3_intermediate_t16(state_chunk));
             }
             Some(res)
         } else {
-            for state_chunk in state.chunks_exact_mut(T) {
-                Self::matmul_external_rep3(state_chunk.try_into().expect("Chunk size checked"));
+            for state_chunk in state.as_chunks_mut::<T>().0 {
+                Self::matmul_external_rep3(state_chunk);
             }
             None
         };
@@ -496,15 +490,13 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
     )> {
         assert!(state.len().is_multiple_of(T));
         let id = PartyID::try_from(net.id())?;
-        for s in state.chunks_exact_mut(T) {
-            self.add_rc_external_rep3(s.try_into().expect("we checked sizes"), r, id);
+        for s in state.as_chunks_mut::<T>().0 {
+            self.add_rc_external_rep3(s, r, id);
         }
         let (squares, quads) = Self::sbox_rep3_precomp_intermediate_vec(state, precomp, net)?;
         let mut matmul_results = Vec::with_capacity(state.len() / T);
-        for s in state.chunks_exact_mut(T) {
-            matmul_results.push(Self::matmul_external_rep3_intermediate(
-                s.try_into().expect("we checked sizes"),
-            ));
+        for s in state.as_chunks_mut::<T>().0 {
+            matmul_results.push(Self::matmul_external_rep3_intermediate(s));
         }
         Ok((squares, quads, matmul_results))
     }
@@ -564,8 +556,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         let mut quad;
         let mut count = 0;
         for (inp, y, squares_, quads_) in izip!(
-            input.chunks_exact_mut(T),
-            y.chunks_exact(T),
+            input.as_chunks_mut::<T>().0,
+            y.as_chunks::<T>().0,
             squares.iter_mut(),
             quads.iter_mut()
         ) {
@@ -612,8 +604,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         let mut quad;
         let mut count = 0;
         for (inp, y, squares_, quads_) in izip!(
-            input.chunks_exact_mut(T),
-            y.chunks_exact(T),
+            input.as_chunks_mut::<T>().0,
+            y.as_chunks::<T>().0,
             squares.iter_mut(),
             quads.iter_mut()
         ) {
@@ -695,15 +687,13 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         }
         let sum = if T >= 4 {
             let mut sum = Vec::with_capacity(t2);
-            for state_chunk in state.chunks_exact_mut(T) {
-                sum.push(self.matmul_internal_rep3_return_sum(
-                    state_chunk.try_into().expect("Chunk size checked"),
-                ));
+            for state_chunk in state.as_chunks_mut::<T>().0 {
+                sum.push(self.matmul_internal_rep3_return_sum(state_chunk));
             }
             Some(sum)
         } else {
-            for state_chunk in state.chunks_exact_mut(T) {
-                self.matmul_internal_rep3(state_chunk.try_into().expect("Chunk size checked"));
+            for state_chunk in state.as_chunks_mut::<T>().0 {
+                self.matmul_internal_rep3(state_chunk);
             }
             None
         };
@@ -797,8 +787,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         match T {
             8 | 12 | 16 | 20 | 24 => {
                 // Applying cheap 4x4 MDS matrix to each 4-element part of the state
-                for state in input.chunks_exact_mut(4) {
-                    Self::matmul_m4_rep3(state.try_into().unwrap());
+                for state in input.as_chunks_mut::<4>().0 {
+                    Self::matmul_m4_rep3(state);
                 }
 
                 let result = input[0].to_owned();
@@ -835,8 +825,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
             16 => {
                 let mut res = Vec::with_capacity(T);
                 // Applying cheap 4x4 MDS matrix to each 4-element part of the state
-                for state in input.chunks_exact_mut(4) {
-                    Self::matmul_m4(state.try_into().unwrap());
+                for state in input.as_chunks_mut::<4>().0 {
+                    Self::matmul_m4(state);
                 }
 
                 // Applying second cheap matrix for t > 4
@@ -897,8 +887,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         match T {
             8 | 12 | 16 | 20 | 24 => {
                 // Applying cheap 4x4 MDS matrix to each 4-element part of the state
-                for state in input.chunks_exact_mut(4) {
-                    Self::matmul_m4(state.try_into().unwrap());
+                for state in input.as_chunks_mut::<4>().0 {
+                    Self::matmul_m4(state);
                 }
 
                 let result = input[0];
@@ -1267,15 +1257,14 @@ impl<F: PrimeField, const T: usize> CircomTraceBatchedHasher<F, T> for Poseidon2
         // Linear layer at beginning
         let matmul_external: Option<[Vec<Rep3PrimeFieldShare<F>>; BATCH_SIZE]> = if T == 16 {
             let mut matmul_external = Vec::with_capacity(BATCH_SIZE);
-            for state_ in state.chunks_exact_mut(T) {
-                let state_: &mut [Rep3PrimeFieldShare<F>; T] =
-                    state_.try_into().expect("we checked sizes");
+            for state_ in state.as_chunks_mut::<T>().0 {
+                let state_: &mut [Rep3PrimeFieldShare<F>; T] = state_;
                 matmul_external.push(Self::matmul_external_rep3_intermediate_t16(state_));
             }
             Some(matmul_external.try_into().expect("we checked sizes"))
         } else {
-            for s in state.chunks_exact_mut(T) {
-                Self::matmul_external_rep3(s.try_into().unwrap());
+            for s in state.as_chunks_mut::<T>().0 {
+                Self::matmul_external_rep3(s);
             }
             None
         };
@@ -1563,17 +1552,15 @@ impl<F: PrimeField, const T: usize> CircomTraceBatchedHasher<F, T> for Poseidon2
         let matmul_external: Option<Vec<Vec<Rep3PrimeFieldShare<F>>>> = if T == 16 {
             Some(
                 state
-                    .chunks_exact_mut(T)
-                    .map(|state_| {
-                        let state_: &mut [Rep3PrimeFieldShare<F>; T] =
-                            state_.try_into().expect("we checked sizes");
-                        Self::matmul_external_rep3_intermediate_t16(state_)
-                    })
+                    .as_chunks_mut::<T>()
+                    .0
+                    .iter_mut()
+                    .map(Self::matmul_external_rep3_intermediate_t16)
                     .collect::<Vec<_>>(),
             )
         } else {
-            for s in state.chunks_exact_mut(T) {
-                Self::matmul_external_rep3(s.try_into().expect("we checked sizes"));
+            for s in state.as_chunks_mut::<T>().0 {
+                Self::matmul_external_rep3(s);
             }
             None
         };

--- a/mpc-core/src/gadgets/poseidon2/poseidon2_permutation.rs
+++ b/mpc-core/src/gadgets/poseidon2/poseidon2_permutation.rs
@@ -100,8 +100,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             }
             8 | 12 | 16 | 20 | 24 => {
                 // Applying cheap 4x4 MDS matrix to each 4-element part of the state
-                for state in input.chunks_exact_mut(4) {
-                    Self::matmul_m4(state.try_into().unwrap());
+                for state in input.as_chunks_mut::<4>().0 {
+                    Self::matmul_m4(state);
                 }
 
                 // Applying second cheap matrix for t > 4

--- a/mpc-core/src/gadgets/poseidon2/poseidon2_shamir_circom_accelerator.rs
+++ b/mpc-core/src/gadgets/poseidon2/poseidon2_shamir_circom_accelerator.rs
@@ -63,8 +63,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
                 Self::matmul_m4_shamir(input.as_mut_slice().try_into().unwrap());
             }
             8 | 12 | 16 | 20 | 24 => {
-                for s in input.chunks_exact_mut(4) {
-                    Self::matmul_m4_shamir(s.try_into().unwrap());
+                for s in input.as_chunks_mut::<4>().0 {
+                    Self::matmul_m4_shamir(s);
                 }
                 let mut stored = [ShamirPrimeFieldShare::default(); 4];
                 for l in 0..4 {
@@ -86,8 +86,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
     ) -> Vec<ShamirPrimeFieldShare<F>> {
         assert_eq!(T, 16);
         let mut res = Vec::with_capacity(T);
-        for s in input.chunks_exact_mut(4) {
-            Self::matmul_m4_shamir(s.try_into().unwrap());
+        for s in input.as_chunks_mut::<4>().0 {
+            Self::matmul_m4_shamir(s);
         }
         let mut stored = [ShamirPrimeFieldShare::default(); 4];
         for l in 0..4 {
@@ -108,8 +108,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         input: &mut [ShamirPrimeFieldShare<F>; T],
     ) -> ShamirPrimeFieldShare<F> {
         assert!(T == 8 || T == 12 || T == 16 || T == 20 || T == 24);
-        for s in input.chunks_exact_mut(4) {
-            Self::matmul_m4_shamir(s.try_into().unwrap());
+        for s in input.as_chunks_mut::<4>().0 {
+            Self::matmul_m4_shamir(s);
         }
         let result = input[0];
         let mut stored = [ShamirPrimeFieldShare::default(); 4];
@@ -273,8 +273,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         let mut quads: [_; BATCH_SIZE] = array::from_fn(|_| Vec::with_capacity(T));
         let mut count = 0;
         for (inp, y_chunk, sq, qu) in izip!(
-            input.chunks_exact_mut(T),
-            y.chunks_exact(T),
+            input.as_chunks_mut::<T>().0,
+            y.as_chunks::<T>().0,
             squares.iter_mut(),
             quads.iter_mut()
         ) {
@@ -312,8 +312,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         let mut quads = vec![Vec::with_capacity(T); t2];
         let mut count = 0;
         for (inp, y_chunk, sq, qu) in izip!(
-            input.chunks_exact_mut(T),
-            y.chunks_exact(T),
+            input.as_chunks_mut::<T>().0,
+            y.as_chunks::<T>().0,
             squares.iter_mut(),
             quads.iter_mut()
         ) {
@@ -438,8 +438,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         Option<[Vec<ShamirPrimeFieldShare<F>>; BATCH_SIZE]>,
     )> {
         assert!(state.len().is_multiple_of(T));
-        for chunk in state.chunks_exact_mut(T) {
-            let chunk: &mut [ShamirPrimeFieldShare<F>; T] = chunk.try_into().unwrap();
+        for chunk in state.as_chunks_mut::<T>().0 {
+            let chunk: &mut [ShamirPrimeFieldShare<F>; T] = chunk;
             for (s, &rc) in chunk
                 .iter_mut()
                 .zip(self.params.round_constants_external[r].iter())
@@ -459,15 +459,13 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
             array::from_fn(|i| state.get(i * T + 3).copied().unwrap_or_default());
         let matmul_external = if T == 16 {
             let mut me = Vec::with_capacity(BATCH_SIZE);
-            for chunk in state.chunks_exact_mut(T) {
-                me.push(Self::matmul_external_shamir_intermediate_t16(
-                    chunk.try_into().expect("we checked sizes"),
-                ));
+            for chunk in state.as_chunks_mut::<T>().0 {
+                me.push(Self::matmul_external_shamir_intermediate_t16(chunk));
             }
             Some(me.try_into().expect("we checked sizes"))
         } else {
-            for chunk in state.chunks_exact_mut(T) {
-                Self::matmul_external_shamir_shares(chunk.try_into().expect("we checked sizes"));
+            for chunk in state.as_chunks_mut::<T>().0 {
+                Self::matmul_external_shamir_shares(chunk);
             }
             None
         };
@@ -498,8 +496,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         [ShamirPrimeFieldShare<F>; BATCH_SIZE],
     )> {
         assert!(state.len().is_multiple_of(T));
-        for chunk in state.chunks_exact_mut(T) {
-            let chunk: &mut [ShamirPrimeFieldShare<F>; T] = chunk.try_into().unwrap();
+        for chunk in state.as_chunks_mut::<T>().0 {
+            let chunk: &mut [ShamirPrimeFieldShare<F>; T] = chunk;
             for (s, &rc) in chunk
                 .iter_mut()
                 .zip(self.params.round_constants_external[r].iter())
@@ -514,10 +512,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
             shamir_state,
         )?;
         let mut matmul_results = Vec::with_capacity(BATCH_SIZE);
-        for chunk in state.chunks_exact_mut(T) {
-            matmul_results.push(Self::matmul_external_shamir_intermediate(
-                chunk.try_into().expect("we checked sizes"),
-            ));
+        for chunk in state.as_chunks_mut::<T>().0 {
+            matmul_results.push(Self::matmul_external_shamir_intermediate(chunk));
         }
         Ok((
             squares,
@@ -552,15 +548,13 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         }
         let sum = if T >= 4 {
             let mut sums = Vec::with_capacity(t2);
-            for chunk in state.chunks_exact_mut(T) {
-                sums.push(self.matmul_internal_shamir_return_sum(
-                    chunk.try_into().expect("Chunk size checked"),
-                ));
+            for chunk in state.as_chunks_mut::<T>().0 {
+                sums.push(self.matmul_internal_shamir_return_sum(chunk));
             }
             Some(sums)
         } else {
-            for chunk in state.chunks_exact_mut(T) {
-                self.matmul_internal_shamir_shares(chunk.try_into().expect("Chunk size checked"));
+            for chunk in state.as_chunks_mut::<T>().0 {
+                self.matmul_internal_shamir_shares(chunk);
             }
             None
         };
@@ -584,8 +578,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         Option<Vec<Vec<ShamirPrimeFieldShare<F>>>>,
     )> {
         assert!(state.len().is_multiple_of(T));
-        for chunk in state.chunks_exact_mut(T) {
-            let chunk: &mut [ShamirPrimeFieldShare<F>; T] = chunk.try_into().unwrap();
+        for chunk in state.as_chunks_mut::<T>().0 {
+            let chunk: &mut [ShamirPrimeFieldShare<F>; T] = chunk;
             for (s, &rc) in chunk
                 .iter_mut()
                 .zip(self.params.round_constants_external[r].iter())
@@ -604,15 +598,13 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         };
         let matmul_external = if T == 16 {
             let mut res = Vec::with_capacity(state.len() / T);
-            for chunk in state.chunks_exact_mut(T) {
-                res.push(Self::matmul_external_shamir_intermediate_t16(
-                    chunk.try_into().expect("Chunk size checked"),
-                ));
+            for chunk in state.as_chunks_mut::<T>().0 {
+                res.push(Self::matmul_external_shamir_intermediate_t16(chunk));
             }
             Some(res)
         } else {
-            for chunk in state.chunks_exact_mut(T) {
-                Self::matmul_external_shamir_shares(chunk.try_into().expect("Chunk size checked"));
+            for chunk in state.as_chunks_mut::<T>().0 {
+                Self::matmul_external_shamir_shares(chunk);
             }
             None
         };
@@ -640,8 +632,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         Vec<ShamirPrimeFieldShare<F>>,
     )> {
         assert!(state.len().is_multiple_of(T));
-        for chunk in state.chunks_exact_mut(T) {
-            let chunk: &mut [ShamirPrimeFieldShare<F>; T] = chunk.try_into().unwrap();
+        for chunk in state.as_chunks_mut::<T>().0 {
+            let chunk: &mut [ShamirPrimeFieldShare<F>; T] = chunk;
             for (s, &rc) in chunk
                 .iter_mut()
                 .zip(self.params.round_constants_external[r].iter())
@@ -652,10 +644,8 @@ impl<F: PrimeField, const T: usize> Poseidon2<F, T, 5> {
         let (squares, quads) =
             Self::sbox_shamir_precomp_intermediate_vec(state, precomp, net, shamir_state)?;
         let mut matmul_results = Vec::with_capacity(state.len() / T);
-        for chunk in state.chunks_exact_mut(T) {
-            matmul_results.push(Self::matmul_external_shamir_intermediate(
-                chunk.try_into().expect("we checked sizes"),
-            ));
+        for chunk in state.as_chunks_mut::<T>().0 {
+            matmul_results.push(Self::matmul_external_shamir_intermediate(chunk));
         }
         Ok((squares, quads, matmul_results))
     }
@@ -941,15 +931,13 @@ impl<F: PrimeField, const T: usize> CircomTraceShamirHasher<F, T> for Poseidon2<
 
         let matmul_external: Option<[Vec<ShamirPrimeFieldShare<F>>; BATCH_SIZE]> = if T == 16 {
             let mut me = Vec::with_capacity(BATCH_SIZE);
-            for chunk in state.chunks_exact_mut(T) {
-                me.push(Self::matmul_external_shamir_intermediate_t16(
-                    chunk.try_into().expect("we checked sizes"),
-                ));
+            for chunk in state.as_chunks_mut::<T>().0 {
+                me.push(Self::matmul_external_shamir_intermediate_t16(chunk));
             }
             Some(me.try_into().expect("we checked sizes"))
         } else {
-            for chunk in state.chunks_exact_mut(T) {
-                Self::matmul_external_shamir_shares(chunk.try_into().expect("we checked sizes"));
+            for chunk in state.as_chunks_mut::<T>().0 {
+                Self::matmul_external_shamir_shares(chunk);
             }
             None
         };
@@ -1226,17 +1214,15 @@ impl<F: PrimeField, const T: usize> CircomTraceShamirHasher<F, T> for Poseidon2<
         let matmul_external: Option<Vec<Vec<ShamirPrimeFieldShare<F>>>> = if T == 16 {
             Some(
                 state
-                    .chunks_exact_mut(T)
-                    .map(|chunk| {
-                        Self::matmul_external_shamir_intermediate_t16(
-                            chunk.try_into().expect("we checked sizes"),
-                        )
-                    })
+                    .as_chunks_mut::<T>()
+                    .0
+                    .iter_mut()
+                    .map(Self::matmul_external_shamir_intermediate_t16)
                     .collect(),
             )
         } else {
-            for chunk in state.chunks_exact_mut(T) {
-                Self::matmul_external_shamir_shares(chunk.try_into().expect("we checked sizes"));
+            for chunk in state.as_chunks_mut::<T>().0 {
+                Self::matmul_external_shamir_shares(chunk);
             }
             None
         };

--- a/mpc-core/src/gadgets/poseidon2/rep3.rs
+++ b/mpc-core/src/gadgets/poseidon2/rep3.rs
@@ -115,8 +115,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             }
             8 | 12 | 16 | 20 | 24 => {
                 // Applying cheap 4x4 MDS matrix to each 4-element part of the state
-                for state in input.chunks_exact_mut(4) {
-                    Self::matmul_m4_rep3(state.try_into().unwrap());
+                for state in input.as_chunks_mut::<4>().0 {
+                    Self::matmul_m4_rep3(state);
                 }
 
                 // Applying second cheap matrix for t > 4
@@ -523,7 +523,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         debug_assert_eq!(state.len() % T, 0);
         let id = PartyID::try_from(net.id())?;
         if id == PartyID::ID0 {
-            for state in state.chunks_exact_mut(T) {
+            for state in state.as_chunks_mut::<T>().0 {
                 for (s, rc) in state
                     .iter_mut()
                     .zip(self.params.round_constants_external[r].iter())
@@ -532,7 +532,7 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
                 }
             }
         } else if id == PartyID::ID1 {
-            for state in state.chunks_exact_mut(T) {
+            for state in state.as_chunks_mut::<T>().0 {
                 for (s, rc) in state
                     .iter_mut()
                     .zip(self.params.round_constants_external[r].iter())
@@ -542,8 +542,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
             }
         }
         Self::sbox_rep3_precomp(state, precomp, net)?;
-        for s in state.chunks_exact_mut(T) {
-            Self::matmul_external_rep3(s.try_into().unwrap());
+        for s in state.as_chunks_mut::<T>().0 {
+            Self::matmul_external_rep3(s);
         }
         Ok(())
     }
@@ -559,17 +559,17 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         debug_assert_eq!(state.len() % T, 0);
         let id = PartyID::try_from(net.id())?;
         if id == PartyID::ID0 {
-            for s in state.chunks_exact_mut(T) {
+            for s in state.as_chunks_mut::<T>().0 {
                 s[0].a += self.params.round_constants_internal[r];
             }
         } else if id == PartyID::ID1 {
-            for s in state.chunks_exact_mut(T) {
+            for s in state.as_chunks_mut::<T>().0 {
                 s[0].b += self.params.round_constants_internal[r];
             }
         }
         Self::single_sbox_rep3_precomp_packed(state, precomp, net)?;
-        for s in state.chunks_exact_mut(T) {
-            self.matmul_internal_rep3(s.try_into().unwrap());
+        for s in state.as_chunks_mut::<T>().0 {
+            self.matmul_internal_rep3(s);
         }
         Ok(())
     }
@@ -622,8 +622,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         // let mut precomp = self.precompute_rep3(num_poseidon, driver)?;
 
         // Linear layer at beginning
-        for s in state.chunks_exact_mut(T) {
-            Self::matmul_external_rep3(s.try_into().unwrap());
+        for s in state.as_chunks_mut::<T>().0 {
+            Self::matmul_external_rep3(s);
         }
 
         // First set of external rounds

--- a/mpc-core/src/gadgets/poseidon2/shamir.rs
+++ b/mpc-core/src/gadgets/poseidon2/shamir.rs
@@ -264,12 +264,12 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         shamir_state: &mut ShamirState<F>,
     ) -> eyre::Result<()> {
         debug_assert_eq!(state.len() % T, 0);
-        for s in state.chunks_exact_mut(T) {
-            self.add_rc_external(s.try_into().unwrap(), r);
+        for s in state.as_chunks_mut::<T>().0 {
+            self.add_rc_external(s, r);
         }
         Self::sbox_shamir_precomp(state, precomp, net, shamir_state)?;
-        for s in state.chunks_exact_mut(T) {
-            Self::matmul_external(s.try_into().unwrap());
+        for s in state.as_chunks_mut::<T>().0 {
+            Self::matmul_external(s);
         }
         Ok(())
     }
@@ -284,12 +284,12 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
         shamir_state: &mut ShamirState<F>,
     ) -> eyre::Result<()> {
         debug_assert_eq!(state.len() % T, 0);
-        for s in state.chunks_exact_mut(T) {
-            self.add_rc_internal(s.try_into().unwrap(), r);
+        for s in state.as_chunks_mut::<T>().0 {
+            self.add_rc_internal(s, r);
         }
         Self::single_sbox_shamir_precomp_packed(state, precomp, net, shamir_state)?;
-        for s in state.chunks_exact_mut(T) {
-            self.matmul_internal(s.try_into().unwrap());
+        for s in state.as_chunks_mut::<T>().0 {
+            self.matmul_internal(s);
         }
         Ok(())
     }
@@ -338,8 +338,8 @@ impl<F: PrimeField, const T: usize, const D: u64> Poseidon2<F, T, D> {
 
         // Linear layer at beginning
         let state = ShamirPrimeFieldShare::convert_mut(state);
-        for s in state.chunks_exact_mut(T) {
-            Self::matmul_external(s.try_into().unwrap());
+        for s in state.as_chunks_mut::<T>().0 {
+            Self::matmul_external(s);
         }
 
         // First set of external rounds

--- a/mpc-core/src/protocols/rep3/pointshare.rs
+++ b/mpc-core/src/protocols/rep3/pointshare.rs
@@ -154,6 +154,16 @@ pub fn open_half_point<C: CurveGroup, N: Network>(a: C, net: &N) -> eyre::Result
     Ok(a + b + c)
 }
 
+/// Open two shared points (potentially on different curves) in a single communication round
+pub fn open_two_half_points<C1: CurveGroup, C2: CurveGroup, N: Network>(
+    a: C1,
+    b: C2,
+    net: &N,
+) -> eyre::Result<(C1, C2)> {
+    let ((a1, b1), (a2, b2)) = net.broadcast((a, b))?;
+    Ok((a + a1 + a2, b + b1 + b2))
+}
+
 /// Open the vector of [`Rep3PointShare`]s
 pub fn open_point_many<C: CurveGroup, N: Network>(
     a: &[PointShare<C>],

--- a/mpc-core/src/protocols/shamir/pointshare.rs
+++ b/mpc-core/src/protocols/shamir/pointshare.rs
@@ -109,6 +109,25 @@ pub fn open_half_point<C: CurveGroup, N: Network>(
     Ok(res)
 }
 
+/// Performs opening of two point shares (potentially on different curves) in a single communication round.
+pub fn open_two_half_points<C1, C2, N: Network>(
+    a: C1,
+    b: C2,
+    net: &N,
+    state: &mut ShamirState<C1::ScalarField>,
+) -> eyre::Result<(C1, C2)>
+where
+    C1: CurveGroup,
+    C2: CurveGroup<ScalarField = C1::ScalarField>,
+{
+    let rcv = net.broadcast_next(state.num_parties, state.threshold * 2 + 1, (a, b))?;
+    let (rcv_a, rcv_b): (Vec<_>, Vec<_>) = rcv.into_iter().unzip();
+    Ok((
+        reconstruct_point(&rcv_a, &state.open_lagrange_2t),
+        reconstruct_point(&rcv_b, &state.open_lagrange_2t),
+    ))
+}
+
 /// Transforms a public value into a shared value: \[a\] = a.
 pub fn promote_to_trivial_share<C: CurveGroup>(a: &C) -> PointShare<C> {
     PointShare::new(*a)

--- a/mpc-core/src/uint/ruint_wrapper.rs
+++ b/mpc-core/src/uint/ruint_wrapper.rs
@@ -400,15 +400,15 @@ impl<const BITS: usize, const LIMBS: usize> UintBackend for RUint<BITS, LIMBS> {
     }
     fn to_le_bytes_into(&self, out: &mut [u8]) {
         assert_eq!(out.len(), Self::BYTES);
-        for (chunk, limb) in out.chunks_exact_mut(8).zip(self.0.as_limbs()) {
-            chunk.copy_from_slice(&limb.to_le_bytes());
+        for (chunk, limb) in out.as_chunks_mut::<8>().0.iter_mut().zip(self.0.as_limbs()) {
+            *chunk = limb.to_le_bytes();
         }
     }
     fn from_le_bytes(bytes: &[u8]) -> Self {
         assert_eq!(bytes.len(), Self::BYTES);
         let mut limbs = [0u64; LIMBS];
-        for (limb, chunk) in limbs.iter_mut().zip(bytes.chunks_exact(8)) {
-            *limb = u64::from_le_bytes(chunk.try_into().expect("chunk is 8 bytes"));
+        for (limb, chunk) in limbs.iter_mut().zip(bytes.as_chunks::<8>().0) {
+            *limb = u64::from_le_bytes(*chunk);
         }
         Self(Uint::from_limbs(limbs))
     }

--- a/tests/tests/circom/e2e_tests/rep3.rs
+++ b/tests/tests/circom/e2e_tests/rep3.rs
@@ -54,17 +54,15 @@ macro_rules! add_test_impl_g16 {
                 let mut rng = thread_rng();
                 let [witness_share1, witness_share2, witness_share3] =
                     SharedWitness::share_rep3(witness, r1cs.num_inputs, &mut rng);
-                let nets0 = LocalNetwork::new_3_parties();
-                let nets1 = LocalNetwork::new_3_parties();
+                let nets = LocalNetwork::new_3_parties();
                 let mut threads = vec![];
-                for (net0, net1, x, zkey) in izip!(
-                    nets0,
-                    nets1,
+                for (net, x, zkey) in izip!(
+                    nets,
                     [witness_share1, witness_share2, witness_share3].into_iter(),
                     [zkey1, zkey2, zkey3].into_iter()
                 ) {
                     threads.push(std::thread::spawn(move || {
-                        Rep3CoGroth16::<$curve>::prove::<_, CircomReduction>(&net0, &net1, &zkey.1, &zkey.0, x).unwrap()
+                        Rep3CoGroth16::<$curve>::prove::<_, CircomReduction>(&net, &zkey.1, &zkey.0, x).unwrap()
                     }));
                 }
                 let result3 = threads.pop().unwrap().join().unwrap();
@@ -105,17 +103,15 @@ macro_rules! add_test_impl_g16 {
                 let mut rng = thread_rng();
                 let [witness_share1, witness_share2, witness_share3] =
                     SharedWitness::share_rep3(witness, r1cs.num_inputs, &mut rng);
-                let nets0 = LocalNetwork::new_3_parties();
-                let nets1 = LocalNetwork::new_3_parties();
+                let nets = LocalNetwork::new_3_parties();
                 let mut threads = vec![];
-                for (net0, net1, x, zkey) in izip!(
-                    nets0,
-                    nets1,
+                for (net, x, zkey) in izip!(
+                    nets,
                     [witness_share1, witness_share2, witness_share3].into_iter(),
                     [zkey1, zkey2, zkey3].into_iter()
                 ) {
                     threads.push(std::thread::spawn(move || {
-                        Rep3CoGroth16::<$curve>::prove_with_shamir_bridge::<_, CircomReduction>(&net0, &net1, &zkey.1, &zkey.0, x).unwrap()
+                        Rep3CoGroth16::<$curve>::prove_with_shamir_bridge::<_, CircomReduction>(&net, &zkey.1, &zkey.0, x).unwrap()
                     }));
                 }
                 let result3 = threads.pop().unwrap().join().unwrap();

--- a/tests/tests/circom/e2e_tests/shamir.rs
+++ b/tests/tests/circom/e2e_tests/shamir.rs
@@ -54,17 +54,15 @@ macro_rules! add_test_impl_g16 {
                 let mut rng = thread_rng();
                 let witness_shares =
                     SharedWitness::share_shamir(witness, r1cs.num_inputs, 1, 3, &mut rng);
-                let nets0 = LocalNetwork::new_3_parties();
-                let nets1 = LocalNetwork::new_3_parties();
+                let nets = LocalNetwork::new_3_parties();
                 let mut threads = vec![];
-                for (net0, net1, x, zkey) in izip!(
-                    nets0,
-                    nets1,
+                for (net, x, zkey) in izip!(
+                    nets,
                     witness_shares.into_iter(),
                     [zkey1, zkey2, zkey3].into_iter()
                 ) {
                     threads.push(std::thread::spawn(move || {
-                        ShamirCoGroth16::<$curve>::prove::<_, CircomReduction>(&net0, &net1, 3, 1, &zkey.1, &zkey.0, x).unwrap()
+                        ShamirCoGroth16::<$curve>::prove::<_, CircomReduction>(&net, 3, 1, &zkey.1, &zkey.0, x).unwrap()
                     }));
                 }
                 let result3 = threads.pop().unwrap().join().unwrap();

--- a/tests/tests/mpc/rep3.rs
+++ b/tests/tests/mpc/rep3.rs
@@ -2262,7 +2262,7 @@ mod field_share {
             result.extend_from_slice(&res[..2 * slices_len]);
             let mut res0 = Vec::with_capacity((res.len() - 2 * slices_len) / 64);
             let mut res1 = Vec::with_capacity((res.len() - 2 * slices_len) / 64);
-            for chunk in res[2 * slices_len..].chunks_exact(64) {
+            for chunk in res[2 * slices_len..].as_chunks::<64>().0 {
                 let mut vec_t0 = chunk[..32].to_vec();
                 let mut vec_t1 = chunk[32..].to_vec();
 
@@ -2527,7 +2527,7 @@ mod field_share {
         for res in is_result.chunks_exact(result_chunk) {
             result.extend_from_slice(&res[..2 * slices_len]);
             let mut res0 = Vec::with_capacity((res.len() - 2 * slices_len) / 8);
-            for chunk in res[2 * slices_len..].chunks_exact(8) {
+            for chunk in res[2 * slices_len..].as_chunks::<8>().0 {
                 let mut vec_t0 = chunk.to_vec();
 
                 for (a, b) in vec_t0.iter_mut().zip(base_powers.iter()) {
@@ -3395,7 +3395,7 @@ mod field_share {
         let nets = LocalNetwork::new_3_parties();
         let mut rng = thread_rng();
         let mut input = vec![ark_bn254::Fr::default(); NUM_POSEIDON * 4];
-        for input in input.chunks_exact_mut(4) {
+        for input in input.as_chunks_mut::<4>().0 {
             input[0] = ark_bn254::Fr::from(0);
             input[1] = ark_bn254::Fr::from(1);
             input[2] = ark_bn254::Fr::from(2);
@@ -3447,8 +3447,8 @@ mod field_share {
         let result3 = rx3.recv().unwrap();
         let is_result = rep3::combine_field_elements(&result1, &result2, &result3);
 
-        for r in is_result.chunks_exact(4) {
-            assert_eq!(r, expected);
+        for r in is_result.as_chunks::<4>().0 {
+            assert_eq!(r, &expected);
         }
     }
 

--- a/tests/tests/mpc/shamir.rs
+++ b/tests/tests/mpc/shamir.rs
@@ -531,7 +531,7 @@ mod field_share {
         let nets = LocalNetwork::new(num_parties);
         let mut rng = thread_rng();
         let mut input = vec![ark_bn254::Fr::default(); NUM_POSEIDON * 4];
-        for input in input.chunks_exact_mut(4) {
+        for input in input.as_chunks_mut::<4>().0 {
             input[0] = ark_bn254::Fr::from(0);
             input[1] = ark_bn254::Fr::from(1);
             input[2] = ark_bn254::Fr::from(2);
@@ -604,8 +604,8 @@ mod field_share {
             shamir::combine_field_elements(&results, &(1..=num_parties).collect_vec(), threshold)
                 .unwrap();
 
-        for r in is_result.chunks_exact(4) {
-            assert_eq!(r, expected);
+        for r in is_result.as_chunks::<4>().0 {
+            assert_eq!(r, &expected);
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes the Groth16 MPC online protocol (what is opened, how C is formed) and is a breaking API change for prove(). A mistake here would leak witness material or produce invalid proofs.
> 
> **Overview**
> Collaborative Groth16 now runs on **one** network/state instead of two concurrent legs. `Rep3CoGroth16::prove`, `prove_with_shamir_bridge`, `ShamirCoGroth16::prove`, and the CLI/tests drop the second `net`/`state`.
> 
> The online phase opens `B·G1` together with `A` (justified because `B` is masked by fresh `s` and `B·G2` is already public), then finishes `r·B·G1` locally. `CircomGroth16Prover` replaces `open_half_point` + networked `scalar_mul` with `open_two_half_points`; Shamir preprocessing drops from 3 correlated pairs to 2.
> 
> Also migrates many `chunks_exact(_mut)` loops to `as_chunks(_mut)` (Poseidon2, Merkle trees, CRS parse, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f96bf60b8fce3d70bd599f1ace068849b5766f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->