### PR TITLE
refactor!: use only one net for witness-extension-vm

### DIFF
--- a/co-circom/circom-mpc-vm/src/mpc/batched_rep3.rs
+++ b/co-circom/circom-mpc-vm/src/mpc/batched_rep3.rs
@@ -25,29 +25,19 @@ type ArithmeticShare<F> = Rep3PrimeFieldShare<F>;
 /// This is a pure MPC improvement and does not use any advanced ZK techniques like folding.
 pub struct BatchedCircomRep3VmWitnessExtension<'a, F: PrimeField, N: Network> {
     _id: PartyID,
-    net0: &'a N,
-    _net1: &'a N,
-    state0: Rep3State,
-    _state1: Rep3State,
+    net: &'a N,
+    state: Rep3State,
     plain: BatchedCircomPlainVmWitnessExtension<F>,
     batch_size: usize,
 }
 
 impl<'a, F: PrimeField, N: Network> BatchedCircomRep3VmWitnessExtension<'a, F, N> {
-    pub fn new(
-        net0: &'a N,
-        net1: &'a N,
-        a2b_type: A2BType,
-        batch_size: usize,
-    ) -> eyre::Result<Self> {
-        let mut state = Rep3State::new(net0, a2b_type)?;
-        let state1 = state.fork(0)?;
+    pub fn new(net: &'a N, a2b_type: A2BType, batch_size: usize) -> eyre::Result<Self> {
+        let state = Rep3State::new(net, a2b_type)?;
         Ok(Self {
             _id: state.id(),
-            net0,
-            _net1: net1,
-            state0: state,
-            _state1: state1,
+            net,
+            state,
             plain: BatchedCircomPlainVmWitnessExtension::new(batch_size),
             batch_size,
         })
@@ -130,7 +120,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             | (BatchedRep3VmType::Arithmetic(a), BatchedRep3VmType::Public(b)) => Ok(a
                 .into_iter()
                 .zip(b)
-                .map(|(a, b)| arithmetic::add_public(a, b, self.state0.id))
+                .map(|(a, b)| arithmetic::add_public(a, b, self.state.id))
                 .collect_vec()
                 .into()),
             (BatchedRep3VmType::Arithmetic(a), BatchedRep3VmType::Arithmetic(b)) => Ok(a
@@ -150,13 +140,13 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             (BatchedRep3VmType::Arithmetic(a), BatchedRep3VmType::Public(b)) => Ok(a
                 .into_iter()
                 .zip(b)
-                .map(|(a, b)| arithmetic::sub_shared_by_public(a, b, self.state0.id))
+                .map(|(a, b)| arithmetic::sub_shared_by_public(a, b, self.state.id))
                 .collect_vec()
                 .into()),
             (BatchedRep3VmType::Public(a), BatchedRep3VmType::Arithmetic(b)) => Ok(a
                 .into_iter()
                 .zip(b)
-                .map(|(a, b)| arithmetic::sub_public_by_shared(a, b, self.state0.id))
+                .map(|(a, b)| arithmetic::sub_public_by_shared(a, b, self.state.id))
                 .collect_vec()
                 .into()),
 
@@ -182,7 +172,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
                 .collect_vec()
                 .into()),
             (BatchedRep3VmType::Arithmetic(a), BatchedRep3VmType::Arithmetic(b)) => {
-                Ok(arithmetic::mul_vec(&a, &b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::mul_vec(&a, &b, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -322,7 +312,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
     fn open(&mut self, a: Self::VmType) -> eyre::Result<Self::Public> {
         match a {
             BatchedRep3VmType::Public(public) => Ok(public),
-            BatchedRep3VmType::Arithmetic(shares) => Ok(arithmetic::open_vec(&shares, self.net0)?),
+            BatchedRep3VmType::Arithmetic(shares) => Ok(arithmetic::open_vec(&shares, self.net)?),
         }
     }
 
@@ -330,7 +320,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
         match a {
             BatchedRep3VmType::Public(a) => Ok(a
                 .iter()
-                .map(|a| arithmetic::promote_to_trivial_share(self.state0.id, *a))
+                .map(|a| arithmetic::promote_to_trivial_share(self.state.id, *a))
                 .collect_vec()),
             BatchedRep3VmType::Arithmetic(a) => Ok(a),
         }
@@ -346,8 +336,8 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
 
     fn compare_vm_config(&mut self, config: &crate::mpc_vm::VMConfig) -> eyre::Result<()> {
         let ser = bincode::serialize(&config)?;
-        self.net0.send_next(ser)?;
-        let recv: Vec<u8> = self.net0.recv_prev()?;
+        self.net.send_next(ser)?;
+        let recv: Vec<u8> = self.net.recv_prev()?;
         let deser = bincode::deserialize(&recv)?;
         if config != &deser {
             eyre::bail!("VM Config does not match: {:?} != {:?}", config, deser);
@@ -372,7 +362,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
         let a = a.into_iter().map(|x| match x {
             BatchedRep3VmType::Public(x) => x
                 .into_iter()
-                .map(|x| arithmetic::promote_to_trivial_share(self.state0.id, x))
+                .map(|x| arithmetic::promote_to_trivial_share(self.state.id, x))
                 .collect_vec(),
             BatchedRep3VmType::Arithmetic(x) => x,
         });
@@ -380,7 +370,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
         let b = b.into_iter().map(|x| match x {
             BatchedRep3VmType::Public(x) => x
                 .into_iter()
-                .map(|x| arithmetic::promote_to_trivial_share(self.state0.id, x))
+                .map(|x| arithmetic::promote_to_trivial_share(self.state.id, x))
                 .collect_vec(),
             BatchedRep3VmType::Arithmetic(x) => x,
         });
@@ -399,7 +389,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             .zip(b_sum)
             .map(|(a, b)| arithmetic::add(a, b))
             .collect_vec();
-        let sum_bits = conversion::a2b_many(&sum, self.net0, &mut self.state0)?;
+        let sum_bits = conversion::a2b_many(&sum, self.net, &mut self.state)?;
 
         let individual_bits = (0..bitlen + 1)
             .flat_map(|i| {
@@ -409,7 +399,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             })
             .collect_vec();
 
-        let result = conversion::bit_inject_many(&individual_bits, self.net0, &mut self.state0)?;
+        let result = conversion::bit_inject_many(&individual_bits, self.net, &mut self.state)?;
         assert!(result.len() % (bitlen + 1) == 0);
         assert!(result.len() / (bitlen + 1) == self.batch_size);
         let mut res = Vec::with_capacity(bitlen);
@@ -426,7 +416,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             BatchedRep3VmType::Public(public) => self.plain.log(public, allow_leaky_logs),
             BatchedRep3VmType::Arithmetic(shares) => {
                 if allow_leaky_logs {
-                    let fields = arithmetic::open_vec(&shares, self.net0)?;
+                    let fields = arithmetic::open_vec(&shares, self.net)?;
                     self.plain.log(fields, allow_leaky_logs)
                 } else {
                     Ok("secret".to_string())

--- a/co-circom/circom-mpc-vm/src/mpc/rep3.rs
+++ b/co-circom/circom-mpc-vm/src/mpc/rep3.rs
@@ -8,7 +8,6 @@ use co_circom_types::Rep3InputType;
 use eyre::bail;
 use itertools::Itertools;
 use mpc_core::{
-    MpcState,
     gadgets::poseidon2::Poseidon2,
     protocols::rep3::{
         Rep3PrimeFieldShare, Rep3State,
@@ -70,23 +69,18 @@ impl<F: PrimeField> Default for Rep3VmType<F> {
 
 pub struct CircomRep3VmWitnessExtension<'a, F: PrimeField, N: Network> {
     id: PartyID,
-    net0: &'a N,
-    net1: &'a N,
-    state0: Rep3State,
-    state1: Rep3State,
+    net: &'a N,
+    state: Rep3State,
     plain: CircomPlainVmWitnessExtension<F>,
 }
 
 impl<'a, F: PrimeField, N: Network> CircomRep3VmWitnessExtension<'a, F, N> {
-    pub fn new(net0: &'a N, net1: &'a N, a2b_type: A2BType) -> eyre::Result<Self> {
-        let mut state0 = Rep3State::new(net0, a2b_type)?;
-        let state1 = state0.fork(0)?;
+    pub fn new(net: &'a N, a2b_type: A2BType) -> eyre::Result<Self> {
+        let state = Rep3State::new(net, a2b_type)?;
         Ok(Self {
-            id: state0.id,
-            net0,
-            net1,
-            state0,
-            state1,
+            id: state.id,
+            net,
+            state,
             plain: CircomPlainVmWitnessExtension::default(),
         })
     }
@@ -147,7 +141,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
                 Ok(arithmetic::mul_public(a, b).into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
-                Ok(arithmetic::mul(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::mul(a, b, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -156,7 +150,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
         match (a, b) {
             (Rep3VmType::Public(a), Rep3VmType::Public(b)) => Ok(self.plain.div(a, b)?.into()),
             (Rep3VmType::Public(a), Rep3VmType::Arithmetic(b)) => {
-                let b = arithmetic::inv(b, self.net0, &mut self.state0)?;
+                let b = arithmetic::inv(b, self.net, &mut self.state)?;
                 Ok(arithmetic::mul_public(b, a).into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
@@ -166,8 +160,8 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
                 Ok(arithmetic::mul_public(a, b.inverse().unwrap()).into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
-                let b = arithmetic::inv(b, self.net0, &mut self.state0)?;
-                Ok(arithmetic::mul(a, b, self.net0, &mut self.state0)?.into())
+                let b = arithmetic::inv(b, self.net, &mut self.state)?;
+                Ok(arithmetic::mul(a, b, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -176,21 +170,21 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
         match (a, b) {
             (Rep3VmType::Public(a), Rep3VmType::Public(b)) => Ok(self.plain.int_div(a, b)?.into()),
             (Rep3VmType::Public(a), Rep3VmType::Arithmetic(b)) => {
-                let divided = yao::field_int_div_by_shared(a, b, self.net0, &mut self.state0)?;
+                let divided = yao::field_int_div_by_shared(a, b, self.net, &mut self.state)?;
                 Ok(divided.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
                 let divisor = b.to_uint();
                 let divided = if is_power_of_two(&divisor) {
                     let divisor_bit = divisor.bit_len() - 1;
-                    yao::field_int_div_power_2(a, self.net0, &mut self.state0, divisor_bit)?
+                    yao::field_int_div_power_2(a, self.net, &mut self.state, divisor_bit)?
                 } else {
-                    yao::field_int_div_by_public(a, b, self.net0, &mut self.state0)?
+                    yao::field_int_div_by_public(a, b, self.net, &mut self.state)?
                 };
                 Ok(divided.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
-                let divided = yao::field_int_div(a, b, self.net0, &mut self.state0)?;
+                let divided = yao::field_int_div(a, b, self.net, &mut self.state)?;
                 Ok(divided.into())
             }
         }
@@ -203,7 +197,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
                 if b.is_zero() {
                     return Ok(Rep3VmType::Public(F::one()));
                 }
-                Ok(arithmetic::pow_public(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::pow_public(a, b, self.net, &mut self.state)?.into())
             }
             _ => todo!("pow with shared exponent not implemented"),
         }
@@ -213,8 +207,8 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
         match (a, b) {
             (Rep3VmType::Public(a), Rep3VmType::Public(b)) => Ok(self.plain.modulo(a, b)?.into()),
             (Rep3VmType::Public(a), Rep3VmType::Arithmetic(b)) => {
-                let divided = yao::field_int_div_by_shared(a, b, self.net0, &mut self.state0)?;
-                let mul = arithmetic::mul(divided, b, self.net0, &mut self.state0)?;
+                let divided = yao::field_int_div_by_shared(a, b, self.net, &mut self.state)?;
+                let mul = arithmetic::mul(divided, b, self.net, &mut self.state)?;
                 let result = arithmetic::sub_public_by_shared(a, mul, self.id);
                 Ok(result.into())
             }
@@ -222,17 +216,17 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
                 let divisor = b.to_uint();
                 let result = if is_power_of_two(&divisor) {
                     let divisor_bit = divisor.bit_len() - 1;
-                    yao::field_mod_power_2(a, self.net0, &mut self.state0, divisor_bit)?
+                    yao::field_mod_power_2(a, self.net, &mut self.state, divisor_bit)?
                 } else {
-                    let divided = yao::field_int_div_by_public(a, b, self.net0, &mut self.state0)?;
+                    let divided = yao::field_int_div_by_public(a, b, self.net, &mut self.state)?;
                     let mul = arithmetic::mul_public(divided, b);
                     arithmetic::sub(a, mul)
                 };
                 Ok(result.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
-                let divided = yao::field_int_div(a, b, self.net0, &mut self.state0)?;
-                let mul = arithmetic::mul(divided, b, self.net0, &mut self.state0)?;
+                let divided = yao::field_int_div(a, b, self.net, &mut self.state)?;
+                let mul = arithmetic::mul(divided, b, self.net, &mut self.state)?;
                 let result = arithmetic::sub(a, mul);
                 Ok(result.into())
             }
@@ -243,14 +237,13 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
         match a {
             Rep3VmType::Public(a) => Ok(self.plain.sqrt(a)?.into()),
             Rep3VmType::Arithmetic(a) => {
-                let sqrt = arithmetic::sqrt(a, self.net0, &mut self.state0)?;
+                let sqrt = arithmetic::sqrt(a, self.net, &mut self.state)?;
                 // Correction to give the result closest to 0
                 // I.e., 2 * is_pos * sqrt - sqrt
                 let sqrt_val = self.val(sqrt);
                 let zero_val = self.plain.val(F::zero());
-                let is_pos =
-                    arithmetic::ge_public(sqrt_val, zero_val, self.net0, &mut self.state0)?;
-                let mut mul = arithmetic::mul(sqrt, is_pos, self.net0, &mut self.state0)?;
+                let is_pos = arithmetic::ge_public(sqrt_val, zero_val, self.net, &mut self.state)?;
+                let mut mul = arithmetic::mul(sqrt, is_pos, self.net, &mut self.state)?;
                 mul.double_in_place();
                 mul -= sqrt;
                 Ok(mul.into())
@@ -271,17 +264,17 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             (Rep3VmType::Public(a), Rep3VmType::Arithmetic(b)) => {
                 let a = self.plain.val(a);
                 let b = self.val(b);
-                Ok(arithmetic::ge_public(b, a, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::ge_public(b, a, self.net, &mut self.state)?.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
                 let a = self.val(a);
                 let b = self.plain.val(b);
-                Ok(arithmetic::lt_public(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::lt_public(a, b, self.net, &mut self.state)?.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
                 let a = self.val(a);
                 let b = self.val(b);
-                Ok(arithmetic::lt(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::lt(a, b, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -292,17 +285,17 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             (Rep3VmType::Public(a), Rep3VmType::Arithmetic(b)) => {
                 let a = self.plain.val(a);
                 let b = self.val(b);
-                Ok(arithmetic::gt_public(b, a, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::gt_public(b, a, self.net, &mut self.state)?.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
                 let a = self.val(a);
                 let b = self.plain.val(b);
-                Ok(arithmetic::le_public(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::le_public(a, b, self.net, &mut self.state)?.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
                 let a = self.val(a);
                 let b = self.val(b);
-                Ok(arithmetic::le(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::le(a, b, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -313,17 +306,17 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             (Rep3VmType::Public(a), Rep3VmType::Arithmetic(b)) => {
                 let a = self.plain.val(a);
                 let b = self.val(b);
-                Ok(arithmetic::le_public(b, a, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::le_public(b, a, self.net, &mut self.state)?.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
                 let a = self.val(a);
                 let b = self.plain.val(b);
-                Ok(arithmetic::gt_public(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::gt_public(a, b, self.net, &mut self.state)?.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
                 let a = self.val(a);
                 let b = self.val(b);
-                Ok(arithmetic::gt(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::gt(a, b, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -334,17 +327,17 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             (Rep3VmType::Public(a), Rep3VmType::Arithmetic(b)) => {
                 let a = self.plain.val(a);
                 let b = self.val(b);
-                Ok(arithmetic::lt_public(b, a, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::lt_public(b, a, self.net, &mut self.state)?.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
                 let a = self.val(a);
                 let b = self.plain.val(b);
-                Ok(arithmetic::ge_public(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::ge_public(a, b, self.net, &mut self.state)?.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
                 let a = self.val(a);
                 let b = self.val(b);
-                Ok(arithmetic::ge(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::ge(a, b, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -354,10 +347,10 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             (Rep3VmType::Public(a), Rep3VmType::Public(b)) => Ok(self.plain.eq(a, b)?.into()),
             (Rep3VmType::Public(b), Rep3VmType::Arithmetic(a))
             | (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
-                Ok(arithmetic::eq_public(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::eq_public(a, b, self.net, &mut self.state)?.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
-                Ok(arithmetic::eq(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::eq(a, b, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -367,10 +360,10 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             (Rep3VmType::Public(a), Rep3VmType::Public(b)) => Ok(self.plain.neq(a, b)?.into()),
             (Rep3VmType::Public(b), Rep3VmType::Arithmetic(a))
             | (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
-                Ok(arithmetic::neq_public(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::neq_public(a, b, self.net, &mut self.state)?.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
-                Ok(arithmetic::neq(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::neq(a, b, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -386,11 +379,11 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
                 todo!("Shared shift_right (public by shared) not implemented");
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
-                let bits = conversion::a2b_selector(a, self.net0, &mut self.state0)?;
+                let bits = conversion::a2b_selector(a, self.net, &mut self.state)?;
                 let result = conversion::b2a_selector(
                     &binary::shift_r_public(&bits, b),
-                    self.net0,
-                    &mut self.state0,
+                    self.net,
+                    &mut self.state,
                 )?;
                 Ok(result.into())
             }
@@ -406,8 +399,8 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
                 if a == F::zero() {
                     Ok(Rep3VmType::Public(F::zero()))
                 } else {
-                    let b = conversion::a2b_selector(b, self.net0, &mut self.state0)?;
-                    let res = binary::shift_l_public_by_shared(a, &b, self.net0, &mut self.state0)?;
+                    let b = conversion::a2b_selector(b, self.net, &mut self.state)?;
+                    let res = binary::shift_l_public_by_shared(a, &b, self.net, &mut self.state)?;
                     Ok(res.into())
                 }
             }
@@ -447,7 +440,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
                 Ok(sub.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
-                let mul = arithmetic::mul(a, b, self.net0, &mut self.state0)?;
+                let mul = arithmetic::mul(a, b, self.net, &mut self.state)?;
                 let add = arithmetic::add(a, b);
                 let sub = arithmetic::sub(add, mul);
                 Ok(sub.into())
@@ -479,17 +472,16 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             (Rep3VmType::Public(a), Rep3VmType::Public(b)) => Ok(self.plain.bit_xor(a, b)?.into()),
             (Rep3VmType::Public(b), Rep3VmType::Arithmetic(a))
             | (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
-                let a = conversion::a2b_selector(a, self.net0, &mut self.state0)?;
+                let a = conversion::a2b_selector(a, self.net, &mut self.state)?;
                 let binary = binary::xor_public(&a, &b.to_uint(), self.id);
-                Ok(conversion::b2a_selector(&binary, self.net0, &mut self.state0)?.into())
+                Ok(conversion::b2a_selector(&binary, self.net, &mut self.state)?.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
-                let (a, b) = mpc_net::join(
-                    || conversion::a2b_selector(a, self.net0, &mut self.state0),
-                    || conversion::a2b_selector(b, self.net1, &mut self.state1),
-                );
-                let binary = binary::xor(&a?, &b?);
-                let result = conversion::b2a_selector(&binary, self.net0, &mut self.state0)?;
+                let [a, b] = conversion::a2b_selector_many(&[a, b], self.net, &mut self.state)?
+                    .try_into()
+                    .expect("a2b_selector_many preserves length");
+                let binary = binary::xor(&a, &b);
+                let result = conversion::b2a_selector(&binary, self.net, &mut self.state)?;
                 Ok(result.into())
             }
         }
@@ -500,18 +492,17 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             (Rep3VmType::Public(a), Rep3VmType::Public(b)) => Ok(self.plain.bit_or(a, b)?.into()),
             (Rep3VmType::Public(b), Rep3VmType::Arithmetic(a))
             | (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
-                let a = conversion::a2b_selector(a, self.net0, &mut self.state0)?;
+                let a = conversion::a2b_selector(a, self.net, &mut self.state)?;
                 let binary = binary::or_public(&a, &b.to_uint(), self.id);
-                let result = conversion::b2a_selector(&binary, self.net0, &mut self.state0)?;
+                let result = conversion::b2a_selector(&binary, self.net, &mut self.state)?;
                 Ok(result.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
-                let (a, b) = mpc_net::join(
-                    || conversion::a2b_selector(a, self.net0, &mut self.state0),
-                    || conversion::a2b_selector(b, self.net1, &mut self.state1),
-                );
-                let binary = binary::or(&a?, &b?, self.net0, &mut self.state0)?;
-                Ok(conversion::b2a_selector(&binary, self.net0, &mut self.state0)?.into())
+                let [a, b] = conversion::a2b_selector_many(&[a, b], self.net, &mut self.state)?
+                    .try_into()
+                    .expect("a2b_selector_many preserves length");
+                let binary = binary::or(&a, &b, self.net, &mut self.state)?;
+                Ok(conversion::b2a_selector(&binary, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -521,18 +512,17 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             (Rep3VmType::Public(a), Rep3VmType::Public(b)) => Ok(self.plain.bit_and(a, b)?.into()),
             (Rep3VmType::Public(b), Rep3VmType::Arithmetic(a))
             | (Rep3VmType::Arithmetic(a), Rep3VmType::Public(b)) => {
-                let a = conversion::a2b_selector(a, self.net0, &mut self.state0)?;
+                let a = conversion::a2b_selector(a, self.net, &mut self.state)?;
                 let binary = binary::and_with_public(&a, &b.to_uint());
-                let result = conversion::b2a_selector(&binary, self.net0, &mut self.state0)?;
+                let result = conversion::b2a_selector(&binary, self.net, &mut self.state)?;
                 Ok(result.into())
             }
             (Rep3VmType::Arithmetic(a), Rep3VmType::Arithmetic(b)) => {
-                let (a, b) = mpc_net::join(
-                    || conversion::a2b_selector(a, self.net0, &mut self.state0),
-                    || conversion::a2b_selector(b, self.net1, &mut self.state1),
-                );
-                let binary = binary::and(&a?, &b?, self.net0, &mut self.state0)?;
-                Ok(conversion::b2a_selector(&binary, self.net0, &mut self.state0)?.into())
+                let [a, b] = conversion::a2b_selector_many(&[a, b], self.net, &mut self.state)?
+                    .try_into()
+                    .expect("a2b_selector_many preserves length");
+                let binary = binary::and(&a, &b, self.net, &mut self.state)?;
+                Ok(conversion::b2a_selector(&binary, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -543,7 +533,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
         }
         match a {
             Rep3VmType::Public(a) => Ok(self.plain.is_zero(a, allow_secret_inputs)?),
-            Rep3VmType::Arithmetic(a) => Ok(arithmetic::is_zero(a, self.net0, &mut self.state0)?),
+            Rep3VmType::Arithmetic(a) => Ok(arithmetic::is_zero(a, self.net, &mut self.state)?),
         }
     }
 
@@ -565,7 +555,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
     fn open(&mut self, a: Self::VmType) -> eyre::Result<F> {
         match a {
             Rep3VmType::Public(a) => Ok(a),
-            Rep3VmType::Arithmetic(a) => arithmetic::open(a, self.net0),
+            Rep3VmType::Arithmetic(a) => arithmetic::open(a, self.net),
         }
     }
 
@@ -586,8 +576,8 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
 
     fn compare_vm_config(&mut self, config: &VMConfig) -> eyre::Result<()> {
         let ser = bincode::serialize(&config)?;
-        self.net0.send_next(ser)?;
-        let recv: Vec<u8> = self.net0.recv_prev()?;
+        self.net.send_next(ser)?;
+        let recv: Vec<u8> = self.net.recv_prev()?;
         let deser = bincode::deserialize(&recv)?;
         if config != &deser {
             eyre::bail!("VM Config does not match: {:?} != {:?}", config, deser);
@@ -604,11 +594,11 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
                 .map(Into::into)
                 .collect()),
             Rep3VmType::Arithmetic(a) => {
-                let a_bits = conversion::a2b_selector(a, self.net0, &mut self.state0)?;
+                let a_bits = conversion::a2b_selector(a, self.net, &mut self.state)?;
                 let a_bits_split = (0..bits)
                     .map(|i| (a_bits >> i).and_mask(&F::Uint::one()))
                     .collect_vec();
-                Ok(bit_inject_many(&a_bits_split, self.net0, &mut self.state0)?
+                Ok(bit_inject_many(&a_bits_split, self.net, &mut self.state)?
                     .into_iter()
                     .map(Into::into)
                     .collect())
@@ -638,11 +628,11 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
 
         let sum = a_sum + b_sum;
 
-        let sum_bits = conversion::a2b_selector(sum, self.net0, &mut self.state0)?;
+        let sum_bits = conversion::a2b_selector(sum, self.net, &mut self.state)?;
         let individual_bits = (0..bitlen + 1)
             .map(|i| (sum_bits >> i).and_mask(&F::Uint::one()))
             .collect_vec();
-        let mut result = bit_inject_many(&individual_bits, self.net0, &mut self.state0)?;
+        let mut result = bit_inject_many(&individual_bits, self.net, &mut self.state)?;
         let carry = result.pop().unwrap();
         result.reverse();
         Ok((result.into_iter().map(Into::into).collect(), carry.into()))
@@ -653,7 +643,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             Rep3VmType::Public(public) => self.plain.log(public, allow_leaky_logs),
             Rep3VmType::Arithmetic(share) => {
                 if allow_leaky_logs {
-                    let field = arithmetic::open(share, self.net0)?;
+                    let field = arithmetic::open(share, self.net)?;
                     Ok(field.to_string())
                 } else {
                     Ok("secret".to_string())
@@ -671,7 +661,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             .any(|x| matches!(x, Rep3VmType::Arithmetic(_)))
         {
             let poseidon = Poseidon2::<_, T, 5>::default();
-            let mut precomp = poseidon.precompute_rep3(1, self.net0, &mut self.state0)?;
+            let mut precomp = poseidon.precompute_rep3(1, self.net, &mut self.state)?;
 
             // We promote all inputs to arithmetic shares here
             let mut iter = inputs.into_iter();
@@ -688,7 +678,7 @@ impl<F: PrimeField + FieldUint, N: Network> VmCircomWitnessExtension<F>
             let trace = poseidon.rep3_permutation_in_place_with_precomputation_intermediate(
                 &mut state,
                 &mut precomp,
-                self.net0,
+                self.net,
             )?;
 
             let outputs = state.into_iter().map(Rep3VmType::Arithmetic).collect_vec();

--- a/co-circom/circom-mpc-vm/src/mpc_vm.rs
+++ b/co-circom/circom-mpc-vm/src/mpc_vm.rs
@@ -1208,12 +1208,11 @@ impl<F: PrimeField + FieldUint> BatchedPlainWitnessExtension<F> {
 impl<'a, F: PrimeField + FieldUint, N: Network> Rep3WitnessExtension<'a, F, N> {
     /// Create a new [Rep3WitnessExtension] VM
     pub fn new(
-        net0: &'a N,
-        net1: &'a N,
+        net: &'a N,
         parser: &CoCircomCompilerParsed<F>,
         config: VMConfig,
     ) -> eyre::Result<Self> {
-        let driver = CircomRep3VmWitnessExtension::new(net0, net1, config.a2b_type)?;
+        let driver = CircomRep3VmWitnessExtension::new(net, config.a2b_type)?;
         let mut signals = vec![Rep3VmType::default(); parser.amount_signals];
         signals[0] = Rep3VmType::Public(F::one());
         let constant_table = parser
@@ -1246,14 +1245,12 @@ impl<'a, F: PrimeField + FieldUint, N: Network> Rep3WitnessExtension<'a, F, N> {
 impl<'a, F: PrimeField + FieldUint, N: Network> BatchedRep3WitnessExtension<'a, F, N> {
     /// Create a new [BatchedRep3WitnessExtension] VM
     pub fn new(
-        net0: &'a N,
-        net1: &'a N,
+        net: &'a N,
         parser: &CoCircomCompilerParsed<F>,
         config: VMConfig,
         batch_size: usize,
     ) -> eyre::Result<Self> {
-        let driver =
-            BatchedCircomRep3VmWitnessExtension::new(net0, net1, config.a2b_type, batch_size)?;
+        let driver = BatchedCircomRep3VmWitnessExtension::new(net, config.a2b_type, batch_size)?;
         let mut signals = vec![
             BatchedRep3VmType::from(Vec::<F>::with_capacity(batch_size));
             parser.amount_signals

--- a/co-circom/co-circom/src/bin/co-circom.rs
+++ b/co-circom/co-circom/src/bin/co-circom.rs
@@ -871,8 +871,7 @@ where
     }
 
     // connect to network
-    let [net0, net1] =
-        TcpNetwork::networks::<2>(network_config).context("while connecting to network")?;
+    let net = TcpNetwork::new(network_config).context("while connecting to network")?;
 
     // parse circuit file & put through our compiler
     let circuit = CoCircomCompiler::<P>::parse(circuit, config.compiler)
@@ -890,7 +889,7 @@ where
             tracing::info!("Starting witness generation...");
             let start = Instant::now();
             let result_witness_share =
-                co_circom::generate_witness_rep3(&circuit, input_share, config.vm, &net0, &net1)?;
+                co_circom::generate_witness_rep3(&circuit, input_share, config.vm, &net)?;
             let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
             tracing::info!("Generate witness took {duration_ms} ms");
 
@@ -913,7 +912,7 @@ where
             let start = Instant::now();
             // TODO we are not creating any randomness here
             let result_witness_share =
-                co_circom::generate_witness_shamir(&circuit, input_share, config.vm, &net0, n, t)?;
+                co_circom::generate_witness_shamir(&circuit, input_share, config.vm, &net, n, t)?;
             let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
             tracing::info!("Generate witness took {duration_ms} ms");
 

--- a/co-circom/co-circom/src/lib.rs
+++ b/co-circom/co-circom/src/lib.rs
@@ -140,12 +140,11 @@ pub fn generate_witness_rep3<F: PrimeField + FieldUint, N: Network>(
     circuit: &CoCircomCompilerParsed<F>,
     input: Rep3SharedInput<F>,
     config: VMConfig,
-    net0: &N,
-    net1: &N,
+    net: &N,
 ) -> eyre::Result<Rep3SharedWitness<F>> {
     // init MPC protocol
-    let rep3_vm = Rep3WitnessExtension::new(net0, net1, circuit, config)
-        .context("while constructing MPC VM")?;
+    let rep3_vm =
+        Rep3WitnessExtension::new(net, circuit, config).context("while constructing MPC VM")?;
 
     let num_public_inputs = input
         .values()

--- a/co-noir/co-acvm/src/mpc/plain.rs
+++ b/co-noir/co-acvm/src/mpc/plain.rs
@@ -210,8 +210,7 @@ impl<F: PrimeField> NoirWitnessExtensionProtocol<F> for PlainAcvmSolver<F> {
         index: Self::AcvmType,
         lut: &<Self::Lookup as mpc_core::lut::LookupTableProvider<F>>::LutType,
     ) -> eyre::Result<F> {
-        self.plain_lut
-            .get_from_lut(index, lut, &(), &(), &mut (), &mut ())
+        self.plain_lut.get_from_lut(index, lut, &(), &mut ())
     }
 
     fn read_from_public_luts(
@@ -221,9 +220,7 @@ impl<F: PrimeField> NoirWitnessExtensionProtocol<F> for PlainAcvmSolver<F> {
     ) -> eyre::Result<Vec<Self::AcvmType>> {
         let mut result = Vec::with_capacity(luts.len());
         for lut in luts {
-            let res = self
-                .plain_lut
-                .get_from_lut(index, lut, &(), &(), &mut (), &mut ())?;
+            let res = self.plain_lut.get_from_lut(index, lut, &(), &mut ())?;
             result.push(res);
         }
         Ok(result)
@@ -235,8 +232,7 @@ impl<F: PrimeField> NoirWitnessExtensionProtocol<F> for PlainAcvmSolver<F> {
         value: Self::AcvmType,
         lut: &mut <Self::Lookup as mpc_core::lut::LookupTableProvider<F>>::LutType,
     ) -> eyre::Result<()> {
-        self.plain_lut
-            .write_to_lut(index, value, lut, &(), &(), &mut (), &mut ())
+        self.plain_lut.write_to_lut(index, value, lut, &(), &mut ())
     }
 
     fn get_length_of_lut(lut: &<Self::Lookup as LookupTableProvider<F>>::LutType) -> usize {

--- a/co-noir/co-acvm/src/mpc/rep3.rs
+++ b/co-noir/co-acvm/src/mpc/rep3.rs
@@ -37,25 +37,20 @@ type ArithmeticShare<F> = Rep3PrimeFieldShare<F>;
 
 pub struct Rep3AcvmSolver<'a, F: PrimeField, N: Network> {
     id: PartyID,
-    net0: &'a N,
-    net1: &'a N,
-    state0: Rep3State,
-    state1: Rep3State,
+    net: &'a N,
+    state: Rep3State,
     lut_provider: Rep3FieldLookupTable<F>,
     plain_solver: PlainAcvmSolver<F>,
     phantom_data: PhantomData<F>,
 }
 
 impl<'a, F: PrimeField + FieldUint, N: Network> Rep3AcvmSolver<'a, F, N> {
-    pub fn new(net0: &'a N, net1: &'a N, a2b_type: A2BType) -> eyre::Result<Self> {
-        let mut state0 = Rep3State::new(net0, a2b_type)?;
-        let state1 = state0.fork(0)?;
+    pub fn new(net: &'a N, a2b_type: A2BType) -> eyre::Result<Self> {
+        let state = Rep3State::new(net, a2b_type)?;
         Ok(Self {
-            id: state0.id,
-            net0,
-            net1,
-            state0,
-            state1,
+            id: state.id,
+            net,
+            state,
             lut_provider: Rep3FieldLookupTable::new(),
             plain_solver: PlainAcvmSolver::<F>::default(),
             phantom_data: PhantomData,
@@ -372,7 +367,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
 
     fn init_brillig_driver(&mut self) -> eyre::Result<Self::BrilligDriver> {
         // TODO we just copy the net ref here this is not safe if used concurrently
-        Ok(Rep3BrilligDriver::new(self.net0, self.state0.fork(0)?))
+        Ok(Rep3BrilligDriver::new(self.net, self.state.fork(0)?))
     }
 
     fn parse_brillig_result(
@@ -381,7 +376,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
     ) -> eyre::Result<Vec<Self::AcvmType>> {
         brillig_result
             .into_iter()
-            .map(|value| Rep3AcvmType::from_brillig_type(value, self.net0, &mut self.state0))
+            .map(|value| Rep3AcvmType::from_brillig_type(value, self.net, &mut self.state))
             .collect()
     }
 
@@ -422,9 +417,9 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
 
     fn shared_zeros(&mut self, len: usize) -> eyre::Result<Vec<Self::AcvmType>> {
         let a = (0..len)
-            .map(|_| self.state0.rngs.rand.masking_field_element())
+            .map(|_| self.state.rngs.rand.masking_field_element())
             .collect::<Vec<_>>();
-        let b = self.net0.reshare_many(&a)?;
+        let b = self.net.reshare_many(&a)?;
         let result = izip!(a, b)
             .map(|(a, b)| Rep3AcvmType::Shared(Rep3PrimeFieldShare::new(a, b)))
             .collect();
@@ -537,7 +532,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 Rep3AcvmType::Shared(arithmetic::mul_public(secret_1, secret_2)),
             ),
             (Rep3AcvmType::Shared(secret_1), Rep3AcvmType::Shared(secret_2)) => {
-                let result = arithmetic::mul(secret_1, secret_2, self.net0, &mut self.state0)?;
+                let result = arithmetic::mul(secret_1, secret_2, self.net, &mut self.state)?;
                 Ok(Rep3AcvmType::Shared(result))
             }
         }
@@ -552,7 +547,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 Ok(Rep3AcvmType::Public(inv))
             }
             Rep3AcvmType::Shared(secret) => {
-                let inv = arithmetic::inv(secret, self.net0, &mut self.state0)?;
+                let inv = arithmetic::inv(secret, self.net, &mut self.state)?;
                 Ok(Rep3AcvmType::Shared(inv))
             }
         }
@@ -619,7 +614,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 Rep3AcvmType::Shared(arithmetic::mul_public(mul, c))
             }
             (Rep3AcvmType::Shared(lhs), Rep3AcvmType::Shared(rhs)) => {
-                let shared_mul = arithmetic::mul(lhs, rhs, self.net0, &mut self.state0)?;
+                let shared_mul = arithmetic::mul(lhs, rhs, self.net, &mut self.state)?;
                 Rep3AcvmType::Shared(arithmetic::mul_public(shared_mul, c))
             }
         };
@@ -640,12 +635,11 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 Rep3AcvmType::Shared(arithmetic::div_shared_by_public(arithmetic::neg(c), q_l)?)
             }
             (Rep3AcvmType::Shared(q_l), Rep3AcvmType::Public(c)) => {
-                let result =
-                    arithmetic::div_public_by_shared(-c, q_l, self.net0, &mut self.state0)?;
+                let result = arithmetic::div_public_by_shared(-c, q_l, self.net, &mut self.state)?;
                 Rep3AcvmType::Shared(result)
             }
             (Rep3AcvmType::Shared(q_l), Rep3AcvmType::Shared(c)) => {
-                let result = arithmetic::div(arithmetic::neg(c), q_l, self.net0, &mut self.state0)?;
+                let result = arithmetic::div(arithmetic::neg(c), q_l, self.net, &mut self.state)?;
                 Rep3AcvmType::Shared(result)
             }
         };
@@ -681,30 +675,27 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         index: Self::AcvmType,
         lut: &<Self::Lookup as mpc_core::lut::LookupTableProvider<F>>::LutType,
     ) -> eyre::Result<Self::AcvmType> {
-        let result = match index {
-            Rep3AcvmType::Public(public) => {
-                let index: BigUint = public.into();
-                let index = usize::try_from(index)
-                    .map_err(|_| eyre::eyre!("Index can not be translated to usize"))?;
+        let result =
+            match index {
+                Rep3AcvmType::Public(public) => {
+                    let index: BigUint = public.into();
+                    let index = usize::try_from(index)
+                        .map_err(|_| eyre::eyre!("Index can not be translated to usize"))?;
 
-                match lut {
-                    mpc_core::protocols::rep3_ring::lut_field::PublicPrivateLut::Public(vec) => {
-                        Self::AcvmType::from(vec[index].to_owned())
-                    }
-                    mpc_core::protocols::rep3_ring::lut_field::PublicPrivateLut::Shared(vec) => {
-                        Self::AcvmType::from(vec[index].to_owned())
+                    match lut {
+                        mpc_core::protocols::rep3_ring::lut_field::PublicPrivateLut::Public(
+                            vec,
+                        ) => Self::AcvmType::from(vec[index].to_owned()),
+                        mpc_core::protocols::rep3_ring::lut_field::PublicPrivateLut::Shared(
+                            vec,
+                        ) => Self::AcvmType::from(vec[index].to_owned()),
                     }
                 }
-            }
-            Rep3AcvmType::Shared(shared) => Self::AcvmType::from(self.lut_provider.get_from_lut(
-                shared,
-                lut,
-                self.net0,
-                self.net1,
-                &mut self.state0,
-                &mut self.state1,
-            )?),
-        };
+                Rep3AcvmType::Shared(shared) => Self::AcvmType::from(
+                    self.lut_provider
+                        .get_from_lut(shared, lut, self.net, &mut self.state)?,
+                ),
+            };
         Ok(result)
     }
 
@@ -727,10 +718,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 let res = Rep3FieldLookupTable::get_from_public_luts(
                     index,
                     luts,
-                    self.net0,
-                    self.net1,
-                    &mut self.state0,
-                    &mut self.state1,
+                    self.net,
+                    &mut self.state,
                 )?;
                 for res in res {
                     result.push(Rep3AcvmType::Shared(res));
@@ -785,26 +774,12 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             (Rep3AcvmType::Shared(index), Rep3AcvmType::Public(value)) => {
                 // TODO there might be a more efficient implementation for this if the table is also public
                 let value = arithmetic::promote_to_trivial_share(self.id, value);
-                self.lut_provider.write_to_lut(
-                    index,
-                    value,
-                    lut,
-                    self.net0,
-                    self.net1,
-                    &mut self.state0,
-                    &mut self.state1,
-                )?;
+                self.lut_provider
+                    .write_to_lut(index, value, lut, self.net, &mut self.state)?;
             }
             (Rep3AcvmType::Shared(index), Rep3AcvmType::Shared(value)) => {
-                self.lut_provider.write_to_lut(
-                    index,
-                    value,
-                    lut,
-                    self.net0,
-                    self.net1,
-                    &mut self.state0,
-                    &mut self.state1,
-                )?;
+                self.lut_provider
+                    .write_to_lut(index, value, lut, self.net, &mut self.state)?;
             }
         }
         Ok(())
@@ -818,10 +793,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         mpc_core::protocols::rep3_ring::lut_field::Rep3FieldLookupTable::<F>::ohv_from_index(
             index,
             len,
-            self.net0,
-            self.net1,
-            &mut self.state0,
-            &mut self.state1,
+            self.net,
+            &mut self.state,
         )
     }
 
@@ -831,7 +804,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         value: Self::ArithmeticShare,
         lut: &mut [Self::ArithmeticShare],
     ) -> eyre::Result<()> {
-        mpc_core::protocols::rep3_ring::lut_field::Rep3FieldLookupTable::<F>::write_to_shared_lut_from_ohv(ohv, value, lut, self.net0, &mut self.state0)
+        mpc_core::protocols::rep3_ring::lut_field::Rep3FieldLookupTable::<F>::write_to_shared_lut_from_ohv(ohv, value, lut, self.net, &mut self.state)
     }
 
     fn get_length_of_lut(lut: &<Self::Lookup as LookupTableProvider<F>>::LutType) -> usize {
@@ -879,7 +852,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
 
     fn open_many(&mut self, a: &[Self::ArithmeticShare]) -> eyre::Result<Vec<F>> {
         let bs = a.iter().map(|x| x.b).collect_vec();
-        let mut cs = self.net0.reshare(bs)?;
+        let mut cs = self.net.reshare(bs)?;
 
         izip!(a, cs.iter_mut()).for_each(|(x, c)| *c += x.a + x.b);
 
@@ -887,11 +860,11 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
     }
 
     fn rand(&mut self) -> eyre::Result<Self::ArithmeticShare> {
-        Ok(arithmetic::rand(&mut self.state0))
+        Ok(arithmetic::rand(&mut self.state))
     }
 
     fn common_rng_seed(&mut self) -> eyre::Result<[u8; 32]> {
-        Ok(self.state0.rngs.generate_shared(self.id))
+        Ok(self.state.rngs.generate_shared(self.id))
     }
 
     fn promote_to_trivial_share(&mut self, public_value: F) -> Self::ArithmeticShare {
@@ -914,8 +887,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
     ) -> eyre::Result<Vec<Self::ArithmeticShare>> {
         yao::decompose_arithmetic(
             input,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             total_bit_size_per_field,
             decompose_bit_size,
         )
@@ -936,8 +909,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         for inp_chunk in input.chunks(BATCH_SIZE) {
             let result = yao::decompose_arithmetic_many(
                 inp_chunk,
-                self.net0,
-                &mut self.state0,
+                self.net,
+                &mut self.state,
                 total_bit_size_per_field,
                 decompose_bit_size,
             )?;
@@ -962,15 +935,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 pub_inputs.push(Self::get_public(val).expect("Already checked it is public"));
             }
         }
-        radix_sort_fields(
-            priv_inputs,
-            pub_inputs,
-            bitsize,
-            self.net0,
-            self.net1,
-            &mut self.state0,
-            &mut self.state1,
-        )
+        radix_sort_fields(priv_inputs, pub_inputs, bitsize, self.net, &mut self.state)
     }
 
     fn slice(
@@ -982,8 +947,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
     ) -> eyre::Result<[Self::ArithmeticShare; 2]> {
         let res = yao::slice_arithmetic(
             input,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             lsb as usize,
             msb as usize,
             bitsize,
@@ -1001,8 +966,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
     ) -> eyre::Result<Vec<[Self::ArithmeticShare; 2]>> {
         let res = yao::slice_arithmetic_many(
             input,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             lsb as usize,
             msb as usize,
             bitsize,
@@ -1029,20 +994,19 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             }
             (Rep3AcvmType::Public(public), Rep3AcvmType::Shared(shared))
             | (Rep3AcvmType::Shared(shared), Rep3AcvmType::Public(public)) => {
-                let shared = conversion::a2b_selector(shared, self.net0, &mut self.state0)?;
+                let shared = conversion::a2b_selector(shared, self.net, &mut self.state)?;
                 let public = public.to_uint() & mask;
                 let binary = binary::and_with_public(&shared, &public); // Already includes masking
-                let result = conversion::b2a_selector(&binary, self.net0, &mut self.state0)?;
+                let result = conversion::b2a_selector(&binary, self.net, &mut self.state)?;
                 Ok(Rep3AcvmType::Shared(result))
             }
             (Rep3AcvmType::Shared(lhs), Rep3AcvmType::Shared(rhs)) => {
-                let (lhs, rhs) = mpc_net::join(
-                    || conversion::a2b_selector(lhs, self.net0, &mut self.state0),
-                    || conversion::a2b_selector(rhs, self.net1, &mut self.state1),
-                );
-                let binary =
-                    binary::and(&lhs?, &rhs?, self.net0, &mut self.state0)?.and_mask(&mask);
-                let result = conversion::b2a_selector(&binary, self.net0, &mut self.state0)?;
+                let [lhs, rhs] =
+                    conversion::a2b_selector_many(&[lhs, rhs], self.net, &mut self.state)?
+                        .try_into()
+                        .expect("a2b_selector_many preserves length");
+                let binary = binary::and(&lhs, &rhs, self.net, &mut self.state)?.and_mask(&mask);
+                let result = conversion::b2a_selector(&binary, self.net, &mut self.state)?;
                 Ok(Rep3AcvmType::Shared(result))
             }
         }
@@ -1066,19 +1030,19 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             }
             (Rep3AcvmType::Public(public), Rep3AcvmType::Shared(shared))
             | (Rep3AcvmType::Shared(shared), Rep3AcvmType::Public(public)) => {
-                let shared = conversion::a2b_selector(shared, self.net0, &mut self.state0)?;
+                let shared = conversion::a2b_selector(shared, self.net, &mut self.state)?;
                 let public = public.to_uint();
                 let binary = binary::xor_public(&shared, &public, self.id).and_mask(&mask);
-                let result = conversion::b2a_selector(&binary, self.net0, &mut self.state0)?;
+                let result = conversion::b2a_selector(&binary, self.net, &mut self.state)?;
                 Ok(Rep3AcvmType::Shared(result))
             }
             (Rep3AcvmType::Shared(lhs), Rep3AcvmType::Shared(rhs)) => {
-                let (lhs, rhs) = mpc_net::join(
-                    || conversion::a2b_selector(lhs, self.net0, &mut self.state0),
-                    || conversion::a2b_selector(rhs, self.net1, &mut self.state1),
-                );
-                let binary = binary::xor(&lhs?, &rhs?).and_mask(&mask);
-                let result = conversion::b2a_selector(&binary, self.net0, &mut self.state0)?;
+                let [lhs, rhs] =
+                    conversion::a2b_selector_many(&[lhs, rhs], self.net, &mut self.state)?
+                        .try_into()
+                        .expect("a2b_selector_many preserves length");
+                let binary = binary::xor(&lhs, &rhs).and_mask(&mask);
+                let result = conversion::b2a_selector(&binary, self.net, &mut self.state)?;
                 Ok(Rep3AcvmType::Shared(result))
             }
         }
@@ -1099,8 +1063,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         let result = yao::slice_and(
             input1,
             input2,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             basis_bits,
             rotation,
             total_bitsize,
@@ -1143,8 +1107,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         let result = yao::slice_xor(
             input1,
             input2,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             basis_bits,
             rotation,
             total_bitsize,
@@ -1187,8 +1151,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         let result = yao::slice_xor_with_filter(
             input1,
             input2,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             basis_bits,
             rotation,
             filter,
@@ -1244,10 +1208,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             &order,
             inputs,
             bitsize,
-            self.net0,
-            self.net1,
-            &mut self.state0,
-            &mut self.state1,
+            self.net,
+            &mut self.state,
         )
     }
 
@@ -1268,11 +1230,11 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 }
                 Rep3AcvmType::Shared(shared) => shared,
             });
-            let mut precomp = poseidon2.precompute_rep3(1, self.net0, &mut self.state0)?;
+            let mut precomp = poseidon2.precompute_rep3(1, self.net, &mut self.state)?;
             poseidon2.rep3_permutation_in_place_with_precomputation(
                 &mut shared,
                 &mut precomp,
-                self.net0,
+                self.net,
             )?;
 
             for (src, des) in shared.into_iter().zip(input.iter_mut()) {
@@ -1302,7 +1264,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         num_poseidon: usize,
         poseidon2: &Poseidon2<F, T, D>,
     ) -> eyre::Result<Poseidon2Precomputations<Self::ArithmeticShare>> {
-        poseidon2.precompute_rep3(num_poseidon, self.net0, &mut self.state0)
+        poseidon2.precompute_rep3(num_poseidon, self.net, &mut self.state)
     }
 
     fn poseidon2_external_round_inplace_with_precomp<const T: usize, const D: u64>(
@@ -1312,7 +1274,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         precomp: &mut Poseidon2Precomputations<Self::ArithmeticShare>,
         poseidon2: &Poseidon2<F, T, D>,
     ) -> eyre::Result<()> {
-        poseidon2.rep3_external_round_precomp(input, r, precomp, self.net0)
+        poseidon2.rep3_external_round_precomp(input, r, precomp, self.net)
     }
 
     fn poseidon2_internal_round_inplace_with_precomp<const T: usize, const D: u64>(
@@ -1322,7 +1284,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         precomp: &mut Poseidon2Precomputations<Self::ArithmeticShare>,
         poseidon2: &Poseidon2<F, T, D>,
     ) -> eyre::Result<()> {
-        poseidon2.rep3_internal_round_precomp(input, r, precomp, self.net0)
+        poseidon2.rep3_internal_round_precomp(input, r, precomp, self.net)
     }
 
     fn is_public_lut(lut: &<Self::Lookup as LookupTableProvider<F>>::LutType) -> bool {
@@ -1338,8 +1300,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 Ok(Rep3AcvmType::Shared(arithmetic::eq_public(
                     *shared,
                     *public,
-                    self.net0,
-                    &mut self.state0,
+                    self.net,
+                    &mut self.state,
                 )?))
             }
 
@@ -1347,13 +1309,13 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 Ok(Rep3AcvmType::Shared(arithmetic::eq_public(
                     *shared,
                     *public,
-                    self.net0,
-                    &mut self.state0,
+                    self.net,
+                    &mut self.state,
                 )?))
             }
 
             (Rep3AcvmType::Shared(a), Rep3AcvmType::Shared(b)) => Ok(Rep3AcvmType::Shared(
-                arithmetic::eq(*a, *b, self.net0, &mut self.state0)?,
+                arithmetic::eq(*a, *b, self.net, &mut self.state)?,
             )),
         }
     }
@@ -1388,7 +1350,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                     }
                 })
                 .collect();
-            arithmetic::eq_public_many(&a, &b, self.net0, &mut self.state0)
+            arithmetic::eq_public_many(&a, &b, self.net, &mut self.state)
                 .map(|shares| shares.into_iter().map(Rep3AcvmType::Shared).collect())
         } else if !bool_a && bool_b {
             let a = a
@@ -1407,7 +1369,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                     }
                 })
                 .collect();
-            arithmetic::eq_public_many(&b, &a, self.net0, &mut self.state0)
+            arithmetic::eq_public_many(&b, &a, self.net, &mut self.state)
                 .map(|shares| shares.into_iter().map(Rep3AcvmType::Shared).collect())
         } else {
             let a: Vec<Self::ArithmeticShare> = a
@@ -1434,7 +1396,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                     }
                 })
                 .collect();
-            arithmetic::eq_many(&a, &b, self.net0, &mut self.state0)
+            arithmetic::eq_many(&a, &b, self.net, &mut self.state)
                 .map(|shares| shares.into_iter().map(Rep3AcvmType::Shared).collect())
         }
     }
@@ -1474,29 +1436,23 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
 
         // TODO parallelize all points?
         for i in (0..points.len()).step_by(3) {
-            let (point, grumpkin_integer) = mpc_net::join(
-                || {
-                    Self::create_grumpkin_point(
-                        &points[i],
-                        &points[i + 1],
-                        &points[i + 2],
-                        self.net0,
-                        &mut self.state0,
-                        pedantic_solving,
-                    )
-                },
-                || {
-                    Self::combine_grumpkin_scalar_field_limbs(
-                        &scalars_lo[i / 3],
-                        &scalars_hi[i / 3],
-                        self.net1,
-                        &mut self.state1,
-                        pedantic_solving,
-                    )
-                },
-            );
+            let point = Self::create_grumpkin_point(
+                &points[i],
+                &points[i + 1],
+                &points[i + 2],
+                self.net,
+                &mut self.state,
+                pedantic_solving,
+            )?;
+            let grumpkin_integer = Self::combine_grumpkin_scalar_field_limbs(
+                &scalars_lo[i / 3],
+                &scalars_hi[i / 3],
+                self.net,
+                &mut self.state,
+                pedantic_solving,
+            )?;
             let iteration_output_point =
-                Self::scalar_point_mul(grumpkin_integer?, point?, self.net0, &mut self.state0)?;
+                Self::scalar_point_mul(grumpkin_integer, point, self.net, &mut self.state)?;
             Self::add_assign_point(&mut output_point, iteration_output_point, self.id);
         }
 
@@ -1515,13 +1471,13 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             Rep3AcvmPoint::Shared(output_point) => {
                 let (x, y, i) = conversion::point_share_to_fieldshares(
                     output_point,
-                    self.net0,
-                    &mut self.state0,
+                    self.net,
+                    &mut self.state,
                 )?;
                 // Set x,y to 0 if infinity is one.
                 // Note: If we don't need the coordinates to be zero in the infinity case, we could add an option to skip this
                 let mul = arithmetic::sub_public_by_shared(ark_bn254::Fr::one(), i, self.id);
-                let res = arithmetic::mul_vec(&[x, y], &[mul, mul], self.net0, &mut self.state0)?;
+                let res = arithmetic::mul_vec(&[x, y], &[mul, mul], self.net, &mut self.state)?;
 
                 let out_x = downcast::<_, Self::ArithmeticShare>(&res[0])
                     .expect("We checked types")
@@ -1555,7 +1511,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         let is_infinity = downcast(&is_infinity).expect("We checked types");
 
         let point =
-            Self::create_grumpkin_point(x, y, is_infinity, self.net0, &mut self.state0, true)?;
+            Self::create_grumpkin_point(x, y, is_infinity, self.net, &mut self.state, true)?;
 
         let y = downcast::<_, Self::AcvmPoint<C>>(&point)
             .expect("We checked types")
@@ -1578,11 +1534,11 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             }
             Rep3AcvmPoint::Shared(point) => {
                 let (x, y, i) =
-                    conversion::point_share_to_fieldshares(point, self.net0, &mut self.state0)?;
+                    conversion::point_share_to_fieldshares(point, self.net, &mut self.state)?;
                 // Set x,y to 0 of infinity is one.
                 // Note: If we don't need the coordinates to be zero in the infinity case, we could add an option to skip this
                 let mul = arithmetic::sub_public_by_shared(F::one(), i, self.id);
-                let res = arithmetic::mul_vec(&[x, y], &[mul, mul], self.net0, &mut self.state0)?;
+                let res = arithmetic::mul_vec(&[x, y], &[mul, mul], self.net, &mut self.state)?;
 
                 (res[0].into(), res[1].into(), i.into())
             }
@@ -1596,13 +1552,13 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 Ok(F::from((a > b) as u64).into())
             }
             (Rep3AcvmType::Public(a), Rep3AcvmType::Shared(b)) => {
-                Ok(arithmetic::lt_public(b, a, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::lt_public(b, a, self.net, &mut self.state)?.into())
             }
             (Rep3AcvmType::Shared(a), Rep3AcvmType::Public(b)) => {
-                Ok(arithmetic::ge_public(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::ge_public(a, b, self.net, &mut self.state)?.into())
             }
             (Rep3AcvmType::Shared(a), Rep3AcvmType::Shared(b)) => {
-                Ok(arithmetic::ge(a, b, self.net0, &mut self.state0)?.into())
+                Ok(arithmetic::ge(a, b, self.net, &mut self.state)?.into())
             }
         }
     }
@@ -1615,8 +1571,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             }
             Rep3AcvmType::Shared(shared) => Ok(Rep3AcvmType::Shared(yao::field_int_div_power_2(
                 shared,
-                self.net0,
-                &mut self.state0,
+                self.net,
+                &mut self.state,
                 shift,
             )?)),
         }
@@ -1636,9 +1592,9 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 }
             }
             Rep3AcvmPoint::Shared(point) => {
-                let is_zero = pointshare::is_zero(point.to_owned(), self.net0, &mut self.state0)?;
+                let is_zero = pointshare::is_zero(point.to_owned(), self.net, &mut self.state)?;
                 let is_zero: ArithmeticShare<C::ScalarField> =
-                    conversion::bit_inject_from_bits(is_zero, self.net0, &mut self.state0)?;
+                    conversion::bit_inject_from_bits(is_zero, self.net, &mut self.state)?;
 
                 let sub = match value {
                     Rep3AcvmPoint::Public(value) => {
@@ -1649,7 +1605,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                     Rep3AcvmPoint::Shared(value) => pointshare::sub(&value, &point),
                 };
 
-                let mut res = pointshare::scalar_mul(&sub, is_zero, self.net0, &mut self.state0)?;
+                let mut res = pointshare::scalar_mul(&sub, is_zero, self.net, &mut self.state)?;
                 pointshare::add_assign(&mut res, &point);
 
                 Ok(Rep3AcvmPoint::Shared(res))
@@ -1675,7 +1631,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 }
                 Rep3AcvmType::Shared(shared) => shared,
             });
-            let result = yao::sha256_from_bristol(&state, &message, self.net0, &mut self.state0)?;
+            let result = yao::sha256_from_bristol(&state, &message, self.net, &mut self.state)?;
             result
                 .iter()
                 .map(|y| Ok(Rep3AcvmType::Shared(*y)))
@@ -1709,14 +1665,14 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         &mut self,
         input: Self::ArithmeticShare,
     ) -> eyre::Result<Self::ArithmeticShare> {
-        let shared = conversion::a2b_selector(input, self.net0, &mut self.state0)?;
+        let shared = conversion::a2b_selector(input, self.net, &mut self.state)?;
 
         let mut result = Rep3UintShare::<F>::default();
         for i in 32usize..35usize {
             result.a.set_bit(i - 32, shared.a.bit(i));
             result.b.set_bit(i - 32, shared.b.bit(i));
         }
-        conversion::b2a_selector(&result, self.net0, &mut self.state0)
+        conversion::b2a_selector(&result, self.net, &mut self.state)
     }
 
     fn slice_and_get_sparse_table_with_rotation_values(
@@ -1736,8 +1692,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         let result = yao::get_sparse_table_with_rotation_values(
             input1,
             input2,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             basis_bits,
             rotation,
             total_bitsize,
@@ -1807,8 +1763,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         let result = yao::get_sparse_normalization_values(
             input1,
             input2,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             base_bits,
             base,
             total_output_bitlen_per_field,
@@ -1852,7 +1808,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                     Rep3AcvmType::Shared(shared) => shared,
                 })
                 .collect();
-            let result = yao::blake2s(&message_input, self.net0, &mut self.state0, num_bits)?;
+            let result = yao::blake2s(&message_input, self.net, &mut self.state, num_bits)?;
             result
                 .into_iter()
                 .map(|y| Ok(Rep3AcvmType::Shared(y)))
@@ -1889,7 +1845,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                     Rep3AcvmType::Shared(shared) => shared,
                 })
                 .collect();
-            let result = yao::blake3(&message_input, self.net0, &mut self.state0, num_bits)?;
+            let result = yao::blake3(&message_input, self.net, &mut self.state, num_bits)?;
             result
                 .into_iter()
                 .map(|y| Ok(Rep3AcvmType::Shared(y)))
@@ -1942,8 +1898,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             input1_x,
             input1_y,
             input1_infinite,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             true,
         )?;
 
@@ -1951,8 +1907,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             input2_x,
             input2_y,
             input2_infinite,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             true,
         )?;
 
@@ -1976,8 +1932,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             (Rep3AcvmPoint::Shared(lhs), Rep3AcvmPoint::Shared(rhs)) => pointshare::add(&lhs, &rhs),
         };
 
-        let (x, y, i) =
-            conversion::point_share_to_fieldshares(shared, self.net0, &mut self.state0)?;
+        let (x, y, i) = conversion::point_share_to_fieldshares(shared, self.net, &mut self.state)?;
         let x = *downcast(&x).expect("We checked types");
         let y = *downcast(&y).expect("We checked types");
         let i = *downcast(&i).expect("We checked types");
@@ -1985,7 +1940,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         // Set x,y to 0 of infinity is one.
         // Note: If we don't need the coordinates to be zero in the infinity case, we could add an option to skip this
         let mul = arithmetic::sub_public_by_shared(F::one(), i, self.id);
-        let res = arithmetic::mul_vec(&[x, y], &[mul, mul], self.net0, &mut self.state0)?;
+        let res = arithmetic::mul_vec(&[x, y], &[mul, mul], self.net, &mut self.state)?;
 
         Ok((res[0].into(), res[1].into(), i.into()))
     }
@@ -2037,7 +1992,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 .iter()
                 .map(|y| match y {
                     Rep3AcvmType::Public(public) => {
-                        arithmetic::promote_to_trivial_share(self.state0.id, *public)
+                        arithmetic::promote_to_trivial_share(self.state.id, *public)
                     }
                     Rep3AcvmType::Shared(shared) => *shared,
                 })
@@ -2046,7 +2001,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 .iter()
                 .map(|y| match y {
                     Rep3AcvmType::Public(public) => {
-                        arithmetic::promote_to_trivial_share(self.state0.id, *public)
+                        arithmetic::promote_to_trivial_share(self.state.id, *public)
                     }
                     Rep3AcvmType::Shared(shared) => *shared,
                 })
@@ -2055,12 +2010,12 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 .iter()
                 .map(|y| match y {
                     Rep3AcvmType::Public(public) => {
-                        arithmetic::promote_to_trivial_share(self.state0.id, *public)
+                        arithmetic::promote_to_trivial_share(self.state.id, *public)
                     }
                     Rep3AcvmType::Shared(shared) => *shared,
                 })
                 .collect();
-            let result = yao::aes_from_bristol(&scalars, &key, &iv, self.net0, &mut self.state0)?;
+            let result = yao::aes_from_bristol(&scalars, &key, &iv, self.net, &mut self.state)?;
 
             result
                 .iter()
@@ -2085,8 +2040,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         let results = yao::slice_and_map_from_sparse_form(
             input1,
             input2,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             base_bits,
             base,
             64,
@@ -2144,8 +2099,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
         let results = yao::slice_and_map_from_sparse_form_sbox(
             input1,
             input2,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             base_bits,
             base,
             64,
@@ -2165,7 +2120,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             .map(|a| Rep3AcvmType::Shared(*a))
             .collect();
 
-        let res0 = conversion::a2b_many(&results[2 * slices..], self.net0, &mut self.state0)?;
+        let res0 = conversion::a2b_many(&results[2 * slices..], self.net, &mut self.state)?;
 
         let sbox_lut = mpc_core::protocols::rep3_ring::lut_field::PublicPrivateLut::Public(
             sbox.iter().map(|&value| F::from(value)).collect::<Vec<_>>(),
@@ -2178,10 +2133,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             let sbox_value = Rep3FieldLookupTable::get_from_public_lut_no_b2a_conversion::<u8, _>(
                 index_bits,
                 &sbox_lut,
-                self.net0,
-                self.net1,
-                &mut self.state0,
-                &mut self.state1,
+                self.net,
+                &mut self.state,
             )?;
             let shift_1 = &sbox_value << 1;
             let shift_2 = &sbox_value >> 7;
@@ -2205,8 +2158,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             );
             let bin_share = mpc_core::protocols::rep3::conversion::bit_inject_many(
                 &a_bits_split,
-                self.net0,
-                &mut self.state0,
+                self.net,
+                &mut self.state,
             )?;
             let (first_bin_share, second_bin_share) = bin_share.split_at(bin_share.len() / 2);
             let mut sum_a = arithmetic::mul_public(first_bin_share[0], base_powers[0]);
@@ -2252,8 +2205,8 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             .collect();
         let result = yao::accumulate_from_sparse_bytes(
             &inputs,
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
             input_bitsize,
             output_bitsize,
             base,
@@ -2298,7 +2251,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             })
             .multiunzip();
         let mul_all_shared: Vec<Rep3PrimeFieldShare<F>> =
-            arithmetic::mul_vec(&shares_1, &shares_2, self.net0, &mut self.state0)?;
+            arithmetic::mul_vec(&shares_1, &shares_2, self.net, &mut self.state)?;
         let mul_all_shared = mul_all_shared.into_iter().map(Rep3AcvmType::Shared);
         let mul_all_shared_indexed = indices
             .into_iter()
@@ -2394,19 +2347,19 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             }
             (Rep3AcvmType::Public(public), Rep3AcvmType::Shared(shared))
             | (Rep3AcvmType::Shared(shared), Rep3AcvmType::Public(public)) => {
-                arithmetic::eq_public(*shared, *public, self.net0, &mut self.state0)?
+                arithmetic::eq_public(*shared, *public, self.net, &mut self.state)?
             }
             (Rep3AcvmType::Shared(a), Rep3AcvmType::Shared(b)) => {
-                arithmetic::eq(*a, *b, self.net0, &mut self.state0)?
+                arithmetic::eq(*a, *b, self.net, &mut self.state)?
             }
         };
 
-        let res_bin = conversion::a2b_selector(res, self.net0, &mut self.state0)?;
+        let res_bin = conversion::a2b_selector(res, self.net, &mut self.state)?;
 
         let res_fr = conversion::b2a(
             &Rep3UintShare::<ark_bn254::Fr>::new(res_bin.a, res_bin.b),
-            self.net0,
-            &mut self.state0,
+            self.net,
+            &mut self.state,
         )?;
         // Safety: we checked that the types match
         let res_fr: Self::ArithmeticShare = *downcast(&res_fr).expect("We checked types");
@@ -2431,7 +2384,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
             })
             .collect_vec();
         let bs = a.iter().map(|x| x.b).collect_vec();
-        let mut cs = self.net0.reshare(bs)?;
+        let mut cs = self.net.reshare(bs)?;
 
         izip!(a, cs.iter_mut()).for_each(|(x, c)| *c += x.a + x.b);
 
@@ -2528,7 +2481,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 Ok(Rep3AcvmType::Shared(arithmetic::mul_public(lhs, rhs)))
             }
             (Rep3AcvmType::Shared(lhs), Rep3AcvmType::Shared(rhs)) => {
-                let result = arithmetic::mul(lhs, rhs, self.net0, &mut self.state0)?;
+                let result = arithmetic::mul(lhs, rhs, self.net, &mut self.state)?;
                 Ok(Rep3AcvmType::Shared(result))
             }
         }
@@ -2544,7 +2497,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 Ok(Rep3AcvmType::Public(lhs / rhs))
             }
             (Rep3AcvmType::Public(lhs), Rep3AcvmType::Shared(rhs)) => {
-                let rhs_inv = arithmetic::inv(rhs, self.net0, &mut self.state0)?;
+                let rhs_inv = arithmetic::inv(rhs, self.net, &mut self.state)?;
                 self.mul_other_acvm_types::<C>(
                     Rep3AcvmType::Public(lhs),
                     Rep3AcvmType::Shared(rhs_inv),
@@ -2558,7 +2511,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                 )))
             }
             (Rep3AcvmType::Shared(lhs), Rep3AcvmType::Shared(rhs)) => {
-                let rhs_inv = arithmetic::inv(rhs, self.net0, &mut self.state0)?;
+                let rhs_inv = arithmetic::inv(rhs, self.net, &mut self.state)?;
                 self.mul_other_acvm_types::<C>(
                     Rep3AcvmType::Shared(lhs),
                     Rep3AcvmType::Shared(rhs_inv),
@@ -2578,7 +2531,7 @@ impl<'a, F: PrimeField + FieldUint, N: Network> NoirWitnessExtensionProtocol<F>
                     .ok_or_else(|| eyre::eyre!("Element has no inverse"))?,
             )),
             Rep3AcvmType::Shared(shared) => {
-                let inv = arithmetic::inv(shared, self.net0, &mut self.state0)?;
+                let inv = arithmetic::inv(shared, self.net, &mut self.state)?;
                 Ok(Rep3AcvmType::Shared(inv))
             }
         }

--- a/co-noir/co-acvm/src/solver.rs
+++ b/co-noir/co-acvm/src/solver.rs
@@ -172,28 +172,26 @@ where
 
 impl<'a, N: Network> Rep3CoSolver<'a, ark_bn254::Fr, N> {
     pub fn new(
-        net0: &'a N,
-        net1: &'a N,
+        net: &'a N,
         compiled_program: ProgramArtifact,
         prover_path: impl AsRef<Path>,
     ) -> eyre::Result<Self> {
         Self::new_bn254(
-            Rep3AcvmSolver::new(net0, net1, A2BType::default())?,
+            Rep3AcvmSolver::new(net, A2BType::default())?,
             compiled_program,
             prover_path,
         )
     }
 
     pub fn new_with_witness(
-        net0: &'a N,
-        net1: &'a N,
+        net: &'a N,
         compiled_program: ProgramArtifact,
         witness: WitnessMap<
             <Rep3AcvmSolver<ark_bn254::Fr, N> as NoirWitnessExtensionProtocol::<ark_bn254::Fr>>::AcvmType,
         >,
     ) -> eyre::Result<Self> {
         Self::new_bn254_with_witness(
-            Rep3AcvmSolver::new(net0, net1, A2BType::default())?,
+            Rep3AcvmSolver::new(net, A2BType::default())?,
             compiled_program,
             witness,
         )

--- a/co-noir/co-noir/src/bin/co-noir.rs
+++ b/co-noir/co-noir/src/bin/co-noir.rs
@@ -1195,13 +1195,11 @@ fn run_generate_witness(config: GenerateWitnessConfig) -> color_eyre::Result<Exi
         bincode::deserialize_from(input_share_file).context("while deserializing input share")?;
 
     // connect to network
-    let [net0, net1] =
-        TcpNetwork::networks::<2>(network_config).context("while connecting to network")?;
+    let net = TcpNetwork::new(network_config).context("while connecting to network")?;
 
     tracing::info!("Starting witness generation...");
     let start = Instant::now();
-    let result_witness_share =
-        co_noir::generate_witness_rep3(input_share, program_artifact, &net0, &net1)?;
+    let result_witness_share = co_noir::generate_witness_rep3(input_share, program_artifact, &net)?;
     let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
     tracing::info!("Generate witness took {duration_ms} ms");
 
@@ -1307,8 +1305,7 @@ fn run_build_proving_key(config: BuildProvingKeyConfig) -> color_eyre::Result<Ex
         )?;
 
     // connect to network
-    let [net0, net1] =
-        TcpNetwork::networks::<2>(network_config).context("while connecting to network")?;
+    let net = TcpNetwork::new(network_config).context("while connecting to network")?;
 
     tracing::info!("Starting proving key generation...");
     match protocol {
@@ -1323,8 +1320,7 @@ fn run_build_proving_key(config: BuildProvingKeyConfig) -> color_eyre::Result<Ex
             let proving_key = co_noir::generate_proving_key_rep3(
                 &constraint_system,
                 witness_share,
-                &net0,
-                &net1,
+                &net,
                 &prover_crs,
             )?;
             let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
@@ -1345,7 +1341,7 @@ fn run_build_proving_key(config: BuildProvingKeyConfig) -> color_eyre::Result<Ex
                 t,
                 &constraint_system,
                 witness_share,
-                &net0,
+                &net,
                 &prover_crs,
             )?;
             let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
@@ -1580,8 +1576,7 @@ fn run_build_and_generate_proof(
         .context("while parsing constraint system")?;
 
     // connect to network
-    let [net0, net1] =
-        TcpNetwork::networks::<2>(network_config).context("while connecting to network")?;
+    let net = TcpNetwork::new(network_config).context("while connecting to network")?;
 
     let circuit_size = co_noir::compute_circuit_size::<Bn254G1>(&constraint_system)?;
     let prover_crs =
@@ -1613,8 +1608,7 @@ fn run_build_and_generate_proof(
             let proving_key = co_noir::generate_proving_key_rep3(
                 &constraint_system,
                 witness_share,
-                &net0,
-                &net1,
+                &net,
                 &prover_crs,
             )?;
             let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
@@ -1625,7 +1619,7 @@ fn run_build_and_generate_proof(
                 TranscriptHash::POSEIDON2 => {
                     let start = Instant::now();
                     let (proof, public_inputs) = Rep3CoUltraHonk::<_, Poseidon2Sponge>::prove(
-                        &net0,
+                        &net,
                         proving_key,
                         &prover_crs,
                         has_zk,
@@ -1638,7 +1632,7 @@ fn run_build_and_generate_proof(
                 TranscriptHash::KECCAK => {
                     let start = Instant::now();
                     let (proof, public_inputs) = Rep3CoUltraHonk::<_, Keccak256>::prove(
-                        &net0,
+                        &net,
                         proving_key,
                         &prover_crs,
                         has_zk,
@@ -1660,7 +1654,7 @@ fn run_build_and_generate_proof(
                 t,
                 &constraint_system,
                 witness_share,
-                &net0,
+                &net,
                 &prover_crs,
             )?;
             let duration_ms = start.elapsed().as_micros() as f64 / 1000.;
@@ -1671,7 +1665,7 @@ fn run_build_and_generate_proof(
                 TranscriptHash::POSEIDON2 => {
                     let start = Instant::now();
                     let (proof, public_inputs) = ShamirCoUltraHonk::<_, Poseidon2Sponge>::prove(
-                        &net0,
+                        &net,
                         n,
                         t,
                         proving_key,
@@ -1687,7 +1681,7 @@ fn run_build_and_generate_proof(
                     // execute prover in MPC
                     let start = Instant::now();
                     let (proof, public_inputs) = ShamirCoUltraHonk::<_, Keccak256>::prove(
-                        &net0,
+                        &net,
                         n,
                         t,
                         proving_key,

--- a/co-noir/co-noir/src/lib.rs
+++ b/co-noir/co-noir/src/lib.rs
@@ -58,8 +58,7 @@ pub type Bn254G1 = <ark_ec::bn::Bn<ark_bn254::Config> as ark_ec::pairing::Pairin
 pub fn execute_circuit_rep3<'a, N: Network>(
     input: Rep3SharedInput<ark_bn254::Fr>,
     compiled_program: ProgramArtifact,
-    net0: &'a N,
-    net1: &'a N,
+    net: &'a N,
 ) -> Result<(
     Rep3SharedWitness<ark_bn254::Fr>,
     PssStore<Rep3AcvmSolver<'a, ark_bn254::Fr, N>, ark_bn254::Fr>,
@@ -67,7 +66,7 @@ pub fn execute_circuit_rep3<'a, N: Network>(
     let witness = witness_map_from_string_map(input, &compiled_program.abi)?;
 
     // init MPC protocol
-    let rep3_vm = Rep3CoSolver::new_with_witness(net0, net1, compiled_program, witness)
+    let rep3_vm = Rep3CoSolver::new_with_witness(net, compiled_program, witness)
         .context("while creating VM")?;
 
     // execute witness generation in MPC
@@ -82,10 +81,9 @@ pub fn execute_circuit_rep3<'a, N: Network>(
 pub fn generate_witness_rep3<N: Network>(
     input: Rep3SharedInput<ark_bn254::Fr>,
     compiled_program: ProgramArtifact,
-    net0: &N,
-    net1: &N,
+    net: &N,
 ) -> Result<Rep3SharedWitness<ark_bn254::Fr>> {
-    let (witness_stack, _) = execute_circuit_rep3(input, compiled_program, net0, net1)?;
+    let (witness_stack, _) = execute_circuit_rep3(input, compiled_program, net)?;
     Ok(witness_stack)
 }
 
@@ -188,12 +186,11 @@ pub fn compute_circuit_size<P: HonkCurve<TranscriptFieldType>>(
 pub fn generate_proving_key_rep3<N: Network>(
     constraint_system: &AcirFormat<ark_bn254::Fr>,
     witness_share: Rep3SharedWitness<ark_bn254::Fr>,
-    net0: &N,
-    net1: &N,
+    net: &N,
     prover_crs: &ProverCrs<Bn254G1>,
 ) -> Result<Rep3ProvingKey<Bn254G1>> {
-    let id = PartyID::try_from(net0.id())?;
-    let mut driver = Rep3AcvmSolver::new(net0, net1, A2BType::default())?;
+    let id = PartyID::try_from(net.id())?;
+    let mut driver = Rep3AcvmSolver::new(net, A2BType::default())?;
     let witness_share = witness_share.into_iter().map(Rep3AcvmType::from).collect();
     let crs = if constraint_system.is_recursive_verification_circuit() {
         prover_crs // TACEO TODO: Maybe just use a subset of the crs here?

--- a/mpc-core/src/lut.rs
+++ b/mpc-core/src/lut.rs
@@ -50,10 +50,8 @@ pub trait LookupTableProvider<T: Default>: Default {
         &mut self,
         index: Self::IndexSecretShare,
         lut: &Self::LutType,
-        net0: &N,
-        net1: &N,
-        state0: &mut Self::State,
-        state1: &mut Self::State,
+        net: &N,
+        state: &mut Self::State,
     ) -> eyre::Result<Self::SecretShare>;
 
     /// Writes a value to the LUT.
@@ -64,16 +62,13 @@ pub trait LookupTableProvider<T: Default>: Default {
     ///
     /// #Returns
     /// Can fail due to networking problems.
-    #[expect(clippy::too_many_arguments)]
     fn write_to_lut<N: Network>(
         &mut self,
         index: Self::IndexSecretShare,
         value: Self::SecretShare,
         lut: &mut Self::LutType,
-        net0: &N,
-        net1: &N,
-        state0: &mut Self::State,
-        state1: &mut Self::State,
+        net: &N,
+        state: &mut Self::State,
     ) -> eyre::Result<()>;
 
     /// Returns the length of the LUT
@@ -107,10 +102,8 @@ impl<F: PrimeField> LookupTableProvider<F> for PlainLookupTableProvider<F> {
         &mut self,
         index: Self::IndexSecretShare,
         lut: &Self::LutType,
-        _net0: &N,
-        _net1: &N,
-        _state0: &mut (),
-        _state1: &mut (),
+        _net: &N,
+        _state: &mut (),
     ) -> eyre::Result<F> {
         let index = field_to_usize(index)
             .ok_or_else(|| eyre::eyre!("Index can not be translated to usize"))?;
@@ -122,10 +115,8 @@ impl<F: PrimeField> LookupTableProvider<F> for PlainLookupTableProvider<F> {
         index: Self::IndexSecretShare,
         value: Self::SecretShare,
         lut: &mut Self::LutType,
-        _net0: &N,
-        _net1: &N,
-        _state0: &mut (),
-        _state1: &mut (),
+        _net: &N,
+        _state: &mut (),
     ) -> eyre::Result<()> {
         let index = field_to_usize(index)
             .ok_or_else(|| eyre::eyre!("Index can not be translated to usize"))?;
@@ -169,10 +160,8 @@ impl<C: CurveGroup> LookupTableProvider<C> for PlainCurveLookupTableProvider<C> 
         &mut self,
         index: Self::IndexSecretShare,
         lut: &Self::LutType,
-        _net0: &N,
-        _net1: &N,
-        _state0: &mut Self::State,
-        _state1: &mut Self::State,
+        _net: &N,
+        _state: &mut Self::State,
     ) -> eyre::Result<Self::SecretShare> {
         let index = field_to_usize(index)
             .ok_or_else(|| eyre::eyre!("Index can not be translated to usize"))?;
@@ -184,10 +173,8 @@ impl<C: CurveGroup> LookupTableProvider<C> for PlainCurveLookupTableProvider<C> 
         index: Self::IndexSecretShare,
         value: Self::SecretShare,
         lut: &mut Self::LutType,
-        _net0: &N,
-        _net1: &N,
-        _state0: &mut Self::State,
-        _state1: &mut Self::State,
+        _net: &N,
+        _state: &mut Self::State,
     ) -> eyre::Result<()> {
         let index = field_to_usize(index)
             .ok_or_else(|| eyre::eyre!("Index can not be translated to usize"))?;

--- a/mpc-core/src/protocols/rep3/conversion.rs
+++ b/mpc-core/src/protocols/rep3/conversion.rs
@@ -44,6 +44,18 @@ pub fn a2b_selector<F: FieldUint, N: Network>(
     }
 }
 
+/// Depending on the `A2BType` of the state, this function selects the appropriate implementation for the arithmetic-to-binary conversion of a vector of values.
+pub fn a2b_selector_many<F: FieldUint, N: Network>(
+    x: &[Rep3PrimeFieldShare<F>],
+    net: &N,
+    state: &mut Rep3State,
+) -> eyre::Result<Vec<Rep3UintShare<F>>> {
+    match state.a2b_type {
+        A2BType::Direct => a2b_many(x, net, state),
+        A2BType::Yao => a2y2b_many(x, net, state),
+    }
+}
+
 /// Depending on the `A2BType` of the state, this function selects the appropriate implementation for the binary-to-arithmetic conversion.
 pub fn b2a_selector<F: FieldUint, N: Network>(
     x: &Rep3UintShare<F>,

--- a/mpc-core/src/protocols/rep3_ring/gadgets/lut_field.rs
+++ b/mpc-core/src/protocols/rep3_ring/gadgets/lut_field.rs
@@ -75,6 +75,7 @@ where
     assert!(k <= T::K);
     let k2 = k >> 1;
 
+    // TODO add a `rand_ohv_many` function to generate both OHVs together
     // create two ohv's with half the bitsize
     let (mut r, e) = gadgets::ohv::rand_ohv::<T, _>(k2, net, state)?;
     let (r_, e_) = gadgets::ohv::rand_ohv::<T, _>(k2, net, state)?;

--- a/mpc-core/src/protocols/rep3_ring/gadgets/lut_field.rs
+++ b/mpc-core/src/protocols/rep3_ring/gadgets/lut_field.rs
@@ -59,10 +59,8 @@ where
 pub fn read_public_lut_low_depth<F: FieldUint, T: IntRing2k, N: Network>(
     lut: &[F],
     index: Rep3RingShare<T>,
-    net0: &N,
-    net1: &N,
-    state0: &mut Rep3State,
-    state1: &mut Rep3State,
+    net: &N,
+    state: &mut Rep3State,
 ) -> eyre::Result<F::Uint>
 where
     Standard: Distribution<T>,
@@ -77,27 +75,23 @@ where
     assert!(k <= T::K);
     let k2 = k >> 1;
 
-    // create two ohv's with half the bitsize in parallel
-    let (a, b) = mpc_net::join(
-        || gadgets::ohv::rand_ohv::<T, _>(k2, net0, state0),
-        || gadgets::ohv::rand_ohv::<T, _>(k2, net1, state1),
-    );
-    let (mut r, e) = a?;
-    let (r_, e_) = b?;
+    // create two ohv's with half the bitsize
+    let (mut r, e) = gadgets::ohv::rand_ohv::<T, _>(k2, net, state)?;
+    let (r_, e_) = gadgets::ohv::rand_ohv::<T, _>(k2, net, state)?;
 
     // Combine r and r_;
     r <<= k2;
     r += r_;
 
     // Open the xor of the index and r
-    let c = binary::open(&(r ^ index), net0)?;
+    let c = binary::open(&(r ^ index), net)?;
     let c: usize =
         c.0.try_into()
             .expect("This transformation should work, otherwise we have another issue")
             & ((1 << k) - 1); // Mask potential overflows from non-well-defined input
 
     // Start the result with a random mask (for potential resharing later)
-    let (mut t, mask_b) = state0
+    let (mut t, mask_b) = state
         .rngs
         .rand
         .random_uint::<F::Uint>(usize::try_from(F::MODULUS_BIT_SIZE).expect("u32 fits into usize"));
@@ -136,10 +130,8 @@ where
 pub fn read_multiple_public_lut_low_depth<F: FieldUint, T: IntRing2k, N: Network>(
     luts: &[Vec<F>],
     index: Rep3RingShare<T>,
-    net0: &N,
-    net1: &N,
-    state0: &mut Rep3State,
-    state1: &mut Rep3State,
+    net: &N,
+    state: &mut Rep3State,
 ) -> eyre::Result<Vec<F::Uint>>
 where
     Standard: Distribution<T>,
@@ -154,20 +146,16 @@ where
     assert!(k <= T::K);
     let k2 = k >> 1;
 
-    // create two ohv's with half the bitsize in parallel
-    let (a, b) = mpc_net::join(
-        || gadgets::ohv::rand_ohv::<T, _>(k2, net0, state0),
-        || gadgets::ohv::rand_ohv::<T, _>(k2, net1, state1),
-    );
-    let (mut r, e) = a?;
-    let (r_, e_) = b?;
+    // create two ohv's with half the bitsize
+    let (mut r, e) = gadgets::ohv::rand_ohv::<T, _>(k2, net, state)?;
+    let (r_, e_) = gadgets::ohv::rand_ohv::<T, _>(k2, net, state)?;
 
     // Combine r and r_;
     r <<= k2;
     r += r_;
 
     // Open the xor of the index and r
-    let c = binary::open(&(r ^ index), net0)?;
+    let c = binary::open(&(r ^ index), net)?;
     let c: usize =
         c.0.try_into()
             .expect("This transformation should work, otherwise we have another issue")
@@ -176,7 +164,7 @@ where
     let mut results = Vec::with_capacity(luts.len());
     for lut in luts {
         // Start the result with a random mask (for potential resharing later)
-        let (mut t, mask_b) = state0.rngs.rand.random_uint::<F::Uint>(
+        let (mut t, mask_b) = state.rngs.rand.random_uint::<F::Uint>(
             usize::try_from(F::MODULUS_BIT_SIZE).expect("u32 fits into usize"),
         );
         t ^= mask_b;

--- a/mpc-core/src/protocols/rep3_ring/gadgets/sort.rs
+++ b/mpc-core/src/protocols/rep3_ring/gadgets/sort.rs
@@ -285,6 +285,7 @@ where
         .map(|(a, b)| Rep3RingShare::new(a, b))
         .collect();
 
+    // TODO execute both shuffles in parallel
     let opened = shuffle_reveal::<PermRing, _>(&perm, rho, net, state)?;
     let bits_shuffled = shuffle(&perm, priv_bits, pub_bits, net, state)?;
     let mut result = vec![Rep3RingShare::zero_share(); len];
@@ -311,6 +312,7 @@ fn apply_inv_field<F: FieldUint, N: Network>(
         .map(|(a, b)| Rep3RingShare::new(a, b))
         .collect();
 
+    // TODO execute both shuffles in parallel
     let opened = shuffle_reveal(&perm, rho, net, state)?;
     let bits_shuffled = shuffle_field(&perm, bits, net, state)?;
     let mut result = vec![Rep3PrimeFieldShare::zero_share(); len];

--- a/mpc-core/src/protocols/rep3_ring/gadgets/sort.rs
+++ b/mpc-core/src/protocols/rep3_ring/gadgets/sort.rs
@@ -28,10 +28,8 @@ pub fn radix_sort_fields<F: FieldUint, N: Network>(
     mut priv_inputs: Vec<FieldShare<F>>,
     pub_inputs: Vec<F>,
     bitsize: usize,
-    net0: &N,
-    net1: &N,
-    state0: &mut Rep3State,
-    state1: &mut Rep3State,
+    net: &N,
+    state: &mut Rep3State,
 ) -> eyre::Result<Vec<FieldShare<F>>> {
     let len = priv_inputs.len() + pub_inputs.len();
 
@@ -43,37 +41,26 @@ pub fn radix_sort_fields<F: FieldUint, N: Network>(
         eyre::bail!("Too many inputs for radix sort. Use a larger PermRing.");
     }
 
-    let perm = gen_perm(
-        &priv_inputs,
-        &pub_inputs,
-        bitsize,
-        net0,
-        net1,
-        state0,
-        state1,
-    )?;
+    let perm = gen_perm(&priv_inputs, &pub_inputs, bitsize, net, state)?;
     priv_inputs.reserve(pub_inputs.len());
 
     // Does not matter whether inputs are shares or not
     for value in pub_inputs {
-        priv_inputs.push(rep3::arithmetic::promote_to_trivial_share(state0.id, value));
+        priv_inputs.push(rep3::arithmetic::promote_to_trivial_share(state.id, value));
     }
-    apply_inv_field(&perm, &priv_inputs, net0, net1, state0, state1)
+    apply_inv_field(&perm, &priv_inputs, net, state)
 }
 
 /// Sorts the inputs (both public and shared) using an oblivious radix sort algorithm according to the permutation which comes from sorting the input `key` (but it is not applied to `key`). The values public/shared values need to be organized to match the order given in `order` (false means a public value, true means a private value). Thereby, only the lowest `bitsize` bits are considered. The final results have the size of the inputs, i.e, are not shortened to bitsize. The resulting permutation is then used to sort the vectors in `inputs`.
 /// We use the algorithm described in [https://eprint.iacr.org/2019/695.pdf](https://eprint.iacr.org/2019/695.pdf).
-#[expect(clippy::too_many_arguments)]
 pub fn radix_sort_fields_vec_by<F: FieldUint, N: Network>(
     priv_key: &[FieldShare<F>],
     pub_key: &[F],
     order: &[bool],
     inputs: Vec<&[FieldShare<F>]>,
     bitsize: usize,
-    net0: &N,
-    net1: &N,
-    state0: &mut Rep3State,
-    state1: &mut Rep3State,
+    net: &N,
+    state: &mut Rep3State,
 ) -> eyre::Result<Vec<Vec<FieldShare<F>>>> {
     let len = priv_key.len() + pub_key.len();
     if len
@@ -84,11 +71,9 @@ pub fn radix_sort_fields_vec_by<F: FieldUint, N: Network>(
         eyre::bail!("Too many inputs for radix sort. Use a larger PermRing.");
     }
     let mut results = Vec::with_capacity(inputs.len());
-    let perm = gen_perm_ordered(
-        priv_key, pub_key, order, bitsize, net0, net1, state0, state1,
-    )?;
+    let perm = gen_perm_ordered(priv_key, pub_key, order, bitsize, net, state)?;
     for inp in inputs {
-        results.push(apply_inv_field(&perm, inp, net0, net1, state0, state1)?)
+        results.push(apply_inv_field(&perm, inp, net, state)?)
     }
     Ok(results)
 }
@@ -96,52 +81,15 @@ pub fn radix_sort_fields_vec_by<F: FieldUint, N: Network>(
 fn decompose<F: FieldUint, N: Network>(
     priv_inputs: &[FieldShare<F>],
     bitsize: usize,
-    net0: &N,
-    net1: &N,
-    state0: &mut Rep3State,
-    state1: &mut Rep3State,
+    net: &N,
+    state: &mut Rep3State,
 ) -> eyre::Result<Vec<Rep3UintShare<F>>> {
     let mask = F::Uint::mask(bitsize);
-    let mut priv_bits = vec![Rep3UintShare::zero_share(); priv_inputs.len()];
-    let (split1, split2) = priv_bits.split_at_mut(priv_inputs.len() / 2);
-    let mut result1 = None;
-    let mut result2 = None;
-
-    // TODO: This step could be optimized (I: Pack the a2b's, II: only reconstruct bitsize bits)
-    mpc_net::join(
-        || {
-            for (i, inp) in priv_inputs.iter().take(priv_inputs.len() / 2).enumerate() {
-                let binary = rep3::conversion::a2b_selector(inp.to_owned(), net0, state0);
-                if let Err(err) = binary {
-                    result1 = Some(err);
-                    break;
-                }
-                let mut binary = binary.unwrap();
-                binary.and_mask_assign(&mask);
-                split1[i] = binary;
-            }
-        },
-        || {
-            for (i, inp) in priv_inputs.iter().skip(priv_inputs.len() / 2).enumerate() {
-                let binary = rep3::conversion::a2b_selector(inp.to_owned(), net1, state1);
-                if let Err(err) = binary {
-                    result2 = Some(err);
-                    break;
-                }
-                let mut binary = binary.unwrap();
-                binary.and_mask_assign(&mask);
-                split2[i] = binary;
-            }
-        },
-    );
-
-    if let Some(err) = result1 {
-        return Err(err);
+    // TODO: This step could be optimized (only reconstruct bitsize bits)
+    let mut priv_bits = rep3::conversion::a2b_selector_many(priv_inputs, net, state)?;
+    for binary in priv_bits.iter_mut() {
+        binary.and_mask_assign(&mask);
     }
-    if let Some(err) = result2 {
-        return Err(err);
-    }
-
     Ok(priv_bits)
 }
 
@@ -149,24 +97,22 @@ fn gen_perm<F: FieldUint, N: Network>(
     priv_inputs: &[FieldShare<F>],
     pub_inputs: &[F],
     bitsize: usize,
-    net0: &N,
-    net1: &N,
-    state0: &mut Rep3State,
-    state1: &mut Rep3State,
+    net: &N,
+    state: &mut Rep3State,
 ) -> eyre::Result<Vec<Rep3RingShare<PermRing>>> {
     // Decompose all private inputs
-    let priv_bits = decompose(priv_inputs, bitsize, net0, net1, state0, state1)?;
+    let priv_bits = decompose(priv_inputs, bitsize, net, state)?;
 
-    let priv_bit_0 = inject_bit(&priv_bits, 0, net0, state0)?;
+    let priv_bit_0 = inject_bit(&priv_bits, 0, net, state)?;
     let pub_bit_0 = inject_public_bit(pub_inputs, 0);
-    let mut perm = gen_bit_perm(priv_bit_0, pub_bit_0, net0, state0)?;
+    let mut perm = gen_bit_perm(priv_bit_0, pub_bit_0, net, state)?;
 
     for i in 1..bitsize {
-        let priv_bit_i = inject_bit(&priv_bits, i, net0, state0)?;
+        let priv_bit_i = inject_bit(&priv_bits, i, net, state)?;
         let pub_bit_i = inject_public_bit(pub_inputs, i);
-        let bit_i = apply_inv(&perm, &priv_bit_i, &pub_bit_i, net0, net1, state0, state1)?;
-        let perm_i = gen_bit_perm(bit_i, vec![], net0, state0)?;
-        perm = compose(perm, perm_i, net0, state0)?;
+        let bit_i = apply_inv(&perm, &priv_bit_i, &pub_bit_i, net, state)?;
+        let perm_i = gen_bit_perm(bit_i, vec![], net, state)?;
+        perm = compose(perm, perm_i, net, state)?;
     }
 
     Ok(perm)
@@ -195,32 +141,29 @@ fn order_and_promote_inputs(
     perm
 }
 
-#[expect(clippy::too_many_arguments)]
 fn gen_perm_ordered<F: FieldUint, N: Network>(
     priv_inputs: &[FieldShare<F>],
     pub_inputs: &[F],
     order: &[bool],
     bitsize: usize,
-    net0: &N,
-    net1: &N,
-    state0: &mut Rep3State,
-    state1: &mut Rep3State,
+    net: &N,
+    state: &mut Rep3State,
 ) -> eyre::Result<Vec<Rep3RingShare<PermRing>>> {
     // Decompose all private inputs
-    let priv_bits = decompose(priv_inputs, bitsize, net0, net1, state0, state1)?;
+    let priv_bits = decompose(priv_inputs, bitsize, net, state)?;
 
-    let priv_bit_0 = inject_bit(&priv_bits, 0, net0, state0)?;
+    let priv_bit_0 = inject_bit(&priv_bits, 0, net, state)?;
     let pub_bit_0 = inject_public_bit(pub_inputs, 0);
-    let perm = order_and_promote_inputs(priv_bit_0, pub_bit_0, order, state0.id);
-    let mut perm = gen_bit_perm(perm, vec![], net0, state0)?; // This first permutation could be optimized by not promoting the public bits
+    let perm = order_and_promote_inputs(priv_bit_0, pub_bit_0, order, state.id);
+    let mut perm = gen_bit_perm(perm, vec![], net, state)?; // This first permutation could be optimized by not promoting the public bits
 
     for i in 1..bitsize {
-        let priv_bit_i = inject_bit(&priv_bits, i, net0, state0)?;
+        let priv_bit_i = inject_bit(&priv_bits, i, net, state)?;
         let pub_bit_i = inject_public_bit(pub_inputs, i);
-        let bit_i = order_and_promote_inputs(priv_bit_i, pub_bit_i, order, state0.id);
-        let bit_i = apply_inv(&perm, &bit_i, &[], net0, net1, state0, state1)?;
-        let perm_i = gen_bit_perm(bit_i, vec![], net0, state0)?;
-        perm = compose(perm, perm_i, net0, state0)?;
+        let bit_i = order_and_promote_inputs(priv_bit_i, pub_bit_i, order, state.id);
+        let bit_i = apply_inv(&perm, &bit_i, &[], net, state)?;
+        let perm_i = gen_bit_perm(bit_i, vec![], net, state)?;
+        perm = compose(perm, perm_i, net, state)?;
     }
 
     Ok(perm)
@@ -325,10 +268,8 @@ fn apply_inv<T: IntRing2k, N: Network>(
     rho: &[Rep3RingShare<PermRing>],
     priv_bits: &[Rep3RingShare<T>],
     pub_bits: &[RingElement<T>],
-    net0: &N,
-    net1: &N,
-    state0: &mut Rep3State,
-    state1: &mut Rep3State,
+    net: &N,
+    state: &mut Rep3State,
 ) -> eyre::Result<Vec<Rep3RingShare<T>>>
 where
     Standard: Distribution<T>,
@@ -337,19 +278,17 @@ where
     debug_assert_eq!(len, priv_bits.len() + pub_bits.len());
 
     let unshuffled = (0..len as PermRing).collect::<Vec<_>>();
-    let (perm_a, perm_b) = state0.rngs.rand.random_perm(unshuffled);
+    let (perm_a, perm_b) = state.rngs.rand.random_perm(unshuffled);
     let perm: Vec<_> = perm_a
         .into_iter()
         .zip(perm_b)
         .map(|(a, b)| Rep3RingShare::new(a, b))
         .collect();
 
-    let (opened, bits_shuffled) = mpc_net::join(
-        || shuffle_reveal::<PermRing, _>(&perm, rho, net0, state0),
-        || shuffle(&perm, priv_bits, pub_bits, net1, state1),
-    );
+    let opened = shuffle_reveal::<PermRing, _>(&perm, rho, net, state)?;
+    let bits_shuffled = shuffle(&perm, priv_bits, pub_bits, net, state)?;
     let mut result = vec![Rep3RingShare::zero_share(); len];
-    for (p, b) in opened?.into_iter().zip(bits_shuffled?) {
+    for (p, b) in opened.into_iter().zip(bits_shuffled) {
         result[p.0 as usize - 1] = b;
     }
     Ok(result)
@@ -358,28 +297,24 @@ where
 fn apply_inv_field<F: FieldUint, N: Network>(
     rho: &[Rep3RingShare<PermRing>],
     bits: &[Rep3PrimeFieldShare<F>],
-    net0: &N,
-    net1: &N,
-    state0: &mut Rep3State,
-    state1: &mut Rep3State,
+    net: &N,
+    state: &mut Rep3State,
 ) -> eyre::Result<Vec<Rep3PrimeFieldShare<F>>> {
     let len = rho.len();
     debug_assert_eq!(len, bits.len());
 
     let unshuffled = (0..len as PermRing).collect::<Vec<_>>();
-    let (perm_a, perm_b) = state0.rngs.rand.random_perm(unshuffled);
+    let (perm_a, perm_b) = state.rngs.rand.random_perm(unshuffled);
     let perm: Vec<_> = perm_a
         .into_iter()
         .zip(perm_b)
         .map(|(a, b)| Rep3RingShare::new(a, b))
         .collect();
 
-    let (opened, bits_shuffled) = mpc_net::join(
-        || shuffle_reveal(&perm, rho, net0, state0),
-        || shuffle_field(&perm, bits, net1, state1),
-    );
+    let opened = shuffle_reveal(&perm, rho, net, state)?;
+    let bits_shuffled = shuffle_field(&perm, bits, net, state)?;
     let mut result = vec![Rep3PrimeFieldShare::zero_share(); len];
-    for (p, b) in opened?.into_iter().zip(bits_shuffled?) {
+    for (p, b) in opened.into_iter().zip(bits_shuffled) {
         result[p.0 as usize - 1] = b;
     }
     Ok(result)

--- a/mpc-core/src/protocols/rep3_ring/lut_curve.rs
+++ b/mpc-core/src/protocols/rep3_ring/lut_curve.rs
@@ -177,14 +177,10 @@ where
     pub fn ohv_from_index<N: Network>(
         index: Rep3PrimeFieldShare<C::ScalarField>,
         len: usize,
-        net0: &N,
-        net1: &N,
-        state0: &mut Rep3State,
-        state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<Vec<Rep3PrimeFieldShare<C::ScalarField>>> {
-        Rep3FieldLookupTable::<C::ScalarField>::ohv_from_index(
-            index, len, net0, net1, state0, state1,
-        )
+        Rep3FieldLookupTable::<C::ScalarField>::ohv_from_index(index, len, net, state)
     }
 
     /// Writes to a shared lookup table with the index already being transformed into the shared one-hot-encoded vector
@@ -234,24 +230,22 @@ where
         &mut self,
         index: Self::IndexSecretShare,
         lut: &Self::LutType,
-        net0: &N,
-        _net1: &N,
-        state0: &mut Rep3State,
-        _state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<Self::SecretShare> {
         let len = lut.len();
         tracing::debug!("doing read on LUT-map of size {}", len);
-        let bits = rep3::conversion::a2b_selector(index, net0, state0)?;
+        let bits = rep3::conversion::a2b_selector(index, net, state)?;
         let k = len.next_power_of_two().ilog2() as usize;
 
         let result = if k == 1 {
-            Self::get_from_lut_internal::<Bit, _>(bits, lut, net0, state0)?
+            Self::get_from_lut_internal::<Bit, _>(bits, lut, net, state)?
         } else if k <= 8 {
-            Self::get_from_lut_internal::<u8, _>(bits, lut, net0, state0)?
+            Self::get_from_lut_internal::<u8, _>(bits, lut, net, state)?
         } else if k <= 16 {
-            Self::get_from_lut_internal::<u16, _>(bits, lut, net0, state0)?
+            Self::get_from_lut_internal::<u16, _>(bits, lut, net, state)?
         } else if k <= 32 {
-            Self::get_from_lut_internal::<u32, _>(bits, lut, net0, state0)?
+            Self::get_from_lut_internal::<u32, _>(bits, lut, net, state)?
         } else {
             panic!("Table is too large")
         };
@@ -264,24 +258,22 @@ where
         index: Self::IndexSecretShare,
         value: Self::SecretShare,
         lut: &mut Self::LutType,
-        net0: &N,
-        _net1: &N,
-        state0: &mut Rep3State,
-        _state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<()> {
         let len = lut.len();
         tracing::debug!("doing write on LUT-map of size {}", len);
-        let bits = rep3::conversion::a2b_selector(index, net0, state0)?;
+        let bits = rep3::conversion::a2b_selector(index, net, state)?;
         let k = len.next_power_of_two().ilog2();
 
         if k == 1 {
-            Self::write_to_lut_internal::<Bit, _>(bits, lut, &value, net0, state0)?
+            Self::write_to_lut_internal::<Bit, _>(bits, lut, &value, net, state)?
         } else if k <= 8 {
-            Self::write_to_lut_internal::<u8, _>(bits, lut, &value, net0, state0)?
+            Self::write_to_lut_internal::<u8, _>(bits, lut, &value, net, state)?
         } else if k <= 16 {
-            Self::write_to_lut_internal::<u16, _>(bits, lut, &value, net0, state0)?
+            Self::write_to_lut_internal::<u16, _>(bits, lut, &value, net, state)?
         } else if k <= 32 {
-            Self::write_to_lut_internal::<u32, _>(bits, lut, &value, net0, state0)?
+            Self::write_to_lut_internal::<u32, _>(bits, lut, &value, net, state)?
         } else {
             panic!("Table is too large")
         };

--- a/mpc-core/src/protocols/rep3_ring/lut_field.rs
+++ b/mpc-core/src/protocols/rep3_ring/lut_field.rs
@@ -74,24 +74,22 @@ impl<F: FieldUint> Rep3FieldLookupTable<F> {
     pub fn get_from_public_luts<N: Network>(
         index: Rep3PrimeFieldShare<F>,
         luts: &[Vec<F>],
-        net0: &N,
-        net1: &N,
-        state0: &mut Rep3State,
-        state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<Vec<Rep3PrimeFieldShare<F>>> {
         let len = luts.iter().map(|l| l.len()).max().unwrap();
         tracing::debug!("doing read on LUT-map of size {}", len);
-        let bits = rep3::conversion::a2b_selector(index, net0, state0)?;
+        let bits = rep3::conversion::a2b_selector(index, net, state)?;
         let k = len.next_power_of_two().ilog2() as usize;
 
         let result = if k == 1 {
-            Self::get_from_public_luts_internal::<Bit, _>(bits, luts, net0, net1, state0, state1)?
+            Self::get_from_public_luts_internal::<Bit, _>(bits, luts, net, state)?
         } else if k <= 8 {
-            Self::get_from_public_luts_internal::<u8, _>(bits, luts, net0, net1, state0, state1)?
+            Self::get_from_public_luts_internal::<u8, _>(bits, luts, net, state)?
         } else if k <= 16 {
-            Self::get_from_public_luts_internal::<u16, _>(bits, luts, net0, net1, state0, state1)?
+            Self::get_from_public_luts_internal::<u16, _>(bits, luts, net, state)?
         } else if k <= 32 {
-            Self::get_from_public_luts_internal::<u32, _>(bits, luts, net0, net1, state0, state1)?
+            Self::get_from_public_luts_internal::<u32, _>(bits, luts, net, state)?
         } else {
             panic!("Table is too large")
         };
@@ -102,10 +100,8 @@ impl<F: FieldUint> Rep3FieldLookupTable<F> {
     fn get_from_public_luts_internal<T: IntRing2k, N: Network>(
         index: Rep3UintShare<F>,
         luts: &[Vec<F>],
-        net0: &N,
-        net1: &N,
-        state0: &mut Rep3State,
-        state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<Vec<Rep3PrimeFieldShare<F>>>
     where
         Standard: Distribution<T>,
@@ -114,17 +110,16 @@ impl<F: FieldUint> Rep3FieldLookupTable<F> {
         let b = T::cast_from_uint(&index.b);
         let share = Rep3RingShare::new(a, b);
 
-        let bins_a = gadgets::lut_field::read_multiple_public_lut_low_depth(
-            luts, share, net0, net1, state0, state1,
-        )?;
-        let bins_b = net0.reshare_many(&bins_a)?;
+        let bins_a =
+            gadgets::lut_field::read_multiple_public_lut_low_depth(luts, share, net, state)?;
+        let bins_b = net.reshare_many(&bins_a)?;
 
         let mut result = Vec::with_capacity(luts.len());
 
         // TODO parallelize this at some point
         for (bin_a, bin_b) in bins_a.into_iter().zip(bins_b) {
             let bin = Rep3UintShare::new(bin_a, bin_b);
-            let res = rep3::conversion::b2a_selector(&bin, net0, state0)?;
+            let res = rep3::conversion::b2a_selector(&bin, net, state)?;
             result.push(res);
         }
 
@@ -134,10 +129,8 @@ impl<F: FieldUint> Rep3FieldLookupTable<F> {
     fn get_from_lut_internal<T: IntRing2k, N: Network>(
         index: Rep3UintShare<F>,
         lut: &PublicPrivateLut<F>,
-        net0: &N,
-        net1: &N,
-        state0: &mut Rep3State,
-        state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<Rep3PrimeFieldShare<F>>
     where
         Standard: Distribution<T>,
@@ -147,21 +140,15 @@ impl<F: FieldUint> Rep3FieldLookupTable<F> {
         let share = Rep3RingShare::new(a, b);
         let val = match lut {
             PublicPrivateLut::Public(vec) => {
-                let bin_a = gadgets::lut_field::read_public_lut_low_depth(
-                    vec.as_ref(),
-                    share,
-                    net0,
-                    net1,
-                    state0,
-                    state1,
-                )?;
-                let bin_b = net0.reshare(bin_a.to_owned())?;
+                let bin_a =
+                    gadgets::lut_field::read_public_lut_low_depth(vec.as_ref(), share, net, state)?;
+                let bin_b = net.reshare(bin_a.to_owned())?;
                 let bin = Rep3UintShare::new(bin_a, bin_b);
-                rep3::conversion::b2a_selector(&bin, net0, state0)?
+                rep3::conversion::b2a_selector(&bin, net, state)?
             }
             PublicPrivateLut::Shared(vec) => {
-                let f_a = gadgets::lut_field::read_shared_lut(vec.as_ref(), share, net0, state0)?;
-                let f_b = net0.reshare(f_a)?;
+                let f_a = gadgets::lut_field::read_shared_lut(vec.as_ref(), share, net, state)?;
+                let f_b = net.reshare(f_a)?;
                 Rep3PrimeFieldShare::new(f_a, f_b)
             }
         };
@@ -173,10 +160,8 @@ impl<F: FieldUint> Rep3FieldLookupTable<F> {
     pub fn get_from_public_lut_no_b2a_conversion<T: IntRing2k, N: Network>(
         index: Rep3UintShare<F>,
         lut: &PublicPrivateLut<F>,
-        net0: &N,
-        net1: &N,
-        state0: &mut Rep3State,
-        state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<Rep3UintShare<F>>
     where
         Standard: Distribution<T>,
@@ -187,15 +172,9 @@ impl<F: FieldUint> Rep3FieldLookupTable<F> {
 
         match lut {
             PublicPrivateLut::Public(vec) => {
-                let bin_a = gadgets::lut_field::read_public_lut_low_depth(
-                    vec.as_ref(),
-                    share,
-                    net0,
-                    net1,
-                    state0,
-                    state1,
-                )?;
-                let bin_b = net0.reshare(bin_a.to_owned())?;
+                let bin_a =
+                    gadgets::lut_field::read_public_lut_low_depth(vec.as_ref(), share, net, state)?;
+                let bin_b = net.reshare(bin_a.to_owned())?;
                 Ok(Rep3UintShare::new(bin_a, bin_b))
             }
             PublicPrivateLut::Shared(_) => {
@@ -208,10 +187,8 @@ impl<F: FieldUint> Rep3FieldLookupTable<F> {
         index: Rep3UintShare<F>,
         lut: &mut PublicPrivateLut<F>,
         value: &Rep3PrimeFieldShare<F>,
-        net0: &N,
-        _net1: &N,
-        state0: &mut Rep3State,
-        _state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<()>
     where
         Standard: Distribution<T>,
@@ -222,16 +199,16 @@ impl<F: FieldUint> Rep3FieldLookupTable<F> {
         match lut {
             PublicPrivateLut::Public(vec) => {
                 // There is not really a performance difference (i.e., more multiplications) when both lut and value are secret shared compared to public lut and private value. Thus we promote
-                let id = state0.id;
+                let id = state.id;
                 let mut shared = vec
                     .iter()
                     .map(|v| arithmetic::promote_to_trivial_share(id, *v))
                     .collect::<Vec<_>>();
-                gadgets::lut_field::write_lut(value, &mut shared, share, net0, state0)?;
+                gadgets::lut_field::write_lut(value, &mut shared, share, net, state)?;
                 *lut = PublicPrivateLut::Shared(shared);
             }
             PublicPrivateLut::Shared(shared) => {
-                gadgets::lut_field::write_lut(value, shared, share, net0, state0)?;
+                gadgets::lut_field::write_lut(value, shared, share, net, state)?;
             }
         }
         Ok(())
@@ -240,43 +217,39 @@ impl<F: FieldUint> Rep3FieldLookupTable<F> {
     fn ohv_from_index_internal<T: IntRing2k, N: Network>(
         index: Rep3UintShare<F>,
         k: usize,
-        net0: &N,
-        _net1: &N,
-        state0: &mut Rep3State,
-        _state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<Vec<Rep3RingShare<Bit>>> {
         let a = T::cast_from_uint(&index.a);
         let b = T::cast_from_uint(&index.b);
         let bits = Rep3RingShare::new(a, b);
 
-        gadgets::ohv::ohv(k, bits, net0, state0)
+        gadgets::ohv::ohv(k, bits, net, state)
     }
 
     /// Creates a shared one-hot-encoded vector from a given shared index
     pub fn ohv_from_index<N: Network>(
         index: Rep3PrimeFieldShare<F>,
         len: usize,
-        net0: &N,
-        net1: &N,
-        state0: &mut Rep3State,
-        state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<Vec<Rep3PrimeFieldShare<F>>> {
-        let bits = rep3::conversion::a2b_selector(index, net0, state0)?;
+        let bits = rep3::conversion::a2b_selector(index, net, state)?;
         let k = len.next_power_of_two().ilog2() as usize;
 
         let e = if k == 1 {
-            Self::ohv_from_index_internal::<Bit, _>(bits, k, net0, net1, state0, state1)?
+            Self::ohv_from_index_internal::<Bit, _>(bits, k, net, state)?
         } else if k <= 8 {
-            Self::ohv_from_index_internal::<u8, _>(bits, k, net0, net1, state0, state1)?
+            Self::ohv_from_index_internal::<u8, _>(bits, k, net, state)?
         } else if k <= 16 {
-            Self::ohv_from_index_internal::<u16, _>(bits, k, net0, net1, state0, state1)?
+            Self::ohv_from_index_internal::<u16, _>(bits, k, net, state)?
         } else if k <= 32 {
-            Self::ohv_from_index_internal::<u32, _>(bits, k, net0, net1, state0, state1)?
+            Self::ohv_from_index_internal::<u32, _>(bits, k, net, state)?
         } else {
             panic!("Table is too large")
         };
 
-        conversion::bit_inject_from_bits_to_field_many::<F, _>(&e, net0, state0)
+        conversion::bit_inject_from_bits_to_field_many::<F, _>(&e, net, state)
     }
 
     /// Writes to a shared lookup table with the index already being transformed into the shared one-hot-encoded vector
@@ -323,24 +296,22 @@ impl<F: FieldUint> LookupTableProvider<F> for Rep3FieldLookupTable<F> {
         &mut self,
         index: Self::IndexSecretShare,
         lut: &Self::LutType,
-        net0: &N,
-        net1: &N,
-        state0: &mut Rep3State,
-        state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<Self::SecretShare> {
         let len = lut.len();
         tracing::debug!("doing read on LUT-map of size {}", len);
-        let bits = rep3::conversion::a2b_selector(index, net0, state0)?;
+        let bits = rep3::conversion::a2b_selector(index, net, state)?;
         let k = len.next_power_of_two().ilog2() as usize;
 
         let result = if k == 1 {
-            Self::get_from_lut_internal::<Bit, _>(bits, lut, net0, net1, state0, state1)?
+            Self::get_from_lut_internal::<Bit, _>(bits, lut, net, state)?
         } else if k <= 8 {
-            Self::get_from_lut_internal::<u8, _>(bits, lut, net0, net1, state0, state1)?
+            Self::get_from_lut_internal::<u8, _>(bits, lut, net, state)?
         } else if k <= 16 {
-            Self::get_from_lut_internal::<u16, _>(bits, lut, net0, net1, state0, state1)?
+            Self::get_from_lut_internal::<u16, _>(bits, lut, net, state)?
         } else if k <= 32 {
-            Self::get_from_lut_internal::<u32, _>(bits, lut, net0, net1, state0, state1)?
+            Self::get_from_lut_internal::<u32, _>(bits, lut, net, state)?
         } else {
             panic!("Table is too large")
         };
@@ -353,24 +324,22 @@ impl<F: FieldUint> LookupTableProvider<F> for Rep3FieldLookupTable<F> {
         index: Self::IndexSecretShare,
         value: Self::SecretShare,
         lut: &mut Self::LutType,
-        net0: &N,
-        net1: &N,
-        state0: &mut Rep3State,
-        state1: &mut Rep3State,
+        net: &N,
+        state: &mut Rep3State,
     ) -> eyre::Result<()> {
         let len = lut.len();
         tracing::debug!("doing write on LUT-map of size {}", len);
-        let bits = rep3::conversion::a2b_selector(index, net0, state0)?;
+        let bits = rep3::conversion::a2b_selector(index, net, state)?;
         let k = len.next_power_of_two().ilog2();
 
         if k == 1 {
-            Self::write_to_lut_internal::<Bit, _>(bits, lut, &value, net0, net1, state0, state1)?
+            Self::write_to_lut_internal::<Bit, _>(bits, lut, &value, net, state)?
         } else if k <= 8 {
-            Self::write_to_lut_internal::<u8, _>(bits, lut, &value, net0, net1, state0, state1)?
+            Self::write_to_lut_internal::<u8, _>(bits, lut, &value, net, state)?
         } else if k <= 16 {
-            Self::write_to_lut_internal::<u16, _>(bits, lut, &value, net0, net1, state0, state1)?
+            Self::write_to_lut_internal::<u16, _>(bits, lut, &value, net, state)?
         } else if k <= 32 {
-            Self::write_to_lut_internal::<u32, _>(bits, lut, &value, net0, net1, state0, state1)?
+            Self::write_to_lut_internal::<u32, _>(bits, lut, &value, net, state)?
         } else {
             panic!("Table is too large")
         };

--- a/tests/src/bin/circom_groth16.rs
+++ b/tests/src/bin/circom_groth16.rs
@@ -48,8 +48,7 @@ fn main() -> eyre::Result<()> {
         CoCircomCompiler::<Bn254>::get_public_inputs(&chacha_circuit, compiler_config).unwrap();
     let num_public_inputs = parsed.public_inputs().len();
 
-    let nets0 = LocalNetwork::new_3_parties();
-    let nets1 = LocalNetwork::new_3_parties();
+    let nets = LocalNetwork::new_3_parties();
 
     let input_file = BufReader::new(File::open(input)?);
     let input: serde_json::Map<String, serde_json::Value> =
@@ -85,16 +84,11 @@ fn main() -> eyre::Result<()> {
     let compiler = [parsed.clone(), parsed.clone(), parsed];
 
     let mut threads = vec![];
-    for (net0, net1, input, parsed) in izip!(nets0, nets1, batch, compiler) {
+    for (net, input, parsed) in izip!(nets, batch, compiler) {
         threads.push(std::thread::spawn(move || {
-            let witness_extension = BatchedRep3WitnessExtension::new(
-                &net0,
-                &net1,
-                &parsed,
-                VMConfig::default(),
-                batch_size,
-            )
-            .unwrap();
+            let witness_extension =
+                BatchedRep3WitnessExtension::new(&net, &parsed, VMConfig::default(), batch_size)
+                    .unwrap();
             let input = input
                 .into_iter()
                 .map(|(name, value)| {

--- a/tests/src/bin/noir_rep3.rs
+++ b/tests/src/bin/noir_rep3.rs
@@ -58,12 +58,10 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // create input shares
     let shares = co_noir_types::split_input_rep3::<ark_bn254::Fr>(inputs);
-    let nets0 = LocalNetwork::new_3_parties();
-    let nets1 = LocalNetwork::new_3_parties();
+    let nets = LocalNetwork::new_3_parties();
     let mut threads = vec![];
-    for (net0, net1, program_artifact, share) in itertools::izip!(
-        nets0,
-        nets1,
+    for (net, program_artifact, share) in itertools::izip!(
+        nets,
         [
             program_artifact.clone(),
             program_artifact.clone(),
@@ -75,8 +73,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             let input_share =
                 co_noir::witness_map_from_string_map(share, &program_artifact.abi).unwrap();
             let solver =
-                Rep3CoSolver::new_with_witness(&net0, &net1, program_artifact, input_share)
-                    .unwrap();
+                Rep3CoSolver::new_with_witness(&net, program_artifact, input_share).unwrap();
             solver.solve().unwrap()
         }));
     }

--- a/tests/tests/circom/batched_witness_extension/rep3.rs
+++ b/tests/tests/circom/batched_witness_extension/rep3.rs
@@ -32,8 +32,7 @@ fn batched_multiplier2(batch_size: usize) -> eyre::Result<()> {
     let parsed = CoCircomCompiler::<Bn254>::parse(&add_circuit, compiler_config)?;
     let num_public_inputs = parsed.public_inputs().len();
 
-    let nets0 = LocalNetwork::new_3_parties();
-    let nets1 = LocalNetwork::new_3_parties();
+    let nets = LocalNetwork::new_3_parties();
 
     let mut rng = thread_rng();
     let mut batch = vec![BatchedRep3SharedInput::default(); 3];
@@ -66,16 +65,11 @@ fn batched_multiplier2(batch_size: usize) -> eyre::Result<()> {
     let compiler = [parsed.clone(), parsed.clone(), parsed];
 
     let mut threads = vec![];
-    for (net0, net1, input, parsed) in izip!(nets0, nets1, batch, compiler) {
+    for (net, input, parsed) in izip!(nets, batch, compiler) {
         threads.push(std::thread::spawn(move || {
-            let witness_extension = BatchedRep3WitnessExtension::new(
-                &net0,
-                &net1,
-                &parsed,
-                VMConfig::default(),
-                batch_size,
-            )
-            .unwrap();
+            let witness_extension =
+                BatchedRep3WitnessExtension::new(&net, &parsed, VMConfig::default(), batch_size)
+                    .unwrap();
             let input = input
                 .into_iter()
                 .map(|(name, value)| {
@@ -136,8 +130,7 @@ fn batched_chacha20(batch_size: usize) -> eyre::Result<()> {
         CoCircomCompiler::<Bn254>::get_public_inputs(&chacha_circuit, compiler_config).unwrap();
     let num_public_inputs = parsed.public_inputs().len();
 
-    let nets0 = LocalNetwork::new_3_parties();
-    let nets1 = LocalNetwork::new_3_parties();
+    let nets = LocalNetwork::new_3_parties();
 
     let input_file = BufReader::new(File::open(input)?);
     let input: serde_json::Map<String, serde_json::Value> =
@@ -173,16 +166,11 @@ fn batched_chacha20(batch_size: usize) -> eyre::Result<()> {
     let compiler = [parsed.clone(), parsed.clone(), parsed];
 
     let mut threads = vec![];
-    for (net0, net1, input, parsed) in izip!(nets0, nets1, batch, compiler) {
+    for (net, input, parsed) in izip!(nets, batch, compiler) {
         threads.push(std::thread::spawn(move || {
-            let witness_extension = BatchedRep3WitnessExtension::new(
-                &net0,
-                &net1,
-                &parsed,
-                VMConfig::default(),
-                batch_size,
-            )
-            .unwrap();
+            let witness_extension =
+                BatchedRep3WitnessExtension::new(&net, &parsed, VMConfig::default(), batch_size)
+                    .unwrap();
             let input = input
                 .into_iter()
                 .map(|(name, value)| {

--- a/tests/tests/circom/witness_extension_tests/rep3.rs
+++ b/tests/tests/circom/witness_extension_tests/rep3.rs
@@ -90,13 +90,12 @@ macro_rules! run_test {
         //install_tracing();
         let mut rng = thread_rng();
         let inputs = rep3::share_field_elements($input, &mut rng);
-        let nets0 = LocalNetwork::new_3_parties();
-        let nets1 = LocalNetwork::new_3_parties();
+        let nets = LocalNetwork::new_3_parties();
         let mut threads = vec![];
 
         let configs = [$config.clone(), $config.clone(), $config];
 
-        for (net0, net1, input, config) in izip!(nets0, nets1, inputs, configs) {
+        for (net, input, config) in izip!(nets, inputs, configs) {
             threads.push(std::thread::spawn(move || {
                 let mut compiler_config = config;
                 compiler_config.simplification =
@@ -107,7 +106,7 @@ macro_rules! run_test {
                 let circuit =
                     CoCircomCompiler::<Bn254>::parse($file.to_owned(), compiler_config).unwrap();
                 let witness_extension =
-                    Rep3WitnessExtension::new(&net0, &net1, &circuit, VMConfig::default()).unwrap();
+                    Rep3WitnessExtension::new(&net, &circuit, VMConfig::default()).unwrap();
                 witness_extension
                     .run_with_flat(
                         input

--- a/tests/tests/mpc/rep3.rs
+++ b/tests/tests/mpc/rep3.rs
@@ -2043,8 +2043,7 @@ mod field_share {
         const VEC_SIZE: usize = 20;
         const CHUNK_SIZE: usize = 14;
 
-        let nets0 = LocalNetwork::new_3_parties();
-        let nets1 = LocalNetwork::new_3_parties();
+        let nets = LocalNetwork::new_3_parties();
         let mut rng = thread_rng();
         let x = (0..VEC_SIZE)
             .map(|_| ark_bn254::Fr::rand(&mut rng))
@@ -2069,25 +2068,13 @@ mod field_share {
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
 
-        for (net0, net1, tx, x_) in izip!(
-            nets0.into_iter(),
-            nets1.into_iter(),
-            [tx1, tx2, tx3],
-            x_shares.into_iter()
-        ) {
+        for (net, tx, x_) in izip!(nets.into_iter(), [tx1, tx2, tx3], x_shares.into_iter()) {
             let x_pub = x[VEC_SIZE / 2..].to_vec();
             std::thread::spawn(move || {
-                let mut state0 = Rep3State::new(&net0, A2BType::default()).unwrap();
-                let mut state1 = state0.fork(0).unwrap();
+                let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
 
                 let decomposed = rep3_ring::gadgets::sort::radix_sort_fields(
-                    x_,
-                    x_pub,
-                    CHUNK_SIZE,
-                    &net0,
-                    &net1,
-                    &mut state0,
-                    &mut state1,
+                    x_, x_pub, CHUNK_SIZE, &net, &mut state,
                 )
                 .unwrap();
                 tx.send(decomposed)
@@ -2553,8 +2540,7 @@ mod field_share {
         const TOTAL_BIT_SIZE: usize = 64;
         let s_box = AES128_SBOX;
 
-        let nets0 = LocalNetwork::new_3_parties();
-        let nets1 = LocalNetwork::new_3_parties();
+        let nets = LocalNetwork::new_3_parties();
         let mut rng = thread_rng();
         let mask = U256::mask(TOTAL_BIT_SIZE);
         let keys_a = (0..VEC_SIZE)
@@ -2608,9 +2594,8 @@ mod field_share {
         let (tx2, rx2) = mpsc::channel();
         let (tx3, rx3) = mpsc::channel();
 
-        for (net0, net1, tx, x, y) in izip!(
-            nets0,
-            nets1,
+        for (net, tx, x, y) in izip!(
+            nets,
             [tx1, tx2, tx3],
             x_shares.into_iter(),
             y_shares.into_iter(),
@@ -2618,13 +2603,12 @@ mod field_share {
             let base_bits = slice_sizes.clone();
             let slices = slice_sizes.len();
             std::thread::spawn(move || {
-                let mut state0 = Rep3State::new(&net0, A2BType::default()).unwrap();
-                let mut state1 = state0.fork(0).unwrap();
+                let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
                 let res = rep3::yao::slice_and_map_from_sparse_form_many_sbox(
                     &x,
                     &y,
-                    &net0,
-                    &mut state0,
+                    &net,
+                    &mut state,
                     &base_bits,
                     BASE,
                     TOTAL_BIT_SIZE,
@@ -2652,14 +2636,14 @@ mod field_share {
                 let base_powers: [ark_bn254::Fr; 32] =
                     array::from_fn(|i| ark_bn254::Fr::from(base_powers[i].clone()));
 
-                let rs = conversion::a2b_many(&rs, &net0, &mut state0).unwrap();
+                let rs = conversion::a2b_many(&rs, &net, &mut state).unwrap();
                 for key in rs {
                     let sbox_value =
                         rep3_ring::lut_field::Rep3FieldLookupTable::get_from_public_lut_no_b2a_conversion::<
                             u8,
                             _,
                         >(
-                            key, &sbox_lut, &net0, &net1, &mut state0, &mut state1
+                            key, &sbox_lut, &net, &mut state
                         )
                         .unwrap();
 
@@ -2687,8 +2671,7 @@ mod field_share {
                             .collect_vec(),
                     );
                     let bin_share =
-                        rep3::conversion::bit_inject_many(&a_bits_split, &net0, &mut state0)
-                            .unwrap();
+                        rep3::conversion::bit_inject_many(&a_bits_split, &net, &mut state).unwrap();
                     let (bin_share, second_bin_share) = bin_share.split_at(bin_share.len() / 2);
                     let mut sum_a = arithmetic::mul_public(bin_share[0], base_powers[0]);
                     let mut sum_b = arithmetic::mul_public(second_bin_share[0], base_powers[0]);

--- a/tests/tests/mpc/rep3_ring.rs
+++ b/tests/tests/mpc/rep3_ring.rs
@@ -2177,32 +2177,23 @@ mod ring_share {
             let x_shares = rep3_ring::share_ring_element_binary(x_, &mut rng);
             let should_result_f = lut[x].to_owned();
 
-            let nets0 = LocalNetwork::new_3_parties();
-            let nets1 = LocalNetwork::new_3_parties();
+            let nets = LocalNetwork::new_3_parties();
             let (tx1, rx1) = mpsc::channel();
             let (tx2, rx2) = mpsc::channel();
             let (tx3, rx3) = mpsc::channel();
 
-            for (net0, net1, tx, x, lut) in izip!(
-                nets0,
-                nets1,
+            for (net, tx, x, lut) in izip!(
+                nets,
                 [tx1, tx2, tx3],
                 x_shares.into_iter(),
                 [lut.clone(), lut.clone(), lut]
             ) {
                 std::thread::spawn(move || {
-                    let mut state0 = Rep3State::new(&net0, A2BType::default()).unwrap();
-                    let mut state1 = state0.fork(0).unwrap();
+                    let mut state = Rep3State::new(&net, A2BType::default()).unwrap();
 
-                    let res = gadgets::lut_field::read_public_lut_low_depth(
-                        &lut,
-                        x,
-                        &net0,
-                        &net1,
-                        &mut state0,
-                        &mut state1,
-                    )
-                    .unwrap();
+                    let res =
+                        gadgets::lut_field::read_public_lut_low_depth(&lut, x, &net, &mut state)
+                            .unwrap();
                     tx.send(res).unwrap();
                 });
             }

--- a/tests/tests/noir/proof_tests/rep3.rs
+++ b/tests/tests/noir/proof_tests/rep3.rs
@@ -52,31 +52,25 @@ fn proof_test<H: TranscriptHasher<TranscriptFieldType>>(
                 acc
             });
 
-    let nets0 = LocalNetwork::new_3_parties();
-    let nets1 = LocalNetwork::new_3_parties();
+    let nets = LocalNetwork::new_3_parties();
     let mut threads = Vec::with_capacity(3);
     let crs_size = co_noir::compute_circuit_size::<Bn254G1>(&constraint_system).unwrap();
     let prover_crs =
         Arc::new(CrsParser::<Bn254G1>::get_crs_g1(CRS_PATH_G1, crs_size, has_zk).unwrap());
     // Get vk
     let verifier_crs = CrsParser::<Bn254G1>::get_crs_g2::<Bn254>(CRS_PATH_G2).unwrap();
-    for (net0, net1, witness) in izip!(nets0, nets1, witnesses) {
+    for (net, witness) in izip!(nets, witnesses) {
         let prover_crs = prover_crs.clone();
         let constraint_system = co_noir::get_constraint_system_from_artifact(&program_artifact);
         threads.push(std::thread::spawn(move || {
             // generate proving key and vk
-            let pk = co_noir::generate_proving_key_rep3(
-                &constraint_system,
-                witness,
-                &net0,
-                &net1,
-                &prover_crs,
-            )
-            .unwrap();
+            let pk =
+                co_noir::generate_proving_key_rep3(&constraint_system, witness, &net, &prover_crs)
+                    .unwrap();
             let vk: VerifyingKey<Bn254> = pk.create_vk(&prover_crs, verifier_crs).unwrap();
 
             let (proof, public_input) =
-                Rep3CoUltraHonk::<_, H>::prove(&net0, pk, &prover_crs, has_zk, &vk.inner_vk)
+                Rep3CoUltraHonk::<_, H>::prove(&net, pk, &prover_crs, has_zk, &vk.inner_vk)
                     .unwrap();
             (proof, public_input, vk)
         }));
@@ -128,8 +122,7 @@ fn witness_and_proof_test<H: TranscriptHasher<TranscriptFieldType>>(
         co_noir::program_artifact_from_reader(File::open(&circuit_file).unwrap())
             .expect("failed to parse program artifact");
 
-    let nets0 = LocalNetwork::new_3_parties();
-    let nets1 = LocalNetwork::new_3_parties();
+    let nets = LocalNetwork::new_3_parties();
     let mut threads = Vec::with_capacity(3);
     let constraint_system = co_noir::get_constraint_system_from_artifact(&program_artifact);
     let crs_size = co_noir::compute_circuit_size::<Bn254G1>(&constraint_system).unwrap();
@@ -139,27 +132,22 @@ fn witness_and_proof_test<H: TranscriptHasher<TranscriptFieldType>>(
     let verifier_crs = CrsParser::<Bn254G1>::get_crs_g2::<Bn254>(CRS_PATH_G2).unwrap();
     let vk = co_noir::generate_vk::<Bn254>(&constraint_system, prover_crs.clone(), verifier_crs)
         .unwrap();
-    for (net0, net1) in nets0.into_iter().zip(nets1) {
+    for net in nets {
         let prover_crs = prover_crs.clone();
         let vk = vk.clone();
         let constraint_system = co_noir::get_constraint_system_from_artifact(&program_artifact);
         let artifact = program_artifact.clone();
         let prover_toml = prover_toml.clone();
         threads.push(std::thread::spawn(move || {
-            let solver = Rep3CoSolver::new(&net0, &net1, artifact, prover_toml).unwrap();
+            let solver = Rep3CoSolver::new(&net, artifact, prover_toml).unwrap();
             let witness = solver.solve().unwrap();
             let witness = co_noir::witness_stack_to_vec_rep3(witness);
             // generate proving key and vk
-            let pk = co_noir::generate_proving_key_rep3(
-                &constraint_system,
-                witness,
-                &net0,
-                &net1,
-                &prover_crs,
-            )
-            .unwrap();
+            let pk =
+                co_noir::generate_proving_key_rep3(&constraint_system, witness, &net, &prover_crs)
+                    .unwrap();
             let (proof, public_input) =
-                Rep3CoUltraHonk::<_, H>::prove(&net0, pk, &prover_crs, has_zk, &vk.inner_vk)
+                Rep3CoUltraHonk::<_, H>::prove(&net, pk, &prover_crs, has_zk, &vk.inner_vk)
                     .unwrap();
             (proof, public_input)
         }));

--- a/tests/tests/noir/witness_extension_tests/mod.rs
+++ b/tests/tests/noir/witness_extension_tests/mod.rs
@@ -65,12 +65,10 @@ macro_rules! add_rep3_acvm_test {
 
                 // create input shares
                 let shares = co_noir::split_input_rep3(inputs);
-                let nets0 = LocalNetwork::new_3_parties();
-                let nets1 = LocalNetwork::new_3_parties();
+                let nets = LocalNetwork::new_3_parties();
                 let mut threads = vec![];
-                for (net0, net1, program_artifact, share) in izip!(
-                    nets0,
-                    nets1,
+                for (net, program_artifact, share) in izip!(
+                    nets,
                     [
                         program_artifact.clone(),
                         program_artifact.clone(),
@@ -81,7 +79,7 @@ macro_rules! add_rep3_acvm_test {
                     threads.push(std::thread::spawn(move || {
                         let input_share = co_noir::witness_map_from_string_map(share, &program_artifact.abi).expect("can translate witness for noir witness extension");
                         let solver =
-                            Rep3CoSolver::new_with_witness(&net0, &net1, program_artifact, input_share).unwrap();
+                            Rep3CoSolver::new_with_witness(&net, program_artifact, input_share).unwrap();
                         let proof = solver.solve().unwrap();
                         proof
                     }));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> This is a breaking API and networking refactor across core REP3 MPC paths; correctness and performance depend on single-connection protocol ordering replacing prior dual-net parallelism.
> 
> **Overview**
> **Breaking change:** REP3 witness generation (Circom VM, batched Circom, Noir ACVM, CLIs, and tests) no longer takes two `Network` handles and forked `Rep3State` instances. Everything is wired through one `net` and one `state`, including `TcpNetwork::new` instead of `TcpNetwork::networks::<2>`.
> 
> The `LookupTableProvider` trait and REP3 LUT/radix-sort helpers drop the `net0`/`net1`/`state0`/`state1` split. Shared bitwise paths that used `mpc_net::join` with paired `a2b_selector` calls now batch via new **`a2b_selector_many`**. Some former parallel steps (e.g. dual OHVs in public LUT read, radix-sort decompose, MSM point/scalar setup) run sequentially on the single state, with TODOs left where parallel shuffles or `rand_ohv_many` could return.
> 
> Plain ACVM LUT calls are updated to match the slimmer LUT API (fewer placeholder state arguments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 477a57fb5c5adf3604cb368100eecd821425dab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->